### PR TITLE
feat: give Saplings the Schrat-Racial effect

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/schrat.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/schrat.nut
@@ -54,6 +54,7 @@
 		this.setSpriteOffset("status_stunned", this.createVec(0, 10));
 		this.setSpriteOffset("arrow", this.createVec(0, 10));
 		this.m.Skills.add(this.new("scripts/skills/racial/schrat_racial"));
+		this.m.Skills.add(this.new("scripts/skills/effects/rf_sapling_harvest_effect"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_pathfinder"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_crippling_strikes"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_steel_brow"));

--- a/mod_reforged/hooks/entity/tactical/enemies/schrat_small.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/schrat_small.nut
@@ -29,6 +29,7 @@
 		this.setSpriteOffset("status_rooted", this.createVec(0, 0));
 		this.setSpriteOffset("status_stunned", this.createVec(-10, -10));
 		this.setSpriteOffset("arrow", this.createVec(-10, -10));
+		this.m.Skills.add(this.new("scripts/skills/racial/schrat_racial"));		// Now saplings receive the same damage-received multipliers
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_pathfinder"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_crippling_strikes"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_steel_brow"));

--- a/mod_reforged/hooks/skills/racial/schrat_racial.nut
+++ b/mod_reforged/hooks/skills/racial/schrat_racial.nut
@@ -39,4 +39,8 @@
 				break;
 		}
 	}
+
+	// We exported everything this function does into its own effect (rf_sapling_harvest).
+	// By overwriting this method we also nullify all other mods hooking into this before us but there is clean solution to this
+	o.onDamageReceived = function( _attacker, _damageHitpoints, _damageArmor ) {};
 });

--- a/scripts/skills/effects/rf_sapling_harvest_effect.nut
+++ b/scripts/skills/effects/rf_sapling_harvest_effect.nut
@@ -1,0 +1,49 @@
+this.rf_sapling_harvest_effect <- ::inherit("scripts/skills/skill", {
+	m = {
+		DamageThreshold = 0.1,
+		SpawnedUnit = "scripts/entity/tactical/enemies/schrat_small"
+	},
+	function create()
+	{
+		this.m.ID = "effects.rf_sapling_harvest";
+		this.m.Name = "Sapling Harvest";
+		this.m.Icon = "skills/terrain_icon_06.png";
+		this.m.SoundOnUse = [];
+		this.m.Type = this.Const.SkillType.StatusEffect;
+		this.m.Order = this.Const.SkillOrder.Last;
+		this.m.IsActive = false;
+		this.m.IsStacking = false;
+		this.m.IsHidden = false;
+	}
+
+	function getDescription()
+	{
+		return ::Reforged.Mod.Tooltips.parseString("Whenever this character receives " + ::MSU.Text.colorGreen((this.m.DamageThreshold * 100.0) + "%") + " or more damage to [Hitpoints|Concept.Hitpoints] from a single hit, spawn a Sapling on an adjacent tile, if possible.");
+	}
+
+	function onDamageReceived( _attacker, _damageHitpoints, _damageArmor )
+	{
+		local actor = this.getContainer().getActor();
+		if (_damageHitpoints < (this.m.DamageThreshold * actor.getHitpointsMax())) return;
+
+		local candidates = [];
+		local myTile = actor.getTile();
+
+		for (local i = 0; i < 6; i++)
+		{
+			if (!myTile.hasNextTile(i)) continue;
+
+			local nextTile = myTile.getNextTile(i);
+			if (nextTile.IsEmpty && ::Math.abs(myTile.Level - nextTile.Level) <= 1)
+			{
+				candidates.push(nextTile);
+			}
+		}
+		if (candidates.len() == 0) return;
+
+		local spawnTile = candidates[::Math.rand(0, candidates.len() - 1)];
+		local sapling = ::Tactical.spawnEntity(this.m.SpawnedUnit, spawnTile.Coords);
+		sapling.setFaction(actor.getFaction());
+		sapling.riseFromGround();
+	}
+});


### PR DESCRIPTION
In return this will extract the Sapling-Spawn effect out of the Schrat-Racial and into its own new effect that is only given to Schrats for now.

Screenshot on how it looks ingame:
![image](https://user-images.githubusercontent.com/2252464/219554595-91da5a81-a70c-44bc-ac83-a7966e892cf2.png)
