### PR TITLE
fix: lower volume of annoying kid ambience sound

### DIFF
--- a/mod_reforged/hooks/config/sound.nut
+++ b/mod_reforged/hooks/config/sound.nut
@@ -1,0 +1,13 @@
+function lowerAnnoyingKid( _soundArray )
+{
+    foreach (soundTable in ::Const.SoundAmbience.GeneralSettlement)
+    {
+        if (soundTable.File != "ambience/settlement/settlement_people_08.wav") continue;
+        soundTable.Volume *= 0.80;
+        break;
+    }
+}
+
+lowerAnnoyingKid(::Const.SoundAmbience.GeneralSettlement);
+lowerAnnoyingKid(::Const.SoundAmbience.LargeSettlement);
+lowerAnnoyingKid(::Const.SoundAmbience.VeryLargeSettlement);


### PR DESCRIPTION
Out of all ambience sound files this is the most annoying one. When it randomly plays twice close to each other it is the most recognizable one. I think most of that is because this sounds volume is above average.