### PR TITLE
Shield rework

### DIFF
--- a/mod_reforged/hooks/items/shields/kite_shield.nut
+++ b/mod_reforged/hooks/items/shields/kite_shield.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("items/shields/kite_shield", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.Condition = 42;
+		this.m.ConditionMax = 42;
+	}
+});

--- a/mod_reforged/hooks/items/shields/worn_kite_shield.nut
+++ b/mod_reforged/hooks/items/shields/worn_kite_shield.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("items/shields/worn_kite_shield", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.Condition = 30;
+		this.m.ConditionMax = 30;
+	}
+});

--- a/mod_reforged/hooks/items/weapons/barbarians/axehammer.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/axehammer.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 22;
 		this.m.Reach = 3;
 	}
 

--- a/mod_reforged/hooks/items/weapons/barbarians/crude_axe.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/crude_axe.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 22;
 		this.m.Reach = 3;
 	}
 

--- a/mod_reforged/hooks/items/weapons/barbarians/heavy_rusty_axe.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/heavy_rusty_axe.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 72;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/barbarians/skull_hammer.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/skull_hammer.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 30;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/barbarians/two_handed_spiked_mace.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/two_handed_spiked_mace.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 22;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/bardiche.nut
+++ b/mod_reforged/hooks/items/weapons/bardiche.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 60;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/fighting_axe.nut
+++ b/mod_reforged/hooks/items/weapons/fighting_axe.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 24;
 		this.m.Reach = 3;
 	}
 

--- a/mod_reforged/hooks/items/weapons/greataxe.nut
+++ b/mod_reforged/hooks/items/weapons/greataxe.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 72;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/greatsword.nut
+++ b/mod_reforged/hooks/items/weapons/greatsword.nut
@@ -4,6 +4,7 @@
 	{
 		create();
 		this.m.Name = "Zweihander";
+		this.m.ShieldDamage = 24;
 		this.m.Reach = 6;
 	}
 

--- a/mod_reforged/hooks/items/weapons/greenskins/orc_axe.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/orc_axe.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 42;
 		this.m.Reach = 3;
 	}
 
@@ -11,11 +12,11 @@
 		this.weapon.onEquip();
 
 		this.addSkill(::MSU.new("scripts/skills/actives/chop", function(o) {
-			o.m.FatigueCost += 5;
+			o.m.FatigueCost += 1;
 		}));
 
 		this.addSkill(::MSU.new("scripts/skills/actives/split_shield", function(o) {
-			o.m.FatigueCost += 8;
+			o.m.FatigueCost += 3;
 			o.setApplyAxeMastery(true);
 		}));
 	}

--- a/mod_reforged/hooks/items/weapons/greenskins/orc_axe_2h.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/orc_axe_2h.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 124;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/hand_axe.nut
+++ b/mod_reforged/hooks/items/weapons/hand_axe.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 22;
 		this.m.Reach = 3;
 	}
 

--- a/mod_reforged/hooks/items/weapons/hatchet.nut
+++ b/mod_reforged/hooks/items/weapons/hatchet.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 14;
 		this.m.Reach = 2;
 	}
 

--- a/mod_reforged/hooks/items/weapons/longaxe.nut
+++ b/mod_reforged/hooks/items/weapons/longaxe.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 50;
 		this.m.Reach = 6;
 	}
 });

--- a/mod_reforged/hooks/items/weapons/throwing_spear.nut
+++ b/mod_reforged/hooks/items/weapons/throwing_spear.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 48;
 		this.m.Reach = 0;
 	}
 });

--- a/mod_reforged/hooks/items/weapons/two_handed_flanged_mace.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_flanged_mace.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 32;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/two_handed_hammer.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_hammer.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 36;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/two_handed_mace.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_mace.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 22;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/two_handed_wooden_hammer.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_wooden_hammer.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 22;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/items/weapons/woodcutters_axe.nut
+++ b/mod_reforged/hooks/items/weapons/woodcutters_axe.nut
@@ -3,6 +3,7 @@
 	o.create = function()
 	{
 		create();
+		this.m.ShieldDamage = 42;
 		this.m.Reach = 5;
 	}
 

--- a/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
@@ -44,26 +44,4 @@
 		if (this.m.IsNew) this.getContainer().add(::new("scripts/skills/effects/rf_swordmasters_finesse_effect"));
 		return onAdded();
 	}
-
-	o.onBuildPerkTree <- function()
-	{
-		local perkTree = this.getPerkTree();
-		local masteryPerks = [
-			"perk.mastery.axe",
-			"perk.mastery.bow",
-			"perk.mastery.cleaver",
-			"perk.mastery.crossbow",
-			"perk.mastery.dagger",
-			"perk.mastery.flail",
-			"perk.mastery.hammer",
-			"perk.mastery.mace",
-			"perk.mastery.polearm",
-			"perk.mastery.spear",
-			"perk.mastery.throwing",
-		];
-		foreach (perk in masteryPerks)
-		{
-			if (perkTree.hasPerk(perk)) perkTree.removePerk(perk);
-		}
-	}
 });

--- a/scripts/items/weapons/rf_battle_axe.nut
+++ b/scripts/items/weapons/rf_battle_axe.nut
@@ -18,7 +18,7 @@ this.rf_battle_axe <- ::inherit("scripts/items/weapons/weapon", {
 		this.m.ShowArmamentIcon = true;
 		this.m.ArmamentIcon = "icon_goblin_weapon_05";
 		this.m.Value = 1950;
-		this.m.ShieldDamage = 24;
+		this.m.ShieldDamage = 40;
 		this.m.Condition = 64.0;
 		this.m.ConditionMax = 64.0;
 		this.m.StaminaModifier = -14;

--- a/scripts/items/weapons/rf_greatsword.nut
+++ b/scripts/items/weapons/rf_greatsword.nut
@@ -21,7 +21,7 @@ this.rf_greatsword <- ::inherit("scripts/items/weapons/weapon", {
 		this.m.ShowArmamentIcon = true;
 		this.m.ArmamentIcon = "icon_sword_two_handed_01";
 		this.m.Value = 2400;
-		this.m.ShieldDamage = 12;
+		this.m.ShieldDamage = 18;
 		this.m.Condition = 60.0;
 		this.m.ConditionMax = 60.0;
 		this.m.StaminaModifier = -10;


### PR DESCRIPTION
This is the first phase of shield damage and shield condition rework.

Phase One: Rebalance  Shield Damage and Shield Condition to make both shields and shield splitting useful.

Phase Two: Increase Shield Damage on regular attacks to be both useful and balanced.

Phase Three: Shield Damage that exceeds a Shield's remaining condition deals the remaining damage to the target.

This PR:
I've balanced our current lineup against each other and against each shield in the game. I feel strongly I have a pretty good balance here. You can see the whole list of shield damage by weapon in the weapons spreadsheet. You can use this link to quickly see shield conditions (https://battlebrothers.fandom.com/wiki/Armor#Shields). If the numbers are too hard to parse and come on up with an understanding of the balance, let me know and I can expand upon my design intentions.

Edit: I forgot I also rebalanced orc axe fatigue cost because it was wrong. I can split up this commit if necessary.