### PR TITLE
feat: show mini-icon for nine-lives while cheat-death effect available

### DIFF
--- a/mod_reforged/hooks/skills/effects/nine_lives_effect.nut
+++ b/mod_reforged/hooks/skills/effects/nine_lives_effect.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("skills/effects/nine_lives_effect", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		// We change the name of this effect so you don't confuse it with the perk 'Nine Lives' which now also displays under StatusEffects
+		this.m.Name = "Heightened Reflexes (Nine Lives)";
+	}
+});

--- a/mod_reforged/hooks/skills/perks/perk_nine_lives.nut
+++ b/mod_reforged/hooks/skills/perks/perk_nine_lives.nut
@@ -1,0 +1,39 @@
+::mods_hookExactClass("skills/perks/perk_nine_lives", function(o) {
+    // New Variables to tweak the behavior of this perk
+    o.m.MinHP <- 11;
+    o.m.MaxHP <- 15;
+
+    local create = o.create;
+	o.create = function()
+	{
+        create();
+
+        // This makes the perk now always show by default on top of characters while it is not procced yet
+		this.m.IconMini = "perk_07_mini";
+        this.addType(::Const.SkillType.StatusEffect);   // 'StatusEffect' is requires so that this will show up under the 'Effects' section in the tooltip
+    }
+
+    // Nine lives now shows up as an effect while available. Therefore we give it a custom more detailed description
+	o.getDescription <- function()
+	{
+		return "Upon receiving the next killing blow, this character will survive with " + ::MSU.Text.colorGreen(this.m.MinHP + "-" + this.m.MaxHP) + " Hitpoints, all damage over time effects wil be removed, and Melee Skill, Melee Defense, Resolve and Initiative will be increased until the start of their next turn.";
+	}
+
+    local setSpent = o.setSpent;
+	o.setSpent = function( _f )
+	{
+        local proc = (_f && !this.m.IsSpent);
+        setSpent(_f);
+        if (proc) this.onProc();
+	}
+
+    // New function that is called after vanilla just applied the 11-15 hitpoints reset, removal of Dots and addition of the temporary nine_lives_effect
+    o.onProc <- function()
+    {
+        this.m.IsHidden = true;     // Visually indicate that this character no longer has cheat-death for this battle
+        if (this.m.MinHP == 11 && this.m.MaxHP == 15) return; // There is no need to set the Hitpoints two times if these values were not changes by us/submods
+
+        this.getContainer().getActor().m.Hitpoints = ::Math.rand(this.m.MinHP, this.m.MaxHP);
+        this.getContainer().getActor().setDirty(true);
+    }
+});


### PR DESCRIPTION
Currently there is no indicator on an entity with Nine-Lives that tells you whether it still has Cheat-Death available. The only way to know is trying to remember whenever you see it being procced.
This PR solves that problem by always displaying the nine-lives mini-icon on top of entities while it is available.

As a side-effect the mini-icon is now removed from the second half of this perk, the one turn stat-buff. But this is a small price to pay for this QoL improvement. Also once we get a variation of that mini-icon we can re-implement that for the second half and have the best of both worlds.

This PR also improves the tweakability of Nine-Lives slightly with the `onProc` function.
I mostly copied the approach that Midas implemented in Legends for this 7 months ago.

**Important:** This PR requires MSU functions which are not yet in MSU. Enduriel said that he wants to get them in ASAP