### PR TITLE
refactor: remove the Type 'Perk' from all racial effects

### DIFF
--- a/mod_reforged/hooks/skills/racial/ghost_racial.nut
+++ b/mod_reforged/hooks/skills/racial/ghost_racial.nut
@@ -1,4 +1,12 @@
 ::mods_hookExactClass("skills/racial/ghost_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+
 	o.onAdded <- function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();

--- a/mod_reforged/hooks/skills/racial/goblin_ambusher_racial.nut
+++ b/mod_reforged/hooks/skills/racial/goblin_ambusher_racial.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("skills/racial/goblin_ambusher_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+});

--- a/mod_reforged/hooks/skills/racial/goblin_shaman_racial.nut
+++ b/mod_reforged/hooks/skills/racial/goblin_shaman_racial.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("skills/racial/goblin_shaman_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+});

--- a/mod_reforged/hooks/skills/racial/lindwurm_racial.nut
+++ b/mod_reforged/hooks/skills/racial/lindwurm_racial.nut
@@ -1,4 +1,12 @@
 ::mods_hookExactClass("skills/racial/lindwurm_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+
 	o.onAdded <- function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();

--- a/mod_reforged/hooks/skills/racial/serpent_racial.nut
+++ b/mod_reforged/hooks/skills/racial/serpent_racial.nut
@@ -1,4 +1,12 @@
 ::mods_hookExactClass("skills/racial/serpent_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+
 	o.onAdded <- function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();

--- a/mod_reforged/hooks/skills/racial/spider_racial.nut
+++ b/mod_reforged/hooks/skills/racial/spider_racial.nut
@@ -1,4 +1,12 @@
-::mods_hookExactClass("skills/racial/serpent_racial", function(o) {
+::mods_hookExactClass("skills/racial/spider_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+	
 	o.onAdded <- function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();

--- a/mod_reforged/hooks/skills/racial/vampire_racial.nut
+++ b/mod_reforged/hooks/skills/racial/vampire_racial.nut
@@ -1,4 +1,12 @@
 ::mods_hookExactClass("skills/racial/vampire_racial", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		if (this.isType(::Const.SkillType.Perk))
+			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
+	}
+
 	o.onAdded <- function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();


### PR DESCRIPTION
There is currently no reason that some of those racial effects randomly had the type 'Perk'. This currently causes issues with our tooltips trying to display those. Also it will cause the Oblivion Potion to remove those racial effects if they are ever to appear on "brothers".

**Important:** This PR requires MSU functions which are not yet in MSU. Enduriel said that he wants to get them in ASAP