### PR TITLE
refactor: reduce hit chance bonuses of slash, thrust, gash

### DIFF
--- a/mod_reforged/hooks/skills/actives/gash_skill.nut
+++ b/mod_reforged/hooks/skills/actives/gash_skill.nut
@@ -1,0 +1,48 @@
+::mods_hookExactClass("skills/actives/gash_skill", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.HitChanceBonus = 5;
+	}
+
+	o.getTooltip = function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.push({
+			id = 6,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = "Has " + ::MSU.Text.colorizePercentage(this.m.HitChanceBonus) + " chance to hit"
+		});
+
+		if (this.getContainer().getActor().getCurrentProperties().IsSpecializedInSwords)
+		{
+			ret.push({
+				id = 6,
+				type = "text",
+				icon = "ui/icons/hitchance.png",
+				text = "Has a [color=" + this.Const.UI.Color.NegativeValue + "]50%[/color] lower threshold to inflict injuries"
+			});
+		}
+		else
+		{
+			ret.push({
+				id = 6,
+				type = "text",
+				icon = "ui/icons/hitchance.png",
+				text = "Has a [color=" + this.Const.UI.Color.NegativeValue + "]33%[/color] lower threshold to inflict injuries"
+			});
+		}
+
+		return ret;
+	}
+
+	o.onAnySkillUsed = function( _skill, _targetEntity, _properties )
+	{
+		if (_skill == this)
+		{
+			_properties.MeleeSkill += this.m.HitChanceBonus;
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/slash.nut
+++ b/mod_reforged/hooks/skills/actives/slash.nut
@@ -1,0 +1,29 @@
+::mods_hookExactClass("skills/actives/slash", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.HitChanceBonus = 5;
+	}
+
+	o.getTooltip = function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.push({
+			id = 6,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = "Has " + ::MSU.Text.colorizePercentage(this.m.HitChanceBonus) + " chance to hit"
+		});
+
+		return ret;
+	}
+
+	o.onAnySkillUsed = function( _skill, _targetEntity, _properties )
+	{
+		if (_skill == this)
+		{
+			_properties.MeleeSkill += this.m.HitChanceBonus;
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/thrust.nut
+++ b/mod_reforged/hooks/skills/actives/thrust.nut
@@ -1,0 +1,29 @@
+::mods_hookExactClass("skills/actives/thrust", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.HitChanceBonus = 10;
+	}
+
+	o.getTooltip = function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.push({
+			id = 6,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = "Has " + ::MSU.Text.colorizePercentage(this.m.HitChanceBonus) + " chance to hit"
+		});
+
+		return ret;
+	}
+
+	o.onAnySkillUsed = function( _skill, _targetEntity, _properties )
+	{
+		if (_skill == this)
+		{
+			_properties.MeleeSkill += this.m.HitChanceBonus;
+		}
+	}
+});


### PR DESCRIPTION
This is to account for the generally longer Reach of spears and swords compared to other one-handed weapons.

This is a temporary solution and includes the most important skills that need adjustment. Ideally we'd have a more streamlined way to adjust both hitchance and tooltip of all skills. That requires a lot of work as the vanilla skills especially 2 tile ones like Impale etc. are very rigidly coded in terms of their tooltip, bonuses (onAnySkillUsed), mastery checks, and this.m.HitChanceBonus.