### PR TITLE
feat: streamline and simplify racial damage reductions

### DIFF
--- a/mod_reforged/hooks/config/tactical_entity_common.nut
+++ b/mod_reforged/hooks/config/tactical_entity_common.nut
@@ -1,0 +1,31 @@
+// We overwrite the vanilla function to remove all damage multiplier and add the burning damage type
+::Const.Tactical.Common.onApplyFire = function( _tile, _entity )
+{
+    if (_entity.getCurrentProperties().IsImmuneToFire) return;
+
+    ::Tactical.spawnIconEffect("status_effect_116", _tile, ::Const.Tactical.Settings.SkillIconOffsetX, ::Const.Tactical.Settings.SkillIconOffsetY, ::Const.Tactical.Settings.SkillIconScale, ::Const.Tactical.Settings.SkillIconFadeInDuration, ::Const.Tactical.Settings.SkillIconStayDuration, ::Const.Tactical.Settings.SkillIconFadeOutDuration, ::Const.Tactical.Settings.SkillIconMovement);
+    local sounds = [
+        "sounds/combat/dlc6/status_on_fire_01.wav",
+        "sounds/combat/dlc6/status_on_fire_02.wav",
+        "sounds/combat/dlc6/status_on_fire_03.wav"
+    ];
+    ::Sound.play(sounds[this.Math.rand(0, sounds.len() - 1)], ::Const.Sound.Volume.Actor, _entity.getPos());
+
+    local damage = this.Math.rand(15, 30);
+    local hitInfo = clone ::Const.Tactical.HitInfo;
+    hitInfo.DamageRegular = damage;
+    hitInfo.DamageArmor = damage;
+    hitInfo.DamageDirect = 0.1;
+    hitInfo.DamageType = ::Const.Damage.DamageType.Burning;     // Uses damagetype system from MSU
+    hitInfo.BodyPart = ::Const.BodyPart.Body;
+    hitInfo.BodyDamageMult = 1.0;
+    hitInfo.FatalityChanceMult = 0.0;
+    hitInfo.Injuries = ::Const.Injury.Burning;
+    hitInfo.IsPlayingArmorSound = false;
+    _entity.onDamageReceived(_entity, null, hitInfo);
+
+    if ((!_entity.isAlive() || _entity.isDying()) && !_entity.isPlayerControlled() && (_tile.Properties.Effect == null || _tile.Properties.Effect.IsByPlayer))
+    {
+        this.updateAchievement("BurnThemAll", 1, 1);
+    }
+}

--- a/mod_reforged/hooks/skills/items/firearms_resistance_skill.nut
+++ b/mod_reforged/hooks/skills/items/firearms_resistance_skill.nut
@@ -1,0 +1,14 @@
+::mods_hookExactClass("skills/items/firearms_resistance_skill", function(o) {
+    // We overwrite the vanilla behavior of that skill completely while replicating its effect pretty future proof
+    o.onBeforeDamageReceived = function( _attacker, _skill, _hitInfo, _properties )
+	{
+        if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Firearm))    // This covers all kinds of firearms
+        {
+            _properties.DamageReceivedRegularMult *= 0.66;
+        }
+        else if (_hitInfo.DamageType == ::Const.Damage.DamageType.Burning)  // This covers burning ground and firelances
+        {
+            _properties.DamageReceivedRegularMult *= 0.66;
+        }
+	}
+});

--- a/mod_reforged/hooks/skills/racial/alp_racial.nut
+++ b/mod_reforged/hooks/skills/racial/alp_racial.nut
@@ -6,59 +6,41 @@
 			case null:
 				break;
 
-			case ::Const.Damage.DamageType.Burning:
-				_properties.DamageReceivedRegularMult *= 1.01; // To balance Handgonne (0.75 x 0.33) + (0.25 * 1.01) = 0.5 where 0.5 is the vanilla damage from handgonne
+			case ::Const.Damage.DamageType.Blunt:
+				if (_skill != null)
+				{
+					if (_skill.isRanged())	// In Vanilla this reduction only exists for slinging of stones. Here it expands to bolas and potential future blunt ranged attacks
+					{
+						_properties.DamageReceivedRegularMult *= 0.33;
+					}
+				}
 				break;
 
 			case ::Const.Damage.DamageType.Piercing:
-				if (_skill != null)
+				if (_skill == null)
+				{
+					_properties.DamageReceivedRegularMult *= 0.5;
+				}
+				else
 				{
 					if (_skill.isRanged())
 					{
-						if (::MSU.isNull(_skill.getItem()))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else if (!_skill.getItem().isItemType(::Const.Items.ItemType.Weapon))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else
-						{
-							if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Bow))
-							{
-								_properties.DamageReceivedRegularMult *= 0.1;
-							}
-							else if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Crossbow) || _skill.getItem().isWeaponType(::Const.Items.WeaponType.Firearm))
-							{
-								_properties.DamageReceivedRegularMult *= 0.33;
-							}
-							else if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Throwing))
-							{
-								if (_skill.getID() == "actives.throw_spear") _properties.DamageReceivedRegularMult *= 0.5;
-								else _properties.DamageReceivedRegularMult *= 0.25;
-							}
-						}
+						_properties.DamageReceivedRegularMult *= 0.33;
+						/* This streamlines the following differences in vanilla:
+							Arrows dealing only 10% damage
+							javelins dealing only 25% damage
+							handgonne & one-use throwing spear dealing 50% damage
+						*/
 					}
 					else
 					{
-						if (::MSU.isNull(_skill.getItem()))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else if (!_skill.getItem().isItemType(::Const.Items.ItemType.Weapon))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else
-						{
-							_properties.DamageReceivedRegularMult *= 0.5;
-						}
+						_properties.DamageReceivedRegularMult *= 0.5;
 					}
 				}
 				break;
 
 			case ::Const.Damage.DamageType.Cutting:
+				// Maybe replace this with some sort of isAnimal or isBeast check on the attacker?
 				if (_skill != null && (_skill.getID() == "actives.wardog_bite" || _skill.getID() == "actives.wolf_bite" || _skill.getID() == "actives.warhound_bite"))
 				{
 					_properties.DamageReceivedRegularMult *= 0.33;

--- a/mod_reforged/hooks/skills/racial/golem_racial.nut
+++ b/mod_reforged/hooks/skills/racial/golem_racial.nut
@@ -19,7 +19,7 @@
 			case ::Const.Damage.DamageType.Blunt:
 				if (_skill != null)
 				{
-					if (_skill.isRanged())
+					if (_skill.isRanged())	// In Vanilla this reduction only exists for slinging of stones. Here it expands to bolas and potential future blunt ranged attacks
 					{
 						_properties.DamageReceivedRegularMult *= 0.33;
 					}
@@ -29,55 +29,22 @@
 			case ::Const.Damage.DamageType.Piercing:
 				if (_skill == null)
 				{
-					_properties.DamageReceivedRegularMult *= 0.33;
+					_properties.DamageReceivedRegularMult *= 0.5;
 				}
 				else
 				{
 					if (_skill.isRanged())
 					{
-						if (::MSU.isNull(_skill.getItem()))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else if (!_skill.getItem().isItemType(::Const.Items.ItemType.Weapon))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else
-						{
-							if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Bow))
-							{
-								_properties.DamageReceivedRegularMult *= 0.1;
-							}
-							else if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Crossbow))
-							{
-								_properties.DamageReceivedRegularMult *= 0.33;
-							}
-							else if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Firearm))
-							{
-								_properties.DamageReceivedRegularMult *= 0.25;
-							}
-							else if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Throwing))
-							{
-								if (_skill.getID() == "actives.throw_spear") _properties.DamageReceivedRegularMult *= 0.5;
-								else _properties.DamageReceivedRegularMult *= 0.25;
-							}
-						}
+						_properties.DamageReceivedRegularMult *= 0.33;
+						/* This streamlines the following differences in vanilla:
+							Arrows dealing only 10% damage
+							javelins and handgonne dealing only 25% damage
+							one-use throwing spear dealing 100% damage
+						*/
 					}
 					else
 					{
-						if (::MSU.isNull(_skill.getItem()))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else if (!_skill.getItem().isItemType(::Const.Items.ItemType.Weapon))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else
-						{
-							_properties.DamageReceivedRegularMult *= 0.5;
-						}
+						_properties.DamageReceivedRegularMult *= 0.5;
 					}
 				}
 				break;

--- a/mod_reforged/hooks/skills/racial/schrat_racial.nut
+++ b/mod_reforged/hooks/skills/racial/schrat_racial.nut
@@ -7,33 +7,27 @@
 				break;
 
 			case ::Const.Damage.DamageType.Burning:
-				_properties.DamageReceivedRegularMult *= 1.33;
+				_properties.DamageReceivedRegularMult *= 2.0;	// In Vanilla this is 1.33 for firelance and 3.0 for burning ground
 				break;
 
 			case ::Const.Damage.DamageType.Piercing:
-				if (_skill != null)
+				if (_skill == null)
+				{
+					_properties.DamageReceivedRegularMult *= 0.50;
+				}
+				else
 				{
 					if (_skill.isRanged())
 					{
-						if (::MSU.isNull(_skill.getItem()))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else if (!_skill.getItem().isItemType(::Const.Items.ItemType.Weapon))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else
-						{
-							if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Throwing))
-							{
-								_properties.DamageReceivedRegularMult *= 0.5;
-							}
-							else
-							{
-								_properties.DamageReceivedRegularMult *= 0.25;
-							}
-						}
+						_properties.DamageReceivedRegularMult *= 0.25;
+						/* This streamlines the following differences in vanilla:
+							javelins dealing 50% damage
+							handgonne and one-use throwing spear dealing 100% damage
+						*/
+					}
+					else
+					{
+						_properties.DamageReceivedRegularMult *= 0.50;	// New: In Vanilla piercing melee attacks are not reduced
 					}
 				}
 				break;

--- a/mod_reforged/hooks/skills/racial/serpent_racial.nut
+++ b/mod_reforged/hooks/skills/racial/serpent_racial.nut
@@ -9,6 +9,8 @@
 			case ::Const.Damage.DamageType.Burning:
 				_properties.DamageReceivedRegularMult *= 0.66;
 				break;
+
+			// In Vanilla they also take reduced damage from firearms and mortars. But those are currently not covered here
 		}
 	}
 });

--- a/mod_reforged/hooks/skills/racial/skeleton_racial.nut
+++ b/mod_reforged/hooks/skills/racial/skeleton_racial.nut
@@ -11,49 +11,24 @@
 				break;
 
 			case ::Const.Damage.DamageType.Piercing:
-				if (_skill != null)
+				if (_skill == null)
+				{
+					_properties.DamageReceivedRegularMult *= 0.5;
+				}
+				else
 				{
 					if (_skill.isRanged())
 					{
-						if (::MSU.isNull(_skill.getItem()))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else if (!_skill.getItem().isItemType(::Const.Items.ItemType.Weapon))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else
-						{
-							if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Bow))
-							{
-								_properties.DamageReceivedRegularMult *= 0.1;
-							}
-							else if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Crossbow) || _skill.getItem().isWeaponType(::Const.Items.WeaponType.Firearm))
-							{
-								_properties.DamageReceivedRegularMult *= 0.33;
-							}
-							else if (_skill.getItem().isWeaponType(::Const.Items.WeaponType.Throwing))
-							{
-								if (_skill.getID() == "actives.throw_spear") _properties.DamageReceivedRegularMult *= 0.5;
-								else _properties.DamageReceivedRegularMult *= 0.25;
-							}
-						}
+						_properties.DamageReceivedRegularMult *= 0.33;
+						/* This streamlines the following differences in vanilla:
+							Arrows dealing only 10% damage
+							javelins dealing only 25% damage
+							one-use throwing spear dealing 50% damage
+						*/
 					}
 					else
 					{
-						if (::MSU.isNull(_skill.getItem()))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else if (!_skill.getItem().isItemType(::Const.Items.ItemType.Weapon))
-						{
-							_properties.DamageReceivedRegularMult *= 0.33;
-						}
-						else
-						{
-							_properties.DamageReceivedRegularMult *= 0.5;
-						}
+						_properties.DamageReceivedRegularMult *= 0.5;
 					}
 				}
 				break;


### PR DESCRIPTION
Vanilla does racial damage reductions and increases hard-coded. This also causes several mistakes where sometimes a specific attack was missing causing that type of damage to deal full damage.
Reforged already did a first rework pass on these racial effects by mimicing them via the DamageType system.

**Overview of the changes:**
This PR tries to simplify those values so they are more presentable to players and understandable for devs.
Burning Ground no longer has inherit mutlipliers for different entity-types. Instead it uses the MSU damage type system and leaves the multipliers to the individual entities.
All races that are resistance to piercing attacks now all have 
- a 66% (or 75% in case of Schrat) damage reduction against ranged piercing (arrows damage is buffed, a few other random attacks here and there nerfed)
- and 50% against melee piercing. (for Schrats this is actually a new addition)
Burning ground does less damage to Schrats now but firelances do more damage against them.

**Additional Thoughts:**

While it does make sense that some projectiles like arrows should deal less damage than bolts to the same target it isn't the job of us hard-coding those differences via the racial effects. That could be solved via some new flexible rule like using the armor pen value of those attacks as an additional damage multiplier for certain races.

But I argue that the streamlining of those ranged piercing attacks doesn't matter in the grand scheme of things. 
It doesn't matter whether arrows deal 10% or 33% damage. They are bad either way against that enemy type and that brother should have better brought a throwing axe to that battle or stayed in reserve.
