### PR TITLE
Perks rebalance

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1701,13 +1701,23 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
 	RF_Tempo = ::UPD.getDescription({
  		Fluff = "By keeping ahead of your opponent, you set the terms of engagement!",
- 		Effects = [{
-			Type = ::UPD.EffectType.Passive,
-			Description = [
-				"Every attack, hit or miss, against a target who acts after you in the current round increases your [Initiative|Concept.Initiative] by " + ::MSU.Text.colorGreen("+15") + ".",
-				"The bonus lasts over into your next [turn|Concept.Turn] but only until the first skill used or waiting that [turn|Concept.Turn]."
-			]
-		}]
+ 		Effects = [
+	 		{
+				Type = ::UPD.EffectType.Passive,
+				Description = [
+					"Every attack, hit or miss, against a target who acts after you in the current round increases your [Initiative|Concept.Initiative] by " + ::MSU.Text.colorGreen("+15") + ".",
+					"The bonus lasts over into your next [turn|Concept.Turn] but only until the first skill used or waiting that [turn|Concept.Turn]."
+				]
+			},
+			{
+				Type = ::UPD.EffectType.Passive,
+				Description = [
+					"When wielding a sword, gain the [Fluid Weapon|Skill+rf_fluid_weapon_effect] effect which has the following effects:",
+					"[Initiative|Concept.Initiative] is increased by " + ::MSU.Text.colorGreen("35%") + " of the equipped sword\'s armor ignore damage percentage.",
+					"The [Fatigue|Concept.Fatigue] Cost of weapon skills is reduced by " + ::MSU.Text.colorGreen("20%") + " of the equipped sword\'s armor effectiveness."
+				]
+			}
+		]
  	}),
 	RF_TheRushOfBattle = ::UPD.getDescription({
  		Fluff = "\'It\'s not uncommon to make it to the end of the battle not remembering any details, just that you slew many men!\'",

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1712,9 +1712,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			{
 				Type = ::UPD.EffectType.Passive,
 				Description = [
-					"When wielding a sword, gain the [Fluid Weapon|Skill+rf_fluid_weapon_effect] effect which has the following effects:",
-					"[Initiative|Concept.Initiative] is increased by " + ::MSU.Text.colorGreen("35%") + " of the equipped sword\'s armor ignore damage percentage.",
-					"The [Fatigue|Concept.Fatigue] Cost of weapon skills is reduced by " + ::MSU.Text.colorGreen("20%") + " of the equipped sword\'s armor effectiveness."
+					"When wielding a sword, gain the [Fluid Weapon|Skill+rf_fluid_weapon_effect] effect."
 				]
 			}
 		]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -806,7 +806,8 @@ foreach (vanillaDesc in vanillaDescriptions)
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"An additional " + ::MSU.Text.colorRed("10%") + " of damage ignores armor."
+				"An additional " + ::MSU.Text.colorRed("10%") + " of damage ignores armor.",
+				"Attacks now apply the [Hemorrhaging Internally|Skill+rf_internal_hemorrhage_effect] effect that deals " + ::MSU.Text.colorGreen("20%") + " of the damage dealt to [Hitpoints|Concept.Hitpoints] in that attack as damage to the target at the end of their [turn|Concept.Turn]."
 			]
 		}]
  	}),

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -782,6 +782,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
+				"Maximum Damage is increased by " + ::MSU.Text.colorGreen("10%") + " of the Maximum Damage of the currently equipped axe.",
 				"Hits to the head will instantly kill a target that has less than " + ::MSU.Text.colorRed("33%") + " [Hitpoints|Concept.Hitpoints] remaining after the hit.",
 				"Ignores [Nine Lives|Perk+perk_nine_lives] on the target.",
 				"If killed via culling, [decapitates|Concept.Fatality] the target."

--- a/mod_reforged/hooks/entity/tactical/enemies/orc_warrior.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/orc_warrior.nut
@@ -81,7 +81,6 @@
 	    {
 	    	this.m.Skills.add(::new("scripts/skills/perks/perk_rf_shield_splitter"));
 	    	this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_axe"));
-	    	this.m.Skills.add(::new("scripts/skills/perks/perk_rf_heft"));
 	    	if (::Reforged.Config.IsLegendaryDifficulty)
 	    	{
 	    		this.m.Skills.add(::new("scripts/skills/perks/perk_killing_frenzy"));

--- a/mod_reforged/hooks/entity/tactical/enemies/sand_golem.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/sand_golem.nut
@@ -41,7 +41,7 @@
     		o.m.IsForceEnabled = true;
 			o.m.IsForceMace = true;
     	}));
-    	this.m.Skills.add(::new("scripts/skills/perks/perk_rf_internal_hemorrhage"));
+    	this.m.Skills.add(::new("scripts/skills/perks/perk_rf_deep_impact"));
 
 		if (::Reforged.Config.IsLegendaryDifficulty)
 		{

--- a/mod_reforged/hooks/entity/tactical/enemies/schrat.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/schrat.nut
@@ -65,9 +65,6 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastLarge + 1;
-		this.m.Skills.add(::MSU.new("scripts/skills/perks/perk_rf_internal_hemorrhage", function(o) {
-			o.m.IsForceEnabled = true;
-		}));
 		this.m.Skills.add(::MSU.new("scripts/skills/perks/perk_rf_dent_armor", function(o) {
 			o.m.IsForceEnabled = true;
 		}));

--- a/mod_reforged/hooks/entity/tactical/enemies/trickster_god.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/trickster_god.nut
@@ -41,7 +41,6 @@
 		this.m.Skills.add(::MSU.new("scripts/skills/perks/perk_rf_dent_armor", function(o) {
 			o.m.IsForceEnabled = true;
 		}));
-		this.m.Skills.add(this.new("scripts/skills/perks/perk_rf_internal_hemorrhage"));
 		this.m.Skills.add(::MSU.new("scripts/skills/effects/return_favor_effect", function(o) {
 			o.onTurnStart = function() {}; // don't remove on turn start i.e. make it permanent
 		}));

--- a/mod_reforged/hooks/entity/tactical/enemies/unhold.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/unhold.nut
@@ -55,7 +55,6 @@
 		{
 			this.m.BaseProperties.MeleeSkill += 10;
 			this.m.Skills.add(this.new("scripts/skills/perks/perk_fortified_mind"));
-			this.m.Skills.add(this.new("scripts/skills/perks/perk_rf_internal_hemorrhage"));
 			this.m.Skills.add(this.new("scripts/skills/perks/perk_rf_survival_instinct"));
 			this.m.Skills.add(::MSU.new("scripts/skills/effects/return_favor_effect", function(o) {
 				o.onTurnStart = function() {}; // don't remove on turn start i.e. make it permanent

--- a/mod_reforged/hooks/entity/tactical/enemies/unhold_bog.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/unhold_bog.nut
@@ -53,7 +53,6 @@
 		{
 			this.m.BaseProperties.MeleeSkill += 10;
 			this.m.Skills.add(this.new("scripts/skills/perks/perk_fortified_mind"));
-			this.m.Skills.add(this.new("scripts/skills/perks/perk_rf_internal_hemorrhage"));
 			this.m.Skills.add(this.new("scripts/skills/perks/perk_rf_survival_instinct"));
 			this.m.Skills.add(::MSU.new("scripts/skills/effects/return_favor_effect", function(o) {
 				o.onTurnStart = function() {}; // don't remove on turn start i.e. make it permanent

--- a/mod_reforged/hooks/entity/tactical/enemies/unhold_frost.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/unhold_frost.nut
@@ -55,7 +55,6 @@
 		{
 			this.m.BaseProperties.MeleeSkill += 10;
 			this.m.Skills.add(this.new("scripts/skills/perks/perk_fortified_mind"));
-			this.m.Skills.add(this.new("scripts/skills/perks/perk_rf_internal_hemorrhage"));
 			this.m.Skills.add(this.new("scripts/skills/perks/perk_rf_survival_instinct"));
 			this.m.Skills.add(::MSU.new("scripts/skills/effects/return_favor_effect", function(o) {
 				o.onTurnStart = function() {}; // don't remove on turn start i.e. make it permanent

--- a/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
@@ -70,7 +70,6 @@
 	    	}
 	    	else
 	    	{
-	    		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_internal_hemorrhage"));
 	    		if (::Reforged.Config.IsLegendaryDifficulty)
 	    		{
 	    			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_deep_impact"));

--- a/mod_reforged/hooks/entity/tactical/humans/officer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/officer.nut
@@ -79,7 +79,6 @@
 	    if (weapon.isWeaponType(::Const.Items.WeaponType.Sword))
 	    {
 	    	this.m.Skills.add(::new("scripts/skills/perks/perk_rf_exploit_opening"));
-	    	this.m.Skills.add(::new("scripts/skills/perks/perk_rf_fluid_weapon"));
 	    	this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_sword"));
 	    	this.m.Skills.add(::new("scripts/skills/perks/perk_rf_tempo"));
 	    	this.m.Skills.add(::new("scripts/skills/perks/perk_rf_en_garde"));

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_axe.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_axe.nut
@@ -15,7 +15,7 @@ this.pg_rf_axe <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 				[],
 				["perk.mastery.axe"],
 				["perk.rf_between_the_eyes"],
-				["perk.rf_heft"],
+				[],
 				["perk.rf_cull"]
 			]
 		};

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_hammer.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_hammer.nut
@@ -12,7 +12,7 @@ this.pg_rf_hammer <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 			"default": [
 				["perk.crippling_strikes"],
 				[],
-				["perk.rf_internal_hemorrhage"],
+				[],
 				["perk.mastery.hammer"],
 				[],
 				["perk.rf_deep_impact"],

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_hammer.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_hammer.nut
@@ -12,11 +12,11 @@ this.pg_rf_hammer <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 			"default": [
 				["perk.crippling_strikes"],
 				[],
-				[],
+				["perk.rf_dent_armor"],
 				["perk.mastery.hammer"],
 				[],
 				["perk.rf_deep_impact"],
-				["perk.rf_dent_armor"]
+				[]
 			]
 		};
 	}

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_sword.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_sword.nut
@@ -12,7 +12,7 @@ this.pg_rf_sword <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 			"default": [
 				[],
 				["perk.rf_exploit_opening"],
-				["perk.rf_fluid_weapon"],
+				[],
 				["perk.mastery.sword"],
 				["perk.rf_tempo"],
 				["perk.rf_kata"],

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_wildling.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_wildling.nut
@@ -13,10 +13,10 @@ this.pg_rf_wildling <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 		this.m.Trees = {
 			"default": [
 				["perk.pathfinder"],
+				["perk.rf_bestial_vigor"],
+				[],
 				[],
 				["perk.rf_savage_strength"],
-				[],
-				["perk.rf_bestial_vigor"],
 				[],
 				["perk.rf_feral_rage"]
 			]

--- a/scripts/skills/effects/rf_fluid_weapon_effect.nut
+++ b/scripts/skills/effects/rf_fluid_weapon_effect.nut
@@ -1,0 +1,106 @@
+this.rf_fluid_weapon_effect <- ::inherit("scripts/skills/skill", {
+	m = {
+		IsForceEnabled = false,
+		ArmorPenAsInit = 0.35,
+		ArmorEffAsFatCostRed = 0.20,
+	},
+	function create()
+	{
+		this.m.ID = "effects.rf_fluid_weapon";
+		this.m.Name = "Fluid Weapon";
+		this.m.Description = "This weapon movements of this character are both graceful and fast.";
+		this.m.Icon = "ui/perks/rf_fluid_weapon.png";
+		// this.m.IconMini = "rf_fluid_weapon_mini";
+		this.m.Type = ::Const.SkillType.StatusEffect;
+		this.m.Order = ::Const.SkillOrder.Last;
+		this.m.IsActive = false;
+		this.m.IsStacking = false;
+		this.m.IsHidden = false;
+	}
+
+	function isHidden()
+	{
+		return !this.isEnabled();
+	}
+
+	function getTooltip()
+	{
+		local tooltip = this.skill.getTooltip();
+
+		local initiativeBonus = this.getInitiativeBonus();
+		if (initiativeBonus > 0)
+		{
+			tooltip.push({
+				id = 10,
+				type = "text",
+				icon = "ui/icons/initiative.png",
+				text = "[color=" + ::Const.UI.Color.PositiveValue + "]+" + initiativeBonus + "[/color] Initiative"
+			});
+		}
+
+		local fatReductionBonus = this.getFatigueReductionBonus();
+		if (fatReductionBonus > 0)
+		{
+			tooltip.push({
+				id = 10,
+				type = "text",
+				icon = "ui/icons/fatigue.png",
+				text = "Weapon skills build up [color=" + ::Const.UI.Color.PositiveValue + "]" + fatReductionBonus + "%[/color] less Fatigue"
+			});
+		}
+
+		return tooltip;
+	}
+
+	function isEnabled()
+	{
+		if (this.m.IsForceEnabled)
+		{
+			return true;
+		}
+
+		if (this.getContainer().getActor().isDisarmed()) return false;
+
+		local weapon = this.getContainer().getActor().getMainhandItem();
+		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Sword))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	function onUpdate(_properties)
+	{
+		if (this.isEnabled())
+		{
+			_properties.Initiative += this.getInitiativeBonus();
+		}
+	}
+
+	function onAfterUpdate(_properties)
+	{
+		if (!this.isEnabled())
+		{
+			return;
+		}
+
+		foreach (skill in this.getContainer().getActor().getMainhandItem().getSkills())
+		{
+			if (skill.isType(::Const.SkillType.Active)) skill.m.FatigueCostMult *= 1.0 - this.getFatigueReductionBonus() * 0.01;
+		}
+	}
+
+	function getInitiativeBonus()
+	{
+		local weapon = this.getContainer().getActor().getMainhandItem();
+		local armorPen = weapon.m.DirectDamageMult + weapon.m.DirectDamageAdd;
+		return ::Math.floor(this.m.ArmorPenAsInit * armorPen * 100);
+	}
+
+	function getFatigueReductionBonus()
+	{
+		local weapon = this.getContainer().getActor().getMainhandItem();
+		return ::Math.floor(this.m.ArmorEffAsFatCostRed * weapon.m.ArmorDamageMult * 100);
+	}
+});

--- a/scripts/skills/effects/rf_fluid_weapon_effect.nut
+++ b/scripts/skills/effects/rf_fluid_weapon_effect.nut
@@ -94,6 +94,8 @@ this.rf_fluid_weapon_effect <- ::inherit("scripts/skills/skill", {
 	function getInitiativeBonus()
 	{
 		local weapon = this.getContainer().getActor().getMainhandItem();
+		if (weapon == null) return 0;
+
 		local armorPen = weapon.m.DirectDamageMult + weapon.m.DirectDamageAdd;
 		return ::Math.floor(this.m.ArmorPenAsInit * armorPen * 100);
 	}
@@ -101,6 +103,8 @@ this.rf_fluid_weapon_effect <- ::inherit("scripts/skills/skill", {
 	function getFatigueReductionBonus()
 	{
 		local weapon = this.getContainer().getActor().getMainhandItem();
+		if (weapon == null) return 0;
+
 		return ::Math.floor(this.m.ArmorEffAsFatCostRed * weapon.m.ArmorDamageMult * 100);
 	}
 });

--- a/scripts/skills/effects/rf_fluid_weapon_effect.nut
+++ b/scripts/skills/effects/rf_fluid_weapon_effect.nut
@@ -52,6 +52,28 @@ this.rf_fluid_weapon_effect <- ::inherit("scripts/skills/skill", {
 		return tooltip;
 	}
 
+	function getNestedTooltip()
+	{
+		if (this.getContainer().getActor().getID() != ::MSU.getDummyPlayer().getID())
+			return this.getTooltip();
+
+		local tooltip = this.skill.getTooltip();
+		tooltip.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/initiative.png",
+			text = ::Reforged.Mod.Tooltips.parseString("[Initiative|Concept.Initiative] is increased by " + ::MSU.Text.colorGreen("35%") + " of the equipped sword\'s armor ignore percentage")
+		});
+		tooltip.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/fatigue.png",
+			text = ::Reforged.Mod.Tooltips.parseString("[Fatigue|Concept.Fatigue] Cost of weapon skills is reduced by " + ::MSU.Text.colorGreen("20%") + " of the equipped sword\'s armor effectiveness")
+		});
+
+		return tooltip;
+	}
+
 	function isEnabled()
 	{
 		if (this.m.IsForceEnabled)

--- a/scripts/skills/perks/perk_rf_cull.nut
+++ b/scripts/skills/perks/perk_rf_cull.nut
@@ -68,4 +68,15 @@ this.perk_rf_cull <- ::inherit("scripts/skills/skill", {
 			_targetEntity.kill(actor, _skill, ::Const.FatalityType.Decapitated);
 		}
 	}
+
+	function onUpdate(_properties)
+	{
+		if (this.getContainer().getActor().isDisarmed()) return;
+
+		local weapon = this.getContainer().getActor().getMainhandItem();
+		if (weapon != null && weapon.isWeaponType(::Const.Items.WeaponType.Axe))
+		{
+			_properties.DamageRegularMax += ::Math.floor(weapon.m.RegularDamageMax * 0.1);
+		}
+	}
 });

--- a/scripts/skills/perks/perk_rf_deep_impact.nut
+++ b/scripts/skills/perks/perk_rf_deep_impact.nut
@@ -1,6 +1,7 @@
 this.perk_rf_deep_impact <- ::inherit("scripts/skills/skill", {
 	m = {
-		IsForceEnabled = false
+		IsForceEnabled = false,
+		PercentageOfDamage = 20
 	},
 	function create()
 	{
@@ -20,6 +21,43 @@ this.perk_rf_deep_impact <- ::inherit("scripts/skills/skill", {
 		if (_skill.isAttack() && (_skill.getDamageType().contains(::Const.Damage.DamageType.Blunt) || this.m.IsForceEnabled))
 		{
 			_properties.DamageDirectAdd += 0.1;
+		}
+	}
+
+	function onTargetHit( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
+	{
+		if (!_targetEntity.isAlive() || _targetEntity.isDying() || !_skill.isAttack() || (!_skill.getDamageType().contains(::Const.Damage.DamageType.Blunt) && !this.m.IsForceEnabled))
+		{
+			return;
+		}
+
+		if (!_targetEntity.getCurrentProperties().IsImmuneToBleeding && _damageInflictedHitpoints >= ::Const.Combat.MinDamageToApplyBleeding)
+		{
+			local hemorrhageDamage = ::Math.floor(_damageInflictedHitpoints * this.m.PercentageOfDamage * 0.01);
+			if (hemorrhageDamage >= 1)
+			{
+				local actor = this.getContainer().getActor();
+				local effect = ::new("scripts/skills/effects/rf_internal_hemorrhage_effect");
+				if (actor.getFaction() == ::Const.Faction.Player || actor.getFaction() == ::Const.Faction.PlayerAnimals)
+				{
+					effect.setAttacker(actor);
+				}
+				effect.setDamage(hemorrhageDamage);
+				_targetEntity.getSkills().add(effect);
+			}
+		}
+	}
+
+	function onQueryTooltip( _skill, _tooltip )
+	{
+		if (_skill.isAttack() && (_skill.getDamageType().contains(::Const.Damage.DamageType.Blunt) || this.m.IsForceEnabled))
+		{
+			_tooltip.push({
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = "Inflicts internal hemorrhage for [color=" + ::Const.UI.Color.DamageValue + "]" + this.m.PercentageOfDamage + "%[/color] of the damage dealt to Hitpoints"
+			});
 		}
 	}
 });

--- a/scripts/skills/perks/perk_rf_tempo.nut
+++ b/scripts/skills/perks/perk_rf_tempo.nut
@@ -49,6 +49,16 @@ this.perk_rf_tempo <- ::inherit("scripts/skills/skill", {
 		return tooltip;
 	}
 
+	function onAdded()
+	{
+		this.getContainer().add(::new("scripts/skills/effects/rf_fluid_weapon_effect"));
+	}
+
+	function onRemoved()
+	{
+		this.getContainer().removeByID("effects.rf_fluid_weapon");
+	}
+
 	function getBonus()
 	{
 		return this.m.Stacks * this.m.BonusInitiative;


### PR DESCRIPTION
The changes in this PR are based on my 145 days play test, and also based on discussions with players in the public server. The intention is to reduce perks that are considered non-competitive with other options at their tiers. Also, to reduce the overall number of "mediocre" perks. This is achieved as follows:

- Bestial Vigor, moved from tier 5 to tier 2. Ideally this should be tier 1. It's basically an improved Recover, which is available to the Wildling only and is one use per combat. But on tier 1 we have Pathfinder, so it goes on tier 2 for now.
- Savage Strength is a strong perk. It moves from tier 3 to tier 5.
- Heft is a no-brainer perk for axes right now. So it has been removed and a lite version of its bonus (10% instead of 30%) has been baked into the Cull perk.
- Internal Hemorrhage is a lackluster option at tier 3. So it has been removed and baked directly into the Deep Impact perk at tier 6.
- Dent Armor is a weak and very limited pick at tier 7. It has been moved to tier 3, so it is a competitive pick even in the early game, allowing you to e.g. dent orc warriors in a relatively early stage of the game with Military Picks or Two Handed Wooden Hammers.
- Fluid Weapon and Tempo separately are less competitive perks when your perk points are so limited. So, Fluid Weapon has been baked into Tempo. Tempo now has two parts: the +15 Initiative per attack is available for everyone, but the Fluid Weapon part requires a sword.