### PR TITLE
feat: set Type of most racial effects to be only 'SkillType.Racial'

### DIFF
--- a/mod_reforged/hooks/skills/racial/ghost_racial.nut
+++ b/mod_reforged/hooks/skills/racial/ghost_racial.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("skills/racial/ghost_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+});

--- a/mod_reforged/hooks/skills/racial/goblin_ambusher_racial.nut
+++ b/mod_reforged/hooks/skills/racial/goblin_ambusher_racial.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("skills/racial/goblin_ambusher_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+});

--- a/mod_reforged/hooks/skills/racial/goblin_shaman_racial.nut
+++ b/mod_reforged/hooks/skills/racial/goblin_shaman_racial.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("skills/racial/goblin_shaman_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+});

--- a/mod_reforged/hooks/skills/racial/lindwurm_racial.nut
+++ b/mod_reforged/hooks/skills/racial/lindwurm_racial.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("skills/racial/lindwurm_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+});

--- a/mod_reforged/hooks/skills/racial/serpent_racial.nut
+++ b/mod_reforged/hooks/skills/racial/serpent_racial.nut
@@ -1,4 +1,12 @@
 ::mods_hookExactClass("skills/racial/serpent_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+
 	o.onBeforeDamageReceived = function( _attacker, _skill, _hitInfo, _properties )
 	{
 		switch (_hitInfo.DamageType)

--- a/mod_reforged/hooks/skills/racial/spider_racial.nut
+++ b/mod_reforged/hooks/skills/racial/spider_racial.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("skills/racial/spider_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+});

--- a/mod_reforged/hooks/skills/racial/vampire_racial.nut
+++ b/mod_reforged/hooks/skills/racial/vampire_racial.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("skills/racial/vampire_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+});


### PR DESCRIPTION
There is currently no reason that some of those racial effects randomly had the type 'Perk'.
That only causes issues with our tooltips trying to display those.

In vanilla there is no reason that some of those racial effects randomly had the type 'StatusEffect'
Afaik this is only relevant if you want to display an Icon and Tooltip to the player. But most of those effects have IsHidden at true which will never display those anyways.
The only exception here is 'schrat_racial'. Here I don't replace the Type

Overwriting those types will also give a small performance boost as those racials will no longer be queried.
When we decide to add descriptions for those and show the to the player we will re-add the type 'StatusEffect'