### PR TITLE
feat: only allow AI to rotate if the user or target has adjacent enemy

### DIFF
--- a/mod_reforged/hooks/skills/actives/barbarian_fury_skill.nut
+++ b/mod_reforged/hooks/skills/actives/barbarian_fury_skill.nut
@@ -1,0 +1,37 @@
+::mods_hookExactClass("skills/actives/barbarian_fury_skill", function(o) {
+	local onVerifyTarget = o.onVerifyTarget;
+	o.onVerifyTarget = function( _originTile, _targetTile )
+	{
+		local ret = onVerifyTarget(_originTile, _targetTile);
+		local user = this.getContainer().getActor();
+
+		// Only allow AI to use the skill if at least one of the two characters has an adjacent enemy
+		if (ret && !user.isPlayerControlled())
+		{
+			ret = false;
+			for (local i = 0; i < 6; i++)
+			{
+				if (_originTile.hasNextTile(i))
+				{
+					local nextTile = _originTile.getNextTile(i);
+					if (nextTile.IsOccupiedByActor && !nextTile.getEntity().isAlliedWith(user))
+					{
+						ret = true;
+						break;
+					}
+				}
+				if (_targetTile.hasNextTile(i))
+				{
+					local nextTile = _targetTile.getNextTile(i);
+					if (nextTile.IsOccupiedByActor && !nextTile.getEntity().isAlliedWith(user))
+					{
+						ret = true;
+						break;
+					}
+				}
+			}
+		}
+
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/rotation.nut
+++ b/mod_reforged/hooks/skills/actives/rotation.nut
@@ -1,0 +1,37 @@
+::mods_hookExactClass("skills/actives/rotation", function(o) {
+	local onVerifyTarget = o.onVerifyTarget;
+	o.onVerifyTarget = function( _originTile, _targetTile )
+	{
+		local ret = onVerifyTarget(_originTile, _targetTile);
+		local user = this.getContainer().getActor();
+
+		// Only allow AI to use the skill if at least one of the two characters has an adjacent enemy
+		if (ret && !user.isPlayerControlled())
+		{
+			ret = false;
+			for (local i = 0; i < 6; i++)
+			{
+				if (_originTile.hasNextTile(i))
+				{
+					local nextTile = _originTile.getNextTile(i);
+					if (nextTile.IsOccupiedByActor && !nextTile.getEntity().isAlliedWith(user))
+					{
+						ret = true;
+						break;
+					}
+				}
+				if (_targetTile.hasNextTile(i))
+				{
+					local nextTile = _targetTile.getNextTile(i);
+					if (nextTile.IsOccupiedByActor && !nextTile.getEntity().isAlliedWith(user))
+					{
+						ret = true;
+						break;
+					}
+				}
+			}
+		}
+
+		return ret;
+	}
+});


### PR DESCRIPTION
Currently, sometimes AI uses Rotation even in the very first round of combat while they are all standing in formation a million miles away from the player. The AI will rotate with an adjacent dude and then move 1 tile and end their turn. This wastes the AI's actions and builds unnecessary Fatigue.

With this change, the AI should hopefully use Rotation in more meaningful circumstances.