### PR TITLE
feat: add support for multi-stage roots and change existing effects

### DIFF
--- a/mod_reforged/config/skills.nut
+++ b/mod_reforged/config/skills.nut
@@ -128,4 +128,129 @@
 			_entity.getSkills().add(::new("scripts/skills/perks/perk_mastery_throwing"));
 		}
 	}
+
+	function makeTrapped( _trappedEffect )
+	{
+		// New Variables
+		_trappedEffect.m.Stage <- 1;
+		_trappedEffect.m.StageMax <- 1;
+		// Variables Imported from Break_Free_Skill
+        _trappedEffect.m.BonusChancePerFail <- 10,    // ChanceBonus is increased by this value every time someone fails
+		_trappedEffect.m.BonusChance <- -10,          // Some effects may want to reduce or increase the initial ChanceBonus
+
+		// These Icons are now defined in the trap-effect rather than in the break-free abilities
+		_trappedEffect.m.BreakFreeIcon <- _trappedEffect.m.Icon;
+		_trappedEffect.m.BreakFreeIconDisabled <- _trappedEffect.m.IconDisabled;
+		_trappedEffect.m.BreakFreeOverlay <- _trappedEffect.m.Overlay;
+		_trappedEffect.m.BreakAllyFreeIcon <- _trappedEffect.m.Icon;
+		_trappedEffect.m.BreakAllyFreeIconDisabled <- _trappedEffect.m.IconDisabled;
+		_trappedEffect.m.BreakAllyFreeOverlay <- _trappedEffect.m.Overlay;
+		_trappedEffect.m.Decal <- "";		// Decal that will spawn when this effect is broken out of
+
+		// Private Variables
+		_trappedEffect.m.BreakFreeSkill <- null;	// Allows multiple trap effects. Break-Free-Ally will now be able to find the correct BreakFree skil
+
+		// Hooks
+		local onUpdate = _trappedEffect.onUpdate;
+		_trappedEffect.onUpdate = function( _properties )
+		{
+			if (this.isImmobilised()) _properties.IsRooted = true;
+
+			// We nullify any changes made by the vanilla function
+			local oldIsRooted = _properties.IsRooted;
+			onUpdate(_properties);
+			_properties.IsRooted = oldIsRooted;
+		}
+
+		_trappedEffect.onAdded <- function()
+		{
+			local breakFree = this.new("scripts/skills/special/rf_break_free_skill");
+			this.m.BreakFreeSkill = breakFree.weakref();
+			breakFree.m.TrappedEffect = this.weakref();
+			breakFree.m.ID = breakFree.getID() + this.getID();	// We give every Break Free a unique ID so they can co-exist on the same entity when trapped by different effects
+			breakFree.m.Icon = this.m.BreakFreeIcon;
+			breakFree.m.IconDisabled = this.m.BreakFreeIconDisabled;
+			breakFree.m.Overlay = this.m.BreakFreeOverlay;
+			breakFree.m.SoundOnUse = this.m.SoundOnHitHitpoints;
+			this.getContainer().add(breakFree);
+		}
+
+		// New Functions
+		_trappedEffect.increaseStages <- function( _amount = 1 )
+		{
+			this.m.Stage += _amount;
+			if (this.m.Stage >= this.m.StageMax) this.m.Stage = this.m.StageMax;
+		}
+
+		_trappedEffect.decreaseStages <- function( _amount = 1, _chanceMessage = "" )
+		{
+			this.m.Stage -= _amount;
+			if (this.m.Stage <= 0)
+			{
+				this.brokenFree(_chanceMessage);
+			}
+			else
+			{
+				::Tactical.EventLog.logEx(::Const.UI.getColorizedEntityName(this.getContainer().getActor()) + " partly breaks free" + _chanceMessage);
+			}
+		}
+
+		_trappedEffect.brokenFree <- function( _chanceMessage = "" )
+		{
+			this.spawnDecal();
+			::Tactical.EventLog.logEx(::Const.UI.getColorizedEntityName(this.getContainer().getActor()) + " breaks free" + _chanceMessage);
+			this.getContainer().getActor().getSprite("status_rooted").Visible = false;
+			this.getContainer().getActor().getSprite("status_rooted_back").Visible = false;
+			this.m.BreakFreeSkill.removeSelf();
+			this.removeSelf();
+		}
+
+		_trappedEffect.getBreakFreeSkill <- function()
+		{
+			return this.m.BreakFreeSkill;
+		}
+
+		// This will indicate to break-free skills and a variety of perks that this character is under a trappedEffect
+		// We could instead use the SkillType system but I wasn't sure whether to add a whole new Type just for this small subset of skills
+		_trappedEffect.isTrappedEffect <- function()
+		{
+			return true;
+		}
+
+		// By default every trapped effect also immobilizes its targed
+		_trappedEffect.isImmobilised <- function()
+		{
+			return true;
+		}
+
+		_trappedEffect.spawnDecal <- function()		// In Vanilla this is handled by the break-free skill
+		{
+			if (this.m.Decal == "") return;
+			local ourTile = this.getContainer().getActor().getTile();
+			local candidates = [];
+
+			if (ourTile.Properties.has("IsItemSpawned") || ourTile.IsCorpseSpawned)
+			{
+				for( local i = 0; i < ::Const.Direction.COUNT; i = ++i )
+				{
+					if (!ourTile.hasNextTile(i)) continue;
+
+					local tile = ourTile.getNextTile(i);
+					if (tile.IsEmpty && !tile.Properties.has("IsItemSpawned") && !tile.IsCorpseSpawned && tile.Level <= ourTile.Level + 1)
+					{
+						candidates.push(tile);
+					}
+				}
+			}
+			else
+			{
+				candidates.push(ourTile);
+			}
+			if (candidates.len() == 0) return;
+
+			local tileToSpawnAt = candidates[::Math.rand(0, candidates.len() - 1)];
+			tileToSpawnAt.spawnDetail(this.m.Decal);
+			tileToSpawnAt.Properties.add("IsItemSpawned");
+		}
+	}
 };

--- a/mod_reforged/hooks/skills/actives/break_ally_free_skill.nut
+++ b/mod_reforged/hooks/skills/actives/break_ally_free_skill.nut
@@ -1,0 +1,73 @@
+::mods_hookExactClass("skills/actives/break_ally_free_skill", function(o) {
+    local create = o.create;
+    o.create = function()
+    {
+        create();
+		this.m.ActionPointCost = 3;
+		this.m.FatigueCost = 10;
+    }
+
+    // Rewrite of the vanilla function. We no longer check for a hard-coded list of effects. Instead we look for the first effect that is a "TrappedEffect" and use it for reference
+	o.isHidden = function()
+    {
+		local actor = this.getContainer().getActor();
+		if (!::Tactical.isActive()) return this.skill.isHidden();
+        if (!actor.isPlacedOnMap()) return this.skill.isHidden();
+        local myTile = actor.getTile();
+
+        for (local i = 0; i < 6; i++)
+        {
+            if (!myTile.hasNextTile(i)) continue;
+            local tile = myTile.getNextTile(i);
+            if (!tile.IsOccupiedByActor) continue;
+            if (!this.isValidTarget(tile.getEntity())) continue;
+
+            // This function also automatically updates the Icons of this skill to match those of the first trapped-effect it finds
+            local skill = this.getFirstTrappedEffect(tile.getEntity());
+            this.m.Icon = skill.m.BreakAllyFreeIcon;
+            this.m.IconDisabled = skill.m.BreakAllyFreeIconDisabled;
+            this.m.Overlay = skill.m.BreakAllyFreeOverlay;
+            return false;
+        }
+		return this.skill.isHidden();
+    }
+
+	o.onVerifyTarget = function( _originTile, _targetTile )
+	{
+		if (!this.skill.onVerifyTarget(_originTile, _targetTile)) return false;
+        return this.isValidTarget(_targetTile.getEntity());
+    }
+
+    o.onUse = function( _user, _targetTile )
+    {
+        this.spawnOverlay(_user, _targetTile);
+        local target = _targetTile.getEntity();
+        local trappedEffect = this.getFirstTrappedEffect(target);
+		local breakFree = trappedEffect.getBreakFreeSkill();    // We don't want any BreakFree skill but instead the one added by the trap effect we use as Icon reference
+		if (breakFree == null) return false;    // This should never happen unless some trapped effect forgets to add the breakFree skill to its target
+        breakFree.setSkillBonus(this.getContainer().getActor().getCurrentProperties().getMeleeSkill());
+        breakFree.onUse(target, _targetTile);
+        return true;
+    }
+
+    // New Helper Functions
+	o.isValidTarget <- function( _target )
+    {
+        if (_target == null) return false;
+        local myActor = this.getContainer().getActor();
+        if (_target.isAlliedWith(myActor) == false) return false;
+        if (::Math.abs(_target.getTile().Level - myActor.getTile().Level) > 1) return false;     // height difference is too great
+
+        return (this.getFirstTrappedEffect(_target) != null);
+    }
+
+	o.getFirstTrappedEffect <- function( _target )
+    {
+        if (_target == null) return null;
+        foreach (skill in _target.getSkills().m.Skills)
+        {
+            if (skill.isTrappedEffect()) return skill;
+        }
+        return null;
+    }
+});

--- a/mod_reforged/hooks/skills/actives/break_free_skill.nut
+++ b/mod_reforged/hooks/skills/actives/break_free_skill.nut
@@ -1,0 +1,6 @@
+::mods_hookExactClass("skills/actives/break_free_skill", function(o) {
+	o.onAdded <- function()
+    {
+        this.removeSelf();
+    }
+});

--- a/mod_reforged/hooks/skills/actives/throw_net.nut
+++ b/mod_reforged/hooks/skills/actives/throw_net.nut
@@ -1,0 +1,23 @@
+::mods_hookExactClass("skills/actives/throw_net", function(o) {
+	o.onVerifyTarget = function( _originTile, _targetTile )
+	{
+		if (!this.skill.onVerifyTarget(_originTile, _targetTile)) return false;
+        if (_targetTile.getEntity().getSkills().hasSkill("effects.net")) return false;  // Can't stack multiple nets... for now
+		return true;
+	}
+
+	local onUse = o.onUse;
+    o.onUse = function( _user, _targetTile )
+    {
+		local targetEntity = _targetTile.getEntity();
+        if (targetEntity.getCurrentProperties().IsImmuneToRoot) return onUse(_user, _targetTile);
+        local netEffect = this.new("scripts/skills/effects/net_effect");
+        if (this.m.IsReinforced)
+        {
+            netEffect.m.BonusChance -= 15;     // Vanilla effect
+            netEffect.m.Decal = "net_destroyed_02";
+        }
+        targetEntity.getSkills().add(netEffect);
+        onUse(_user, _targetTile);  // The original function also tries to add a 'net_effect' but that will fail because the skill doesn't stack.
+    }
+});

--- a/mod_reforged/hooks/skills/actives/web_skill.nut
+++ b/mod_reforged/hooks/skills/actives/web_skill.nut
@@ -1,0 +1,8 @@
+::mods_hookExactClass("skills/actives/web_skill", function(o) {
+	o.onVerifyTarget = function( _originTile, _targetTile )
+	{
+		if (!this.skill.onVerifyTarget(_originTile, _targetTile)) return false;
+        if (_targetTile.getEntity().getSkills().hasSkill("effects.web")) return false;  // Can't stack multiple webs... for now
+		return true;
+	}
+});

--- a/mod_reforged/hooks/skills/effects/kraken_ensnare_effect.nut
+++ b/mod_reforged/hooks/skills/effects/kraken_ensnare_effect.nut
@@ -1,0 +1,22 @@
+::mods_hookExactClass("skills/effects/kraken_ensnare_effect", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.SoundOnHitHitpoints = [
+			"sounds/enemies/dlc2/krake_break_free_fail_01.wav",
+			"sounds/enemies/dlc2/krake_break_free_fail_02.wav",
+			"sounds/enemies/dlc2/krake_break_free_fail_03.wav",
+			"sounds/enemies/dlc2/krake_break_free_fail_04.wav",
+			"sounds/enemies/dlc2/krake_break_free_fail_05.wav"
+		];
+        ::Reforged.Skills.makeTrapped(this);
+		this.m.BreakFreeIcon = "skills/active_148.png";
+		this.m.BreakFreeIconDisabled = "skills/active_148_sw.png";
+		this.m.BreakFreeOverlay = "active_148";
+		this.m.BreakAllyFreeIcon = "skills/active_151.png";
+		this.m.BreakAllyFreeIconDisabled = "skills/active_151_sw.png";
+		this.m.BreakAllyFreeOverlay = "status_effect_96";
+		this.m.Decal = ::Const.BloodDecals[::Const.BloodType.Red][::Math.rand(0, ::Const.BloodDecals[::Const.BloodType.Red].len() - 1)];
+	}
+});

--- a/mod_reforged/hooks/skills/effects/net_effect.nut
+++ b/mod_reforged/hooks/skills/effects/net_effect.nut
@@ -1,0 +1,56 @@
+::mods_hookExactClass("skills/effects/net_effect", function(o) {
+	o.m.DebuffPerStage <- 0.25;		// At 2 Stages this is 44,75% which is basically equal to the vanilla value. But at 1 Stage it is only 25%
+
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.SoundOnHitHitpoints = [
+			"sounds/combat/break_free_net_01.wav",
+			"sounds/combat/break_free_net_02.wav",
+			"sounds/combat/break_free_net_03.wav"
+		];
+        ::Reforged.Skills.makeTrapped(this);
+		this.m.BreakFreeIcon = "skills/active_74.png";
+		this.m.BreakFreeIconDisabled = "skills/active_74_sw.png";
+		this.m.BreakFreeOverlay = "active_74";
+		this.m.BreakAllyFreeIcon = "skills/active_157.png";
+		this.m.BreakAllyFreeIconDisabled = "skills/active_157_sw.png";
+		this.m.BreakAllyFreeOverlay = "status_effect_99";
+		this.m.Decal = "net_destroyed";		// In vanilla this is different for reinforced nets. They have "net_destroyed_02" here. This is a TODO
+
+		this.m.Stage = 2;
+		this.m.StageMax = 2;
+	}
+
+	local getTooltip = o.getTooltip;
+	o.getTooltip = function()
+	{
+		local ret = getTooltip();
+		foreach (entry in ret)
+		{
+			entry.text = ::MSU.String.replace(entry.text, "-45", "" + ::Math.floor(this.getDebuffMultiplier() * 100.0 - 100.0));
+		}
+		return ret;
+	}
+
+	o.getName <- function()
+	{
+		return this.skill.getName() + " (" + this.m.Stage + ")";
+	}
+
+	// Complete overwrite of vanilla as we change all aspects of it. IsRooted is also now handled by the trap-effect
+	o.onUpdate = function( _properties )
+	{
+		local debuffMultiplier = this.getDebuffMultiplier();
+		_properties.MeleeDefenseMult *= debuffMultiplier;
+		_properties.RangedDefenseMult *= debuffMultiplier;
+		_properties.InitiativeMult *= debuffMultiplier;
+	}
+
+	// New Functions
+	o.getDebuffMultiplier <- function()
+	{
+		return ::Math.pow(1.0 - this.m.DebuffPerStage, this.m.Stage);
+	}
+});

--- a/mod_reforged/hooks/skills/effects/rooted_effect.nut
+++ b/mod_reforged/hooks/skills/effects/rooted_effect.nut
@@ -1,0 +1,21 @@
+::mods_hookExactClass("skills/effects/rooted_effect", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.SoundOnHitHitpoints = [
+			"sounds/combat/break_free_roots_00.wav",
+			"sounds/combat/break_free_roots_01.wav",
+			"sounds/combat/break_free_roots_02.wav",
+			"sounds/combat/break_free_roots_03.wav"
+		];
+        ::Reforged.Skills.makeTrapped(this);
+		this.m.BreakFreeIcon = "skills/active_75.png";
+		this.m.BreakFreeIconDisabled = "skills/active_75_sw.png";
+		this.m.BreakFreeOverlay = "active_75";
+		this.m.BreakAllyFreeIcon = "skills/active_159.png";
+		this.m.BreakAllyFreeIconDisabled = "skills/active_159_sw.png";
+		this.m.BreakAllyFreeOverlay = "status_effect_101";
+		this.m.Decal = "roots_destroyed";
+	}
+});

--- a/mod_reforged/hooks/skills/effects/web_effect.nut
+++ b/mod_reforged/hooks/skills/effects/web_effect.nut
@@ -1,0 +1,20 @@
+::mods_hookExactClass("skills/effects/web_effect", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.SoundOnHitHitpoints = [
+			"sounds/combat/break_free_net_01.wav",
+			"sounds/combat/break_free_net_02.wav",
+			"sounds/combat/break_free_net_03.wav"
+		];
+        ::Reforged.Skills.makeTrapped(this);
+		this.m.BreakFreeIcon = "skills/active_113.png";
+		this.m.BreakFreeIconDisabled = "skills/active_113_sw.png";
+		this.m.BreakFreeOverlay = "active_113";
+		this.m.BreakAllyFreeIcon = "skills/active_158.png";
+		this.m.BreakAllyFreeIconDisabled = "skills/active_158_sw.png";
+		this.m.BreakAllyFreeOverlay = "status_effect_100";
+		this.m.Decal = "web_destroyed";
+	}
+});

--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -5,4 +5,9 @@
 	{
 		return this.isAttack() && !this.isRanged() && this.getBaseValue("ActionPointCost") <= 4 && this.getBaseValue("MaxRange") == 1;
 	}
+
+	o.isTrappedEffect <- function()		// Needs to be overwritten for any effect that is a 'trapped_effect'
+	{
+		return false;
+	}
 });

--- a/scripts/skills/special/rf_break_free_skill.nut
+++ b/scripts/skills/special/rf_break_free_skill.nut
@@ -1,0 +1,85 @@
+// This skill already exists in Vanilla. We rework this skill while keeping the ID the same so only our version will be added.
+
+this.rf_break_free_skill <- this.inherit("scripts/skills/skill", {
+	m = {
+        // Public
+        StagesRemovedPerUse = 1,
+
+        // Private
+		SkillBonus = null,  // Hacky vanilla solution to use MeleeSkill from allies when they try to free this actor
+        TrappedEffect = null        // Weakref to the effect which caused this skill to be added. Important when multiple Trapped-Effects are present
+	},
+
+	function create()
+	{
+		this.m.ID = "actives.break_free";
+		this.m.Name = "Break Free";
+		this.m.Description = "Use everything at your disposal to free yourself from what is holding you in place. Hack, slash, cut or gnaw at it if need be!";
+		this.m.Icon = "skills/active_15.png";
+		this.m.IconDisabled = "skills/active_15_sw.png";
+		this.m.Overlay = "active_15";
+		this.m.SoundOnUse = [];
+		this.m.Type = ::Const.SkillType.Active;
+		this.m.Order = ::Const.SkillOrder.BeforeLast;
+		this.m.IsSerialized = false;
+		this.m.IsActive = true;
+		this.m.IsTargeted = false;
+		this.m.IsStacking = false;
+		this.m.IsAttack = false;
+		this.m.IsRemovedAfterBattle = true;
+		this.m.ActionPointCost = 3;
+		this.m.FatigueCost = 10;
+		this.m.MinRange = 0;
+		this.m.MaxRange = 0;
+	}
+
+	function getTooltip()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+        ret.push({
+            id = 4,
+            type = "text",
+            icon = "ui/icons/melee_skill.png",
+            text = "Has a " + ::MSU.Text.colorGreen(this.getChance() + "%") + " chance to succeed, based on Melee Skill. Each failed attempt will increase the chance to succeed for subsequent attempts."
+        });
+        return ret;
+	}
+
+	function setSkillBonus( _d )
+	{
+		this.m.SkillBonus = _d;
+	}
+
+	function getChance()
+	{
+        if (this.getContainer().hasSkill("effects.goblin_shaman_potion")) return 100;
+        local meleeSkill = (this.m.SkillBonus == null) ? this.getContainer().getActor().getCurrentProperties().getMeleeSkill() : this.m.SkillBonus;
+		return ::Math.min(100, meleeSkill + this.m.TrappedEffect.m.BonusChance);
+	}
+
+	function onVerifyTarget( _originTile, _targetTile )
+	{
+		return true;
+	}
+
+	function onUse( _user, _targetTile )
+	{
+		::Tactical.EventLog.log_newline();
+
+		local chance = this.getChance();
+        this.m.SkillBonus = null;   // We reset this variable again because it was only used temporarily during getChance().
+
+		local rolled = ::Math.rand(1, 100);
+        local chanceMessage = " (Chance: " + chance + ", Rolled: " + rolled + ")";
+		if (rolled > chance)
+        {
+			::Tactical.EventLog.logEx(::Const.UI.getColorizedEntityName(_user) + " fails to break free" + chanceMessage);
+			this.m.TrappedEffect.m.BonusChance += this.m.TrappedEffect.m.BonusChancePerFail;
+			return false;
+        }
+        this.m.TrappedEffect.decreaseStages(this.m.StagesRemovedPerUse, chanceMessage);
+        _user.setDirty(true);
+        return true;
+	}
+});
+


### PR DESCRIPTION
- TrappedEffects (Nets, Webs, Roots, Tentacles) now have a `Stage` variable that determines how firmly you are trapped.
- Using Break Free only removes one `Stage` at a time (modifable)
- Debuffs of TrappedEffects may now scale depending on the amount of stages.
- Different TrappedEffects can now theoretically stack on top of each other. Each one will spawn a separate BreakFree skill which will only reduce Stages of that respective effect

This PR will allow us to make more interesting trapped-effects and also balance the existing effects.
The existing system of rolling a single dice for removing all negative effects at once is at times too random.

**Included Balance Adjustments:**
- BreakFree and BreakAllyFree now cost 3 AP and 10 Fatigue
- Nets now apply 2 Stages, Reinforced Nets apply 3 Stages. Nets debuff their target by a diminishing 25% per stage.

**Do not merge!**: This is still just a prototype and proof of concept that has to be thoroughly discussed 