### PR TITLE
refactor: set action points to 7 but reduce AP cost of movement

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
@@ -53,6 +53,8 @@
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_backstabber"));
 
 		// Reforged
+		this.m.BaseProperties.ActionPoints = 7;
+		this.m.BaseProperties.MovementAPCostAdditional -= 1;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_vigorous_assault"));
 		this.m.Skills.add(::MSU.new("scripts/skills/perks/perk_rf_kata", function(o) {
 			o.m.IsForceEnabled = true;

--- a/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
@@ -71,5 +71,6 @@
 	    assignRandomEquipment();
 
 	    ::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 5);
+	    this.m.Skills.removeByID("perk.rf_two_for_one");
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
@@ -4,7 +4,7 @@
 	    this.goblin.onInit();
 		local b = this.m.BaseProperties;
 		b.setValues(this.Const.Tactical.Actor.GoblinWolfrider);
-		b.AdditionalActionPointCost = 1;
+		// b.AdditionalActionPointCost = 1;
 		// b.DamageDirectMult = 1.25;
 		b.IsSpecializedInSwords = true;
 		b.IsSpecializedInSpears = true;
@@ -53,8 +53,7 @@
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_backstabber"));
 
 		// Reforged
-		this.m.BaseProperties.ActionPoints = 7;
-		this.m.BaseProperties.MovementAPCostAdditional -= 1;
+		this.m.Skills.add(::new("scripts/skills/racial/rf_goblin_wolfrider_racial"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_vigorous_assault"));
 		this.m.Skills.add(::MSU.new("scripts/skills/perks/perk_rf_kata", function(o) {
 			o.m.IsForceEnabled = true;

--- a/scripts/skills/racial/rf_goblin_wolfrider_racial.nut
+++ b/scripts/skills/racial/rf_goblin_wolfrider_racial.nut
@@ -1,0 +1,37 @@
+this.rf_goblin_wolfrider <- ::inherit("scripts/skills/skill", {
+	m = {},
+	function create()
+	{
+		this.m.ID = "racial.rf_goblin_wolfrider";
+		this.m.Name = "Wolfrider";
+		this.m.Description = "This character is riding a wolf, which makes using weapons a little harder than usual.";
+		this.m.Icon = "";
+		this.m.Type = ::Const.SkillType.Racial | ::Const.SkillType.Perk;
+		this.m.Order = ::Const.SkillOrder.Any;
+		this.m.IsActive = false;
+		this.m.IsStacking = false;
+		this.m.IsHidden = false;
+	}
+
+	function getTooltip()
+	{
+		local ret = this.skill.getTooltip();
+		ret.push({
+			id = 8,
+			type = "text",
+			icon = "ui/icons/ammo.png",
+			text = format("Weapon skills cost %s Action Point", ::MSU.Text.colorRed("+1"));
+		});
+	}
+
+	function onAfterUpdate( _properties )
+	{
+		local weapon = this.getContainer().getActor().getMainhandItem();
+		if (weapon == null) return;
+
+		foreach (skill in weapon.getSkills())
+		{
+			skill.m.ActionPointCost += 1;
+		}
+	}
+});


### PR DESCRIPTION
With this they can move 7 tiles on normal ground (compared to 6 in vanilla). They can attack twice with Falchion and then Bite, or attack thrice with Spear and then Bite.

Currently they have 13 AP which means that with Falchion they can attack 4 times, and then Bite (so 5 total attacks) and with Spear they can attack 6 times and then Bite (so 7 total attacks). This is broken. I believe the vanilla devs gave them 13 AP to allow them to have a large movement - and not so many attacks. But in Reforged because we have AP cost reduction on goblin weapons and then from the Two for One perk which further reduces it - it allows them to attack so much.

After the changes in this PR, their attacks are normal in number, but they still get to move roughly similar number of tiles as vanilla.