### PR TITLE
refactor: tweak adjacency mechanic and rework polearm mastery

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -349,13 +349,13 @@ local vanillaDescriptions = [
 		ID = "perk.mastery.polearm",
 		Key = "SpecPolearm",
 		Description = ::UPD.getDescription({
-	 		Fluff = "Master polearms and keeping the enemy at bay.",
-	 		Requirement = "Polearm",
+	 		Fluff = "Master polearms in close formation and keep the enemy at bay.",
 	 		Effects = [{
  				Type = ::UPD.EffectType.Passive,
  				Description = [
- 					"Skills build up " + ::MSU.Text.colorRed("25%") + " less [Fatigue|Concept.Fatigue].",
- 					"All skills with two-handed weapons, with a range of 2 tiles, having an [Action Point|Concept.ActionPoints] cost of " + ::MSU.Text.colorRed("6") + " have their [Action Point|Concept.ActionPoints] cost reduced to " + ::MSU.Text.colorRed("5") + ", and no longer have a penalty for attacking targets directly adjacent."
+ 					"Polearm Skills build up " + ::MSU.Text.colorRed("25%") + " less [Fatigue|Concept.Fatigue].",
+					"Adjacent allies no longer reduce your chance to hit for melee attacks with a range of 2 or more tiles."
+					"[Hook|Skill+hook] and [Repel|Skill+hook] ignore the defense bonus of shields."
  				]
  			}]
 	 	}),

--- a/mod_reforged/hooks/skills/actives/hook.nut
+++ b/mod_reforged/hooks/skills/actives/hook.nut
@@ -1,0 +1,13 @@
+::mods_hookExactClass("skills/actives/hook", function(o) {
+
+	local onAfterUpdate = o.onAfterUpdate;
+	o.onAfterUpdate = function( _properties )
+	{
+		local oldActionPointCost = this.m.ActionPointCost;
+		onAfterUpdate(_properties);
+		this.m.ActionPointCost = oldActionPointCost;	// Revert any AP changes made by vanilla, Polearm Mastery no longer reduces that cost
+
+		this.m.IsShieldRelevant = !_properties.IsSpecializedInPolearms;		// New effect from Polearm Mastery
+	}
+
+});

--- a/mod_reforged/hooks/skills/actives/impale.nut
+++ b/mod_reforged/hooks/skills/actives/impale.nut
@@ -1,0 +1,11 @@
+::mods_hookExactClass("skills/actives/impale", function(o) {
+
+	local onAfterUpdate = o.onAfterUpdate;
+	o.onAfterUpdate = function( _properties )
+	{
+		local oldActionPointCost = this.m.ActionPointCost;
+		onAfterUpdate(_properties);
+		this.m.ActionPointCost = oldActionPointCost;	// Revert any AP changes made by vanilla, Polearm Mastery no longer reduces that cost
+	}
+
+});

--- a/mod_reforged/hooks/skills/actives/reap_skill.nut
+++ b/mod_reforged/hooks/skills/actives/reap_skill.nut
@@ -1,0 +1,11 @@
+::mods_hookExactClass("skills/actives/reap_skill", function(o) {
+
+	local onAfterUpdate = o.onAfterUpdate;
+	o.onAfterUpdate = function( _properties )
+	{
+		local oldActionPointCost = this.m.ActionPointCost;
+		onAfterUpdate(_properties);
+		this.m.ActionPointCost = oldActionPointCost;	// Revert any AP changes made by vanilla, Polearm Mastery no longer reduces that cost
+	}
+
+});

--- a/mod_reforged/hooks/skills/actives/repel.nut
+++ b/mod_reforged/hooks/skills/actives/repel.nut
@@ -1,0 +1,13 @@
+::mods_hookExactClass("skills/actives/repel", function(o) {
+
+	local onAfterUpdate = o.onAfterUpdate;
+	o.onAfterUpdate = function( _properties )
+	{
+		local oldActionPointCost = this.m.ActionPointCost;
+		onAfterUpdate(_properties);
+		this.m.ActionPointCost = oldActionPointCost;	// Revert any AP changes made by vanilla, Polearm Mastery no longer reduces that cost
+
+		this.m.IsShieldRelevant = !_properties.IsSpecializedInPolearms;		// New effect from Polearm Mastery
+	}
+
+});

--- a/mod_reforged/hooks/skills/actives/strike_skill.nut
+++ b/mod_reforged/hooks/skills/actives/strike_skill.nut
@@ -1,0 +1,11 @@
+::mods_hookExactClass("skills/actives/strike_skill", function(o) {
+
+	local onAfterUpdate = o.onAfterUpdate;
+	o.onAfterUpdate = function( _properties )
+	{
+		local oldActionPointCost = this.m.ActionPointCost;
+		onAfterUpdate(_properties);
+		this.m.ActionPointCost = oldActionPointCost;	// Revert any AP changes made by vanilla, Polearm Mastery no longer reduces that cost
+	}
+
+});

--- a/mod_reforged/hooks/skills/perks/perk_mastery_polearm.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_polearm.nut
@@ -1,18 +1,17 @@
 ::mods_hookExactClass("skills/perks/perk_mastery_polearm", function(o) {
-	local onAfterUpdate = ::mods_getMember(o, "onAfterUpdate");
-	::mods_override(o, "onAfterUpdate", function( _properties ) {
-		onAfterUpdate(_properties);
-		local weapon = this.getContainer().getActor().getMainhandItem();
-		if (weapon != null && weapon.isItemType(::Const.Items.ItemType.TwoHanded) && weapon.isItemType(::Const.Items.ItemType.MeleeWeapon))
-		{
-			foreach (skill in weapon.getSkills())
-			{
-				 if (skill.m.MaxRange == 2 && skill.m.ActionPointCost > 5)
-				 {
-					 skill.m.ActionPointCost -= 1;
-				 }
-			}
-		}
-	});
+	// Not the cleanest way but it'll have to do for now.
+	// Other methods would be more performance intensive or may cause drinking an oblivion potion to let a brother keep the adjacency ignore until the savegame is reloaded
+	o.onCombatStarted <- function()
+	{
+		local adjacencySkill = this.getContainer().getSkillByID("special.rf_polearm_adjacency");
+		adjacencySkill.m.IgnoreAllyPenalty = true;
+	}
+
+	o.onCombatFinished <- function()
+	{
+		local adjacencySkill = this.getContainer().getSkillByID("special.rf_polearm_adjacency");
+		adjacencySkill.m.IgnoreAllyPenalty = false;
+	}
+
 });
 

--- a/scripts/skills/special/rf_polearm_adjacency.nut
+++ b/scripts/skills/special/rf_polearm_adjacency.nut
@@ -1,8 +1,9 @@
 this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 	m = {
-		TotalMalus = 0,
 		MalusPerAlly = 5,
-		MalusPerEnemy = 10
+		MalusPerEnemy = 10,
+		AlliesIgnored = 1,		// Amount of allies that this effect will ignore until applying its penalty
+		IgnoreAllyPenalty = false,		// To allow us to offer this feature as a perk effect
 	},
 	function create()
 	{
@@ -18,7 +19,7 @@ this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 	function isEnabled()
 	{
 		local weapon = this.getContainer().getActor().getMainhandItem();
-		if (weapon != null && weapon.getRangeMax() > 1)
+		if (weapon != null && weapon.getRangeMax() > 1 && weapon.isItemType(::Const.Items.ItemType.MeleeWeapon))
 		{
 			return true;
 		}
@@ -28,52 +29,72 @@ this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 
 	function onAnySkillUsed( _skill, _targetEntity, _properties )
 	{
-		this.m.TotalMalus = 0;
-
-		if (_targetEntity == null || _skill.getMaxRange() == 1 || !_skill.isAttack() || _skill.isRanged() || !_skill.m.IsWeaponSkill || !this.isEnabled() || !::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()))
-		{
-			return;
-		}
-
-		local user = this.getContainer().getActor();
-		if (!user.isPlacedOnMap())
-			return;
-
-		foreach (faction in ::Tactical.Entities.getAllInstances())
-		{
-			foreach (actor in faction)
-			{
-				if (actor.isPlacedOnMap() && actor.getTile().getDistanceTo(user.getTile()) == 1)
-				{
-					this.m.TotalMalus += actor.isAlliedWith(user) ? this.m.MalusPerAlly : this.m.MalusPerEnemy;
-				}
-			}
-		}
-
-		_properties.MeleeSkill -= this.m.TotalMalus;
+		_properties.MeleeSkill -= this.calculatePenaltyForSkill( _skill );
 	}
 
 	function onGetHitFactors( _skill, _targetTile, _tooltip )
 	{
-		if (this.m.TotalMalus > 0)
+		local penalty = this.calculatePenaltyForSkill(_skill);
+		if (penalty > 0)
 		{
 			_tooltip.push({
 				icon = "ui/tooltips/negative.png",
-				text = ::MSU.Text.colorizePercentage(-this.m.TotalMalus) + " Crowded"
+				text = ::MSU.Text.colorizePercentage(-penalty) + " Crowded"
 			});
 		}
 	}
 
 	function onQueryTooltip( _skill, _tooltip )
 	{
-		if (_skill.isAttack() && !_skill.isRanged() && _skill.getMaxRange() > 1 && _skill.m.IsWeaponSkill && this.isEnabled())
+		local penalty = this.calculatePenaltyForSkill(_skill);
+		if (penalty > 0)
 		{
 			_tooltip.push({
 				id = 10,
 				type = "text",
 				icon = "ui/icons/hitchance.png",
-				text = "Has reduced chance to hit when standing next to others. " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent ally and " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent enemy"
+				text = "Has reduced chance to hit when standing next to others. " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent ally (except the first one) " + ::MSU.Text.colorizePercentage(-this.m.MalusPerEnemy) + " per adjacent enemy"
 			});
 		}
+	}
+
+	// Returns the actual penalty that the adjeceny mechanic will apply given a skill
+	function calculatePenaltyForSkill( _skill )
+	{
+		if (_skill.getMaxRange() == 1 || !_skill.isAttack() || _skill.isRanged() || !_skill.m.IsWeaponSkill )
+		{
+			return 0;
+		}
+
+		return calculatePenalty();
+	}
+
+	// Returns the raw penalty that the adjeceny mechanic would apply to melee skill
+	function calculatePenalty()
+	{
+		local actor = this.getContainer().getActor();
+		if (!actor.isPlacedOnMap() || !this.isEnabled()) return 0;
+
+		local penalty = 0;
+		local countedAllies = 0;	// For the purposes of the 'AlliesIgnored' feature of this effect
+		for (local direction = 0; direction < 6; direction++)
+		{
+			if (actor.getTile().hasNextTile(direction) == false) continue;
+			local nextTile = actor.getTile().getNextTile(direction);
+			if (nextTile.IsOccupiedByActor == false) continue;
+			if (nextTile.getEntity().isAlliedWith(actor))
+			{
+				if (this.m.IgnoreAllyPenalty) continue;
+				countedAllies++
+				if (countedAllies <= this.m.AlliesIgnored) continue;	// We may ignore the penalty from the first bunch of allies
+				penalty += this.m.MalusPerAlly;
+			}
+			else
+			{
+				penalty += this.m.MalusPerEnemy;
+			}
+		}
+
+		return penalty;
 	}
 });


### PR DESCRIPTION
- Adjacency Mechanic now always ignores the first ally
- Polearm Mastery no longer reduces the AP cost by 1
- Polearm Mastery now lets the user ignore adjacent allies
- Polearm Mastery now lets hook and repel ignore shield bonus