### PR TITLE
fix: correctly use dynamic width instead of a static one for combat log

### DIFF
--- a/ui/mods/mod_reforged/css_hooks/screens/tooltip/modules/tactical_screen_topbar/topbar_event_log_module.css
+++ b/ui/mods/mod_reforged/css_hooks/screens/tooltip/modules/tactical_screen_topbar/topbar_event_log_module.css
@@ -13,7 +13,6 @@
 .tactical-screen .topbar-event-log-module .ui-control.list
 {
 	background-size: 39.0rem 41.1rem;
-	width: 49.0rem;
 }
 
 .tactical-screen .topbar-event-log-module .l-event-logs-container

--- a/ui/mods/mod_reforged/js_hooks/screens/tooltip/modules/tactical_screen_topbar/topbar_event_log_module.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/tooltip/modules/tactical_screen_topbar/topbar_event_log_module.js
@@ -12,11 +12,17 @@ TacticalScreenTopbarEventLogModule.prototype.createDIV = function(_parentDiv)
 
     var newParentDiv = $('<div class="new-log-container"/>');
     grandpa.append(newParentDiv);
+
+    // This solution defines a dymanic width for the combat log which is dependant on the current resolution
 	var width = Math.max(200, Math.min(grandpa.parent().width() / 3.5, 800));
 	newParentDiv.css('width', width);
 	newParentDiv.css('background-size', newParentDiv.width() + " " + newParentDiv.height());
 
     Reforged.Hooks.TacticalScreenTopbarEventLogModule_createDIV.call(this, newParentDiv);
 
-    this.mEventsListContainer.css('background-size', newParentDiv.width() - 65, + " " + newParentDiv.height());
+    // Now we retroactively adjust the width of some child elements according to the 'width' calculated above
+	var eventLogsContainerLayout = this.mContainer.find('.l-event-logs-container:first');
+	eventLogsContainerLayout.css('width', newParentDiv.width() - 60);
+
+    this.mEventsListContainer.css('background-size', newParentDiv.width() - 75, + " " + newParentDiv.height());
 };


### PR DESCRIPTION
This adds a line of code from Leonions original solution which I forgot. 
Now all necessary widths are correctly adjusted retroactively after the vanilla function ran through.