### PR TITLE
fix: prevent AI from targeting mortars

### DIFF
--- a/mod_reforged/hooks/ai/tactical/behavior.nut
+++ b/mod_reforged/hooks/ai/tactical/behavior.nut
@@ -1,0 +1,11 @@
+::mods_hookBaseClass("ai/tactical/behavior", function(o) {
+    o = o[o.SuperName];
+
+    local queryTargetValue = o.queryTargetValue;
+    o.queryTargetValue = function( _entity, _target, _skill = null )
+    {
+        // Currently Mortars are near invincible and not meant to be killed. But AI still targets them sometimes. This line should make it so they are basically never targeted.
+        if (_entity.getType() == ::Const.EntityType.Mortar) return 0.01;
+        return queryTargetValue(_entity, _target, _skill);
+    }
+});


### PR DESCRIPTION
Mortars are not meant to be killed but in Vanilla, But AI still targets them. This is frustrating when allies waste their ranged attacks on mortars or your dogs get hung up on them instead of pinning down the engineers or fleeing enemies.

This PR reduces those instances to a minimum by tanking the value of mortars.

This is an exact copy from an AI-Fix-Collection mod of mine and I ran this in a longer campaign without issues. Though I can't remember this exact case of AI-Targeting was actually fixed.