### PR TITLE
Weapon tier

### DIFF
--- a/mod_reforged/hooks/items/weapons/crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/crossbow.nut
@@ -12,9 +12,7 @@
 
 		this.addSkill(::new("scripts/skills/actives/shoot_bolt"));
 
-		local reload = ::MSU.new("scripts/skills/actives/reload_bolt", function(o) {
-			o.m.FatigueCost += 2;
-		});
+		local reload = ::MSU.new("scripts/skills/actives/reload_bolt");
 		reload.m.IsHidden = this.m.IsLoaded;
 		this.addSkill(reload);
 	}

--- a/mod_reforged/hooks/items/weapons/greenskins/goblin_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/goblin_crossbow.nut
@@ -13,8 +13,8 @@
 		this.addSkill(::new("scripts/skills/actives/shoot_bolt"));
 
 		local reload = ::MSU.new("scripts/skills/actives/reload_bolt", function(o) {
-			o.m.ActionPointCost += 1;
-			o.m.FatigueCost += 5;
+			o.m.ActionPointCost += 2;
+			o.m.FatigueCost += 2;
 		});
 		reload.m.IsHidden = this.m.IsLoaded;
 		this.addSkill(reload);

--- a/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
@@ -13,8 +13,8 @@
 		this.addSkill(::new("scripts/skills/actives/shoot_bolt"));
 
 		local reload = ::MSU.new("scripts/skills/actives/reload_bolt", function(o) {
-			o.m.ActionPointCost += 1;
-			o.m.FatigueCost += 5;
+			o.m.ActionPointCost += 2;
+			o.m.FatigueCost += 2;
 		});
 		reload.m.IsHidden = this.m.IsLoaded;
 		this.addSkill(reload);

--- a/mod_reforged/hooks/items/weapons/light_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/light_crossbow.nut
@@ -12,7 +12,9 @@
 
 		this.addSkill(::new("scripts/skills/actives/shoot_bolt"));
 
-		local reload = ::MSU.new("scripts/skills/actives/reload_bolt");
+		local reload = ::MSU.new("scripts/skills/actives/reload_bolt", function(o) {
+			o.m.FatigueCost -= 2;
+		});
 		reload.m.IsHidden = this.m.IsLoaded;
 		this.addSkill(reload);
 	}

--- a/mod_reforged/hooks/items/weapons/war_bow.nut
+++ b/mod_reforged/hooks/items/weapons/war_bow.nut
@@ -15,7 +15,6 @@
 		}));
 
 		this.addSkill(::MSU.new("scripts/skills/actives/aimed_shot", function(o) {
-			o.m.ActionPointCost += 1;
 			o.m.FatigueCost += 3;
 		}));
 	}

--- a/mod_reforged/hooks/items/weapons/woodcutters_axe.nut
+++ b/mod_reforged/hooks/items/weapons/woodcutters_axe.nut
@@ -16,6 +16,7 @@
 
 		this.addSkill(::MSU.new("scripts/skills/actives/round_swing", function(o) {
 			o.m.ActionPointCost -= 1;
+			o.m.FatigueCost -= 5;
 		}));
 
 		this.addSkill(::MSU.new("scripts/skills/actives/split_shield", function(o) {


### PR DESCRIPTION
Heavy and goblin crossbow reload now costs 6 AP but will be reduced by 2 AP by weapon mastery. Reduced fatigue costs on crossbows to reasonable, sensible and usable levels. Reduced extra AP cost of warbow aimed shot. Reduced woodcutters axe round swing fatigue cost to the proper level (wasn't reduced before when it should've been).