### PR TITLE
Polearm adjacency tweak

### DIFF
--- a/scripts/skills/special/rf_polearm_adjacency.nut
+++ b/scripts/skills/special/rf_polearm_adjacency.nut
@@ -7,8 +7,8 @@ this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 	function create()
 	{
 		this.m.ID = "special.rf_polearm_adjacency";
-		this.m.Name = "";
-		this.m.Description = "";
+		this.m.Name = "Crowded";
+		this.m.Description = "Long range melee weapons are harder to use in a crowded environment. When using such weapons, any melee attack with a base range of 2 or more tiles has its hit chance reduced by " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent ally (ignoring the first two adjacent allies) and " + ::MSU.Text.colorizePercentage(-this.m.MalusPerEnemy) + " per adjacent enemy.";
 		this.m.Type = ::Const.SkillType.Special;
 		this.m.IsActive = false;
 		this.m.IsHidden = true;
@@ -69,7 +69,7 @@ this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 		{
 			_tooltip.push({
 				icon = "ui/tooltips/negative.png",
-				text = ::MSU.Text.colorizePercentage(-malus) + " Crowded"
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizePercentage(-malus) + " [Crowded|Skill+rf_polearm_adjacency]")
 			});
 		}
 	}
@@ -82,7 +82,7 @@ this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/hitchance.png",
-				text = "Has reduced chance to hit when standing next to others. " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent ally (ignoring the first two adjacent allies) and " + ::MSU.Text.colorizePercentage(-this.m.MalusPerEnemy) + " per adjacent enemy"
+				text = ::Reforged.Mod.Tooltips.parseString("May have [reduced chance to hit|Skill+rf_polearm_adjacency] when standing next to others")
 			});
 		}
 	}

--- a/scripts/skills/special/rf_polearm_adjacency.nut
+++ b/scripts/skills/special/rf_polearm_adjacency.nut
@@ -72,7 +72,7 @@ this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/hitchance.png",
-				text = "Has reduced chance to hit when standing next to others. " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent ally and " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent enemy"
+				text = "Has reduced chance to hit when standing next to others. " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent ally and " + ::MSU.Text.colorizePercentage(-this.m.MalusPerEnemy) + " per adjacent enemy"
 			});
 		}
 	}

--- a/scripts/skills/special/rf_polearm_adjacency.nut
+++ b/scripts/skills/special/rf_polearm_adjacency.nut
@@ -1,8 +1,8 @@
 this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 	m = {
-		TotalMalus = 0,
 		MalusPerAlly = 5,
-		MalusPerEnemy = 10
+		MalusPerEnemy = 10,
+		NumAlliesToIgnore = 2
 	},
 	function create()
 	{
@@ -26,53 +26,63 @@ this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 		return false;
 	}
 
+	function isEnabledForSkill( _skill )
+	{
+		return _skill.getMaxRange() > 1 && _skill.isAttack() && !_skill.isRanged() && _skill.m.IsWeaponSkill;
+	}
+
 	function onAnySkillUsed( _skill, _targetEntity, _properties )
 	{
-		this.m.TotalMalus = 0;
+		_properties.MeleeSkill -= this.getMalusForSkill(_skill);
+	}
 
-		if (_targetEntity == null || _skill.getMaxRange() == 1 || !_skill.isAttack() || _skill.isRanged() || !_skill.m.IsWeaponSkill || !this.isEnabled())
-		{
-			return;
-		}
+	function getMalusForSkill( _skill )
+	{
+		if (!this.isEnabledForSkill(_skill) || !this.isEnabled())
+			return 0;
 
 		local user = this.getContainer().getActor();
 		if (!user.isPlacedOnMap())
-			return;
+			return 0;
 
-		foreach (faction in ::Tactical.Entities.getAllInstances())
+		local numAllies = 0;
+		local numEnemies = 0;
+		local myTile = user.getTile();
+		for (local i = 0; i < 6; i++)
 		{
-			foreach (actor in faction)
-			{
-				if (actor.isPlacedOnMap() && actor.getTile().getDistanceTo(user.getTile()) == 1)
-				{
-					this.m.TotalMalus += actor.isAlliedWith(user) ? this.m.MalusPerAlly : this.m.MalusPerEnemy;
-				}
-			}
+			if (!myTile.hasNextTile(i)) continue;
+			local nextTile = myTile.getNextTile(i);
+			if (!nextTile.IsOccupiedByActor) continue;
+
+			local nextEntity = nextTile.getEntity();
+			if (nextEntity.isAlliedWith(user)) numAllies++;
+			else numEnemies++;
 		}
 
-		_properties.MeleeSkill -= this.m.TotalMalus;
+		return (this.m.MalusPerAlly * ::Math.max(0, numAllies - this.m.NumAlliesToIgnore)) + (this.m.MalusPerEnemy * numEnemies);
 	}
 
 	function onGetHitFactors( _skill, _targetTile, _tooltip )
 	{
-		if (this.m.TotalMalus > 0)
+		local malus = this.getMalusForSkill(_skill);
+		if (malus > 0)
 		{
 			_tooltip.push({
 				icon = "ui/tooltips/negative.png",
-				text = ::MSU.Text.colorizePercentage(-this.m.TotalMalus) + " Crowded"
+				text = ::MSU.Text.colorizePercentage(-malus) + " Crowded"
 			});
 		}
 	}
 
 	function onQueryTooltip( _skill, _tooltip )
 	{
-		if (_skill.isAttack() && !_skill.isRanged() && _skill.getMaxRange() > 1 && _skill.m.IsWeaponSkill && this.isEnabled())
+		if (this.isEnabled() && this.isEnabledForSkill(_skill))
 		{
 			_tooltip.push({
 				id = 10,
 				type = "text",
 				icon = "ui/icons/hitchance.png",
-				text = "Has reduced chance to hit when standing next to others. " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent ally and " + ::MSU.Text.colorizePercentage(-this.m.MalusPerEnemy) + " per adjacent enemy"
+				text = "Has reduced chance to hit when standing next to others. " + ::MSU.Text.colorizePercentage(-this.m.MalusPerAlly) + " per adjacent ally (ignoring the first two adjacent allies) and " + ::MSU.Text.colorizePercentage(-this.m.MalusPerEnemy) + " per adjacent enemy"
 			});
 		}
 	}

--- a/scripts/skills/special/rf_polearm_adjacency.nut
+++ b/scripts/skills/special/rf_polearm_adjacency.nut
@@ -30,7 +30,7 @@ this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 	{
 		this.m.TotalMalus = 0;
 
-		if (_targetEntity == null || _skill.getMaxRange() == 1 || !_skill.isAttack() || _skill.isRanged() || !_skill.m.IsWeaponSkill || !this.isEnabled() || !::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()))
+		if (_targetEntity == null || _skill.getMaxRange() == 1 || !_skill.isAttack() || _skill.isRanged() || !_skill.m.IsWeaponSkill || !this.isEnabled())
 		{
 			return;
 		}


### PR DESCRIPTION
Changes:
- Change: Ignore the first two adjacent allies for the adjacency malus.
- Change: Add Name, Description and nested tooltip hyperlinks.
- Fix: Remove the condition for being the active entity.
- Fix: onQueryTooltip using this.m.MalusPerAlly instead of MalusPerEnemy for enemies

Code improvements:
- New isEnabledForSkill function to centralize conditions to check for skills.
- New getMalusForSkill function to get the malus instead of storing in a this.m.TotalMalus variable.
- Iterate over adjacent tiles instead of all actors on the map.