### PR TITLE
fix: prevent vanilla from using itemID for comparing ammunition types

### DIFF
--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -136,6 +136,38 @@
 		return ::Math.max(0, count - startSurroundCountAt);
 	}
 
+	// Temporarily changes the getID function from the ammo item to instead return getAmmoType
+	// This is the alternative to re-/overwriting these two functions. The Vanilla function uses 'ammo.getID' which we can't fix otherwise
+    local hasRangedWeapon = o.hasRangedWeapon;
+    o.hasRangedWeapon = function()
+    {
+        local ammoItem = this.getItems().getItemAtSlot(::Const.ItemSlot.Ammo);
+        if (ammoItem == null) return hasRangedWeapon();
+
+        local oldGetID = ammoItem.getID;
+        ammoItem.getID = ammoItem.getAmmoType;
+
+        local ret = hasRangedWeapon();
+
+        ammoItem.getID = oldGetID;
+        return ret;
+    }
+
+    local getRangedWeaponInfo = o.getRangedWeaponInfo;
+    o.getRangedWeaponInfo = function()
+    {
+        local ammoItem = this.getItems().getItemAtSlot(::Const.ItemSlot.Ammo);
+        if (ammoItem == null) return getRangedWeaponInfo();
+
+        local oldGetID = ammoItem.getID;
+        ammoItem.getID = ammoItem.getAmmoType;
+
+        local ret = getRangedWeaponInfo();
+
+        ammoItem.getID = oldGetID;
+        return ret;
+    }
+
 	o.getSurroundedBonus <- function( _targetEntity )
 	{
 		local surroundedCount = _targetEntity.getSurroundedCount();

--- a/mod_reforged/hooks/items/ammo/ammo.nut
+++ b/mod_reforged/hooks/items/ammo/ammo.nut
@@ -1,0 +1,76 @@
+::mods_hookExactClass("items/ammo/ammo", function(o)
+{
+    o.m.AmmoTypeName <- "ammo_type_name";	// Must be overwritten with an actual informative name
+    o.m.AmmoWeight <- 0.0;			// Every Ammo in this bag applies this value as a negative StaminaModifier
+	o.m.StaminaModifier <- 0;		// Flat StaminaModifier. In Vanilla this already exists on most other equipables
+
+    local create = o.create;
+    o.create = function()
+    {
+        create();
+		this.m.ItemType = ::Const.Items.ItemType.Ammo;		// This is a line that Vanilla just forgot to include in this shared parent class
+    }
+
+    local onEquip = o.onEquip;
+    o.onEquip = function()
+    {
+		onEquip();
+		this.addGenericItemSkill();		// Now that ammunition by design can inflict a Staminamodifier and potentially more effects we force an addGenericItemSkill call
+    }
+
+// Function overwrites of 'item.nut' functions
+
+    // New function that new ammunition items can use to reduce the amount of copying the same lines
+    o.getTooltip <- function()
+    {
+        local ret = this.item.getTooltip();   // Name + Description + Category + Value + image
+
+		if (this.getStaminaModifier() < 0)
+		{
+			ret.push({
+				id = 8,
+				type = "text",
+				icon = "ui/icons/fatigue.png",
+				text = "Maximum Fatigue " + ::MSU.Text.colorRed(this.getStaminaModifier())
+			});
+		}
+
+		if (this.m.Ammo != 0)
+		{
+			ret.push({
+				id = 6,
+				type = "text",
+				icon = "ui/icons/ammo.png",
+				text = "Contains " + ::MSU.Text.colorRed(this.m.Ammo) + " " + this.m.AmmoTypeName + "s"
+			});
+		}
+		else
+		{
+			ret.push({
+				id = 6,
+				type = "text",
+				icon = "ui/tooltips/warning.png",
+				text = ::MSU.Text.colorRed("Is empty and useless")
+			});
+		}
+        ret.push({
+            id = 7,
+            type = "text",
+            icon = "ui/icons/asset_ammo.png",
+            text = "Refill cost per ammunition: [b]" + ::MSU.Text.colorRed(this.m.AmmoCost) + "[/b]"
+        });
+        return ret;
+    }
+
+    o.getStaminaModifier <- function()
+    {
+		local staminaModifier = this.m.StaminaModifier;		// flat modifier
+		staminaModifier -= ::Math.ceil(this.getAmmo() * this.m.AmmoWeight)		// scaling modifier
+        return staminaModifier;
+    }
+
+    o.onUpdateProperties <- function( _properties )
+	{
+		_properties.Stamina += this.getStaminaModifier();
+    }
+});

--- a/mod_reforged/hooks/items/ammo/large_powder_bag.nut
+++ b/mod_reforged/hooks/items/ammo/large_powder_bag.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("items/ammo/large_powder_bag", function(o)
+{
+    local create = o.create;
+    o.create = function()
+    {
+        create();
+        this.m.ID = "ammo.powder_large";   // Gives this a new unique ID as opposed Vanilla
+    }
+});

--- a/mod_reforged/hooks/items/ammo/large_quiver_of_arrows.nut
+++ b/mod_reforged/hooks/items/ammo/large_quiver_of_arrows.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("items/ammo/large_quiver_of_arrows", function(o)
+{
+    local create = o.create;
+    o.create = function()
+    {
+        create();
+        this.m.ID = "ammo.arrows_large";   // Gives this a new unique ID as opposed Vanilla
+    }
+});

--- a/mod_reforged/hooks/items/ammo/large_quiver_of_bolts.nut
+++ b/mod_reforged/hooks/items/ammo/large_quiver_of_bolts.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("items/ammo/large_quiver_of_bolts", function(o)
+{
+    local create = o.create;
+    o.create = function()
+    {
+        create();
+        this.m.ID = "ammo.bolts_large";   // Gives this a new unique ID as opposed Vanilla
+    }
+});

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -91,3 +91,27 @@
 		return this.m.Reach;
 	}
 });
+
+::mods_hookDescendants("items/weapons/weapon", function(o) {
+	if ("getAmmoID" in o)
+	{
+		local getAmmoID = o.getAmmoID;
+		o.getAmmoID = function()	// This will correct all current and most future Vanilla items and those coming from random mods
+		{
+			local ret = getAmmoID();
+			if (ret == "ammo.arrows")
+			{
+				return ::Const.Items.AmmoType.Arrows;
+			}
+			if (ret == "ammo.bolts")
+			{
+				return ::Const.Items.AmmoType.Bolts;
+			}
+			if (ret == "ammo.powder")
+			{
+				return ::Const.Items.AmmoType.Powder;
+			}
+			return ret;
+		}
+	}
+})

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -1,5 +1,6 @@
 ::mods_hookExactClass("items/weapons/weapon", function (o) {
 	o.m.Reach <- 1;
+	o.m.RequiredAmmoType <- ::Const.Items.AmmoType.None;
 
 	local getTooltip = o.getTooltip;
 	o.getTooltip = function()
@@ -90,6 +91,13 @@
 	{
 		return this.m.Reach;
 	}
+
+	o.getRequiredAmmoType <- function()
+	{
+		if (this.m.RequiredAmmoType == ::Const.Items.AmmoType.None) return this.getAmmoID();
+		return this.m.RequiredAmmoType;
+	}
+
 });
 
 ::mods_hookDescendants("items/weapons/weapon", function(o) {

--- a/mod_reforged/hooks/skills/special/no_ammo_warning.nut
+++ b/mod_reforged/hooks/skills/special/no_ammo_warning.nut
@@ -1,0 +1,18 @@
+
+::mods_hookExactClass("skills/special/no_ammo_warning", function(o) {
+    // Temporarily changes the getID function from the ammo item into getAmmoType
+    local isHidden = o.isHidden;
+    o.isHidden = function()
+    {
+        local ammoItem = this.getContainer().getActor().getItems().getItemAtSlot(::Const.ItemSlot.Ammo);
+        if (ammoItem == null) return isHidden();
+
+        local oldGetID = ammoItem.item.getID;
+        ammoItem.item.getID = ammoItem.getAmmoType;
+
+        local ret = isHidden();
+
+        ammoItem.item.getID = oldGetID;
+        return ret;
+    }
+});


### PR DESCRIPTION
Vanilla BB commited one of the great sins in programming: Assign the same ID multiple times for different objects.
`powder_bag.nut` has the same ID as `large_powder_bag.nut`
`quiver_of_arrows.nut` has the same ID as `large_quiver_of_arrows.nut`
`quiver_of_bolts.nut` has the same ID as `large_quiver_of_bolts.nut`

**Why is that?** 
Because of some parts of the codebase that are responsible for checking whether you have the correct ammunition for the equipped ranged weapon. They compare the result of `getID()`of the equipped ammunition against the result of `getAmmoID()` of the equipped ranged weapon.
Meanwhile other parts of the code-base correctly use the id-entries of the enum `Const.Items.AmmoType` when checking for certain ammunition types

**Challenge:**
- Those old wrong checks between `getID()` and `getAmmoID()` are burried somewhat deep in three different functions. Overwriting those should be the last resort.
- Overwriting `getID()` is not an option. It is supposed to return an ItemID and not some ammunition-type.

**Solution:** (3 steps)
- (1) We define that from now on `function getAmmoID()` on ranged weapons is supposed to return a type from the `Const.Items.AmmoType` enum. This is easily fixable retroactively by refactoring the return values whenever that function is about to return one of the old ItemIDs
- (2) We do a Switcheroo for all the three wrong vanilla functions: When they are called we make it so `getID()` of the ammo item is switched out with the `getAmmoType()` of that same ammo item. And afterwards they are switched back. The Vanilla code stays the same but it now compared the right kind of types with each other.
- (3) We finally define new actual unique ID's for the three large ammunition variants. And moving forward we can have more ammunition container for existing ranged weapons with their own unique ID