### PR TITLE
feat: improve quality of life of a few vanilla contracts

### DIFF
--- a/mod_reforged/config/text/text.nut
+++ b/mod_reforged/config/text/text.nut
@@ -1,0 +1,28 @@
+::Reforged.Text <- {
+    function getDayHourString( _seconds )
+    {
+        local days = ::Math.floor(_seconds / ::World.getTime().SecondsPerDay);
+        local hours = ::Math.floor(_seconds / ::World.getTime().SecondsPerHour) % 24;
+		local dayHourString = "";
+		switch (days)
+		{
+			case 0:
+				break;	// empty string
+			case 1:
+				dayHourString = "1 day and ";
+				break;
+			default:
+				dayHourString = days + " days and ";
+		}
+        dayHourString += (hours == 0) ? "" : hours + " hours";
+        return dayHourString;
+    }
+
+    function getDaysAndHalf( _seconds )
+    {
+        local doubleDays = ::Math.round(2.0 * (_seconds / ::World.getTime().SecondsPerDay));
+        local daysAndHalf = (doubleDays / 2.0);
+        if (daysAndHalf <= 1.0) return "a day"
+        return "" + daysAndHalf + " days";
+    }
+}

--- a/mod_reforged/hooks/contracts/contract.nut
+++ b/mod_reforged/hooks/contracts/contract.nut
@@ -1,0 +1,31 @@
+::mods_hookBaseClass("contracts/contract", function(o)
+{
+	while(!("EmployerID" in o.m)) o = o[o.SuperName]; 	// find the base class
+
+	local getUICharacterImage = o.getUICharacterImage;
+	o.getUICharacterImage = function( _index = 0 )
+	{
+		if ((!("Characters" in this.m.ActiveScreen) || !this.m.ActiveScreen.Characters.len()) &&
+			(!("Banner" in this.m.ActiveScreen) || _index == 0) &&
+			"ShowEmployer" in this.m.ActiveScreen &&
+			this.m.ActiveScreen.ShowEmployer &&
+			_index != 0 &&
+			"Destination" in this.m &&
+			this.m.Destination != null &&
+			!this.m.Destination.isNull() &&
+			this.m.Destination.isLocation() &&
+			this.m.Destination.isLocationType(::Const.World.LocationType.Settlement) &&
+			this.m.Destination.isDiscovered()
+		)
+		{
+			return {
+				Image = this.m.Destination.getImagePath(),
+				IsProcedural = false
+			};
+		}
+		else
+		{
+			return getUICharacterImage(_index);
+		}
+	}
+});

--- a/mod_reforged/hooks/contracts/contracts/deliver_item_contract.nut
+++ b/mod_reforged/hooks/contracts/contracts/deliver_item_contract.nut
@@ -1,0 +1,14 @@
+::mods_hookExactClass("contracts/contracts/deliver_item_contract", function(o) {
+    local onPrepareVariables = o.onPrepareVariables;
+    o.onPrepareVariables = function( _vars )
+    {
+        onPrepareVariables(_vars);
+        foreach (var in _vars)
+        {
+            if (var[0] != "days") continue;
+            local seconds = ::MSU.Time.getSecondsRequiredToTravel(this.m.Flags.get("Distance"), ::Const.World.MovementSettings.Speed, true);
+            var[1] = ::Reforged.Text.getDaysAndHalf(seconds);
+            break;
+        }
+    }
+});

--- a/mod_reforged/hooks/contracts/contracts/escort_caravan_contract.nut
+++ b/mod_reforged/hooks/contracts/contracts/escort_caravan_contract.nut
@@ -1,0 +1,14 @@
+::mods_hookExactClass("contracts/contracts/escort_caravan_contract", function(o) {
+    local onPrepareVariables = o.onPrepareVariables;
+    o.onPrepareVariables = function( _vars )
+    {
+        onPrepareVariables(_vars);
+        foreach (var in _vars)
+        {
+            if (var[0] != "days") continue;
+            local seconds = ::MSU.Time.getSecondsRequiredToTravel(this.m.Flags.get("Distance"), ::Const.World.MovementSettings.Speed * 0.6, true);
+            var[1] = ::Reforged.Text.getDaysAndHalf(seconds);
+            break;
+        }
+    }
+});

--- a/mod_reforged/hooks/contracts/contracts/return_item_contract.nut
+++ b/mod_reforged/hooks/contracts/contracts/return_item_contract.nut
@@ -1,0 +1,47 @@
+::mods_hookExactClass("contracts/contracts/return_item_contract", function(o) {
+    local createStates = o.createStates;
+    o.createStates = function()
+    {
+        createStates();
+        foreach (state in this.m.States)
+        {
+            if (state.ID != "Offer") continue;
+            local end = state.end;
+            state.end = function()
+            {
+                end();
+                this.Contract.m.Target.setMovementSpeed(this.Contract.m.Target.getBaseMovementSpeed() * 0.9);  // Thieves are easier to catch
+            }
+            break;
+        }
+    }
+
+    local createScreens = o.createScreens;
+    o.createScreens = function()
+    {
+        createScreens();
+        foreach (screen in this.m.Screens)
+        {
+            if (screen.ID != "CounterOffer1") continue;
+            foreach (option in screen.Options)
+            {   // We now show the original payment so the player compare the two
+                if (option.Text != "We\'re paid to return it, and that\'s what we\'ll do.") continue;
+                option.Text = "We\'re paid %reward_completion% to return it, and that\'s what we\'ll do.";
+                break;
+            }
+            break;
+        }
+    }
+
+    local onPrepareVariables = o.onPrepareVariables;
+    o.onPrepareVariables = function( _vars )
+    {
+        onPrepareVariables(_vars);
+        foreach (var in _vars)
+        {
+            if (var[0] != "bribe") continue;
+            var[1] = "[b]" + var[1] + "[/b]";     // Bribe is bold now so its easier to spot and compare
+            break;
+        }
+    }
+});

--- a/mod_reforged/hooks/msu.nut
+++ b/mod_reforged/hooks/msu.nut
@@ -61,6 +61,17 @@
 	}
 }
 
+
+::logInfo("Reforged::MSU -- adding ::MSU.Time.getSecondsRequiredToTravel");
+::MSU.Time <- {
+	function getSecondsRequiredToTravel( _numTiles, _speed, _onRoadOnly = false )	// This is a close copy of how vanilla calculates their distance duration
+	{
+		_speed *= ::Const.World.MovementSettings.GlobalMult;
+		if (_onRoadOnly) _speed *= ::Const.World.MovementSettings.RoadMult;
+		return _numTiles * 170.0 / _speed;
+	}
+}
+
 ::logInfo("Reforged::MSU -- adding ::MSU.Text.colorizePercentage");
 ::MSU.Text.colorizePercentage <- function( _value, _options = null )
 {


### PR DESCRIPTION
- Deliver Item and Caravan Contracts now display their estimated time in days + hours
- Return Item Contract now displays the original payout during a CounterOffer event
- Return Item Contract thieves are a bit easier to catch should they choose to run (10% slower)
- Contracts with a settlement as their destination will now try to display an image of that during the contract dialog