### PR TITLE
feat: introduce and apply the two keywords 'trapped' and 'out of action'

### DIFF
--- a/mod_reforged/config/z_nested_tooltips.nut
+++ b/mod_reforged/config/z_nested_tooltips.nut
@@ -19,6 +19,10 @@
 			Turn = ::MSU.Class.BasicTooltip("Turn", ::Reforged.Mod.Tooltips.parseString("Combat in battle brothers is turn-based. Each combat consists of a series of [rounds|Concept.Round]. During a round, characters act in turns. A character\'s position in the turn order is determined by the character\'s [Initiative|Concept.Initiative] relative to other characters.\n\n[Effects|Concept.StatusEffect] that last a certain number of turns last until the character has started or ended their turn that many times, depending on whether the [effect|Concept.StatusEffect] expires at the start or end of the turn respectively.")),
 			Round = ::MSU.Class.BasicTooltip("Round", ::Reforged.Mod.Tooltips.parseString("Combat in battle brothers is turn-based. Each combat consists of a series of rounds. During a round, characters act in [turns|Concept.Turn]. A round ends when all characters have ended their [turns|Concept.Turn].")),
 			ZoneOfControl = ::MSU.Class.BasicTooltip("Zone of Control", ::Reforged.Mod.Tooltips.parseString("Most melee characters exert Zone of Control on their surrounding tiles. Trying to move out of enemy Zone of Control will trigger one free attack from each controlling enemy until the first attack hit or every attack missed. A hit will cancel the movement.")),
+		},
+		Keyword = {
+			Trapped = ::MSU.Class.BasicTooltip("Trapped", ::Reforged.Mod.Tooltips.parseString("A trapped character is unable to move until they are freed. This is caused by effects like [Netted|Skill+net_effect], [Webbed|Skill+web_effect] and [Rooted|Skill+rooted_effect].")),
+			OutOfAction = ::MSU.Class.BasicTooltip("Out of Action", ::Reforged.Mod.Tooltips.parseString("A character that is out of action will have their [turns|Concept.Turn] skipped. This is caused by effects like [Stunned|Skill+stunned_effect], [Sleeping|Skill+sleeping_effect] and [Nightmares|Skill+nightmare_effect].")),
 		}
 	},
 	AutoConcepts = [

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -127,7 +127,7 @@ local vanillaDescriptions = [
  				Type = ::UPD.EffectType.Active,
  				Description = [
 					"Unlocks the [Rotation|Skill+rotation] skill which allows you to switch places with an adjacent allied character while ignoring [Zone of Control|Concept.ZoneOfControl].",
-					"Does not work if either character is [stunned|Skill+stunned_effect], [rooted|Skill+rooted_effect] or otherwise disabled."
+					"Does not work if either character is [trapped|Keyword.Trapped] or [out of action|Keyword.OutOfAction]."
 				]
  			}]
 	 	}),
@@ -216,7 +216,7 @@ local vanillaDescriptions = [
 	 		Effects = [{
  				Type = ::UPD.EffectType.Passive,
  				Description = [
- 					"Damage is increased by " + ::MSU.Text.colorGreen("20%") + " against enemies who have sustained an [injury|Concept.Injury] or are [sleeping|Skill+sleeping_effect], [stunned|Skill+stunned_effect], [netted|Skill+net_effect], [webbed|Skill+web_effect], or [rooted|Skill+rooted_effect]."
+ 					"Damage is increased by " + ::MSU.Text.colorGreen("20%") + " against enemies who have sustained an [injury|Concept.Injury], are [trapped|Keyword.Trapped] or [out of action|Keyword.OutOfAction]."
  				]
  			}]
 	 	}),
@@ -582,7 +582,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Gain " + ::MSU.Text.colorGreen("+10") + " [Melee Skill|Concept.MeleeSkill] and [Ranged Skill|Concept.RangeSkill], and " + ::MSU.Text.colorGreen("+20%") + " chance to hit the head when attacking a [rattled|Skill+rf_rattled_effect], [stunned|Skill+stunned_effect], [dazed|Skill+dazed_effect], [netted|Skill+net_effect], [sleeping|Skill+sleeping_effect], [staggered|Skill+staggered_effect], [webbed|Skill+web_effect], or [rooted|Skill+rooted_effect] target."
+				"Gain " + ::MSU.Text.colorGreen("+10") + " [Melee Skill|Concept.MeleeSkill] and [Ranged Skill|Concept.RangeSkill], and " + ::MSU.Text.colorGreen("+20%") + " chance to hit the head when attacking a [trapped|Keyword.Trapped], [rattled|Skill+rf_rattled_effect], [dazed|Skill+dazed_effect], [staggered|Skill+staggered_effect] target or one that is [out of action|Keyword.OutOfAction]."
 			]
 		}]
  	}),
@@ -674,9 +674,8 @@ foreach (vanillaDesc in vanillaDescriptions)
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Attacks that do at least " + ::MSU.Text.colorRed(5) + " damage to [Hitpoints|Concept.Hitpoints] and apply a valid [status effect|Concept.StatusEffect] or are against characters with a valid [status effect|Concept.StatusEffect] have a chance to inflict an [injury|Concept.Injury]. This chance is " + ::MSU.Text.colorGreen("100%") + " for two-handed maces and " + ::MSU.Text.colorGreen("50%") + " for one-handed maces.",
-				"If the damage was sufficient to inflict an [injury|Concept.Injury], it inflicts an additional [injury|Concept.Injury].",
-				"Valid status effects include: [stunned|Skill+stunned_effect], [netted|Skill+net_effect], [webbed|Skill+web_effect], [rooted|Skill+rooted_effect], [sleeping|Skill+sleeping_effect]."
+				"Attacks that do at least " + ::MSU.Text.colorRed(5) + " damage to [Hitpoints|Concept.Hitpoints] and apply a valid [status effect|Concept.StatusEffect] or are against characters that are [trapped|Keyword.Trapped] or [out of action|Keyword.OutOfAction] have a chance to inflict an [injury|Concept.Injury]. This chance is " + ::MSU.Text.colorGreen("100%") + " for two-handed maces and " + ::MSU.Text.colorGreen("50%") + " for one-handed maces.",
+				"If the damage was sufficient to inflict an [injury|Concept.Injury], it inflicts an additional [injury|Concept.Injury]."
 			]
 		}]
  	}),


### PR DESCRIPTION
These keywords would make it much easier to explain the synergies and conditions of several perks/skills in one word instead of having to count every variation of those effects by hand each time.

I'm not happy with the name **Out of Action**. It's not a keyword in the literal sense and weird using it in certain sentences like 
`grants immunity to [being] out of action`
`grants immunity to being trapped` sounds just fine in contrast.

There is also a small argument to skip **Out of Action** because it only encompasses two sub-effects. And I don't see us introducing a frozen effect anytime soon. 
