### PR TITLE
refactor: change encumbrance to increase fatigue at turn start

### DIFF
--- a/scripts/skills/effects/rf_encumbrance_effect.nut
+++ b/scripts/skills/effects/rf_encumbrance_effect.nut
@@ -38,7 +38,7 @@ this.rf_encumbrance_effect <- ::inherit("scripts/skills/skill", {
 					id = 10,
 					type = "text",
 					icon = "ui/icons/fatigue.png",
-					text = "[color=" + ::Const.UI.Color.NegativeValue + "]-1[/color] Fatigue Recovery per turn"
+					text = "[color=" + ::Const.UI.Color.NegativeValue + "]+1[/color] Fatigue at the start of every turn"
 				});
 				break;
 
@@ -48,7 +48,7 @@ this.rf_encumbrance_effect <- ::inherit("scripts/skills/skill", {
 						id = 10,
 						type = "text",
 						icon = "ui/icons/fatigue.png",
-						text = "[color=" + ::Const.UI.Color.NegativeValue + "]-2[/color] Fatigue Recovery per turn"
+						text = "[color=" + ::Const.UI.Color.NegativeValue + "]+2[/color] Fatigue at the start of every turn"
 					},
 					{
 						id = 10,
@@ -65,7 +65,7 @@ this.rf_encumbrance_effect <- ::inherit("scripts/skills/skill", {
 						id = 10,
 						type = "text",
 						icon = "ui/icons/fatigue.png",
-						text = "[color=" + ::Const.UI.Color.NegativeValue + "]-2[/color] Fatigue Recovery per turn"
+						text = "[color=" + ::Const.UI.Color.NegativeValue + "]+2[/color] Fatigue at the start of every turn"
 					},
 					{
 						id = 10,
@@ -82,7 +82,7 @@ this.rf_encumbrance_effect <- ::inherit("scripts/skills/skill", {
 						id = 10,
 						type = "text",
 						icon = "ui/icons/fatigue.png",
-						text = "[color=" + ::Const.UI.Color.NegativeValue + "]-3[/color] Fatigue Recovery per turn"
+						text = "[color=" + ::Const.UI.Color.NegativeValue + "]+3[/color] Fatigue at the start of every turn"
 					},
 					{
 						id = 10,
@@ -130,26 +130,46 @@ this.rf_encumbrance_effect <- ::inherit("scripts/skills/skill", {
 		switch (this.getEncumbranceLevel())
 		{
 			case 0:
+			case 1:
 				return;
 
-			case 1:
-				_properties.FatigueRecoveryRate -= 1;
-				break;
-
 			case 2:
-				_properties.FatigueRecoveryRate -= 2;
 				_properties.MovementFatigueCostAdditional += 1;
 				break;
 
 			case 3:
-				_properties.FatigueRecoveryRate -= 2;
 				_properties.MovementFatigueCostAdditional += 3;
 				break;
 
 			default:
-				_properties.FatigueRecoveryRate -= 3;
 				_properties.MovementFatigueCostAdditional += 3;
 				break;
 		}
+	}
+
+	function onTurnStart()
+	{
+		local fatigue;
+		switch (this.getEncumbranceLevel())
+		{
+			case 0:
+				return;
+
+			case 1:
+				fatigue = 1;
+				break;
+
+			case 2:
+			case 3:
+				fatigue = 2;
+				break;
+
+			default:
+				fatigue = 3;
+				break;
+		}
+
+		local actor = this.getContainer().getActor();
+		actor.setFatigue(::Math.min(actor.getFatigueMax(), actor.getFatigue() + fatigue));
 	}
 });


### PR DESCRIPTION
This _is_ how the encumbrance mechanic was originally conceptualized to work. Currently, the way vanilla works is that Fatigue Recovery is only relevant until you reach maximum fatigue. At that point, you always regain 15 Fatigue. This makes traits such as Asthmatic, and injuries which affect Fatigue Recovery basically irrelevant at that stage. It also makes it so that the Encumbrance mechanic doesn't work as intended.

To change the complete mechanic so that Fatigue Recovery is always used at Max Fatigue instead of a minimum of 15 would require overwriting actor.nut `onTurnStart` function or doing an ugly switcheroo on it as it touches many things. So, instead of doing that, this PR makes it so that only the "Encumbrance" mechanic overrides the min. 15 Fatigue recovery mechanic, which makes it work as intended and is, imo, an ok compromise for now.

EDIT: Based on the discussion on the PR we decided to change Encumbrance to now "increase Fatigue by x at the start of a turn" rather than change "FatigueRecovery" property.