### PR TITLE
fix: add projected attributes in exact class hook

### DIFF
--- a/mod_reforged/hooks/skills/backgrounds/character_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/character_background.nut
@@ -14,6 +14,14 @@
 		}];
 	}
 
+	local getTooltip = "getTooltip" in o ? o.getTooltip : null;
+	o.getTooltip <- function()
+	{
+		local ret = getTooltip == null ? this.skill.getTooltip() : getTooltip();
+		ret.extend(this.getProjectedAttributesTooltip());
+		return ret;
+	}
+
 	o.getPerkTreeTooltip <- function()
 	{
 		return {


### PR DESCRIPTION
This fixes issues where some vanilla backgrounds (e.g. fisherman, militia) who don't have `getTooltip` defined in them were not getting the projected attributes tooltip from the hookDescendants.