### PR TITLE
feat: mark armor with attachements that you unequip as to-be-repaired

### DIFF
--- a/mod_reforged/hooks/items/armor/armor.nut
+++ b/mod_reforged/hooks/items/armor/armor.nut
@@ -1,0 +1,8 @@
+::mods_hookExactClass("items/armor/armor", function(o) {
+	local onUnequip = o.onUnequip;
+	o.onUnequip = function()
+	{
+        if (this.getUpgrade() != null) this.setToBeRepaired(true);      // If an armor piece has an attachement you basically always want it repaired
+		onUnequip();
+	}
+});


### PR DESCRIPTION
I tested this successfully ingame.

When we expand attachements and layers we probably want to revisit this option and put it behind a mod setting.
But right now it pure upside in 99% of the cases