### PR TITLE
refactor: rebalance shield damage of weapons and shield durability

### DIFF
--- a/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
@@ -1,0 +1,9 @@
+::mods_hookExactClass("items/shields/special/craftable_schrat_shield", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.Condition = 42;
+		this.m.ConditionMax = 42;
+	}
+});

--- a/mod_reforged/hooks/items/weapons/barbarians/axehammer.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/axehammer.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 22;
+		this.m.ShieldDamage = 12;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/barbarians/crude_axe.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/crude_axe.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 22;
+		this.m.ShieldDamage = 16;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/barbarians/heavy_rusty_axe.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/heavy_rusty_axe.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 46;
+		this.m.ShieldDamage = 40;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/bardiche.nut
+++ b/mod_reforged/hooks/items/weapons/bardiche.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 42;
+		this.m.ShieldDamage = 32;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/fighting_axe.nut
+++ b/mod_reforged/hooks/items/weapons/fighting_axe.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 26;
+		this.m.ShieldDamage = 18;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/greataxe.nut
+++ b/mod_reforged/hooks/items/weapons/greataxe.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 46;
+		this.m.ShieldDamage = 40;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/greenskins/orc_axe.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/orc_axe.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 42;
+		this.m.ShieldDamage = 22;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/greenskins/orc_axe_2h.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/orc_axe_2h.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 68;
+		this.m.ShieldDamage = 54;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/hand_axe.nut
+++ b/mod_reforged/hooks/items/weapons/hand_axe.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 22;
+		this.m.ShieldDamage = 12;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/hatchet.nut
+++ b/mod_reforged/hooks/items/weapons/hatchet.nut
@@ -4,7 +4,7 @@
 	{
 		create();
 		this.m.Reach = 2;
-		this.m.ShieldDamage = 14;
+		this.m.ShieldDamage = 10;
 	}
 
 	o.onEquip = function()

--- a/mod_reforged/hooks/items/weapons/longaxe.nut
+++ b/mod_reforged/hooks/items/weapons/longaxe.nut
@@ -4,6 +4,6 @@
 	{
 		create();
 		this.m.Reach = 6;
-		this.m.ShieldDamage = 30;
+		this.m.ShieldDamage = 32;
 	}
 });

--- a/mod_reforged/hooks/items/weapons/throwing_spear.nut
+++ b/mod_reforged/hooks/items/weapons/throwing_spear.nut
@@ -4,6 +4,6 @@
 	{
 		create();
 		this.m.Reach = 0;
-		this.m.ShieldDamage = 48;
+		this.m.ShieldDamage = 40;
 	}
 });

--- a/scripts/items/weapons/rf_battle_axe.nut
+++ b/scripts/items/weapons/rf_battle_axe.nut
@@ -18,7 +18,7 @@ this.rf_battle_axe <- ::inherit("scripts/items/weapons/weapon", {
 		this.m.ShowArmamentIcon = true;
 		this.m.ArmamentIcon = "icon_rf_battle_axe_01";
 		this.m.Value = 1950;
-		this.m.ShieldDamage = 28;
+		this.m.ShieldDamage = 26;
 		this.m.Condition = 64.0;
 		this.m.ConditionMax = 64.0;
 		this.m.StaminaModifier = -14;


### PR DESCRIPTION
This improves the reliability of shields across the board especially Kite Shields and above. The change to the Living Tree Shield ensures that it isn't destroyed by a single hit from a Mansplitter with Axe Mastery and Shield Expert.

Weapons:
- axehammer: 22 to 12
- crude_axe: 22 to 16
- heavy_rusty_axe: 46 to 40
- bardiche: 42 to 32
- fighting_axe: 26 to 18
- greataxe: 46 to 40
- orc_axe: 42 to 22
- orc_axe_2h: 68 to 54
- hand_axe: 22 to 12
- hatchet: 14 to 10
- longaxe: 30 to 32
- throwing_spear: 48 to 40
- rf_battle_axe: 28 to 26

Shields:
- craftable_schrat_shield: 40 to 42