### PR TITLE
feat: add aura effects only on demand to the entities

### DIFF
--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -19,7 +19,6 @@
 		this.getSkills().add(::new("scripts/skills/special/rf_direct_damage_limiter"));
 		this.getSkills().add(::new("scripts/skills/special/rf_polearm_adjacency"));
 		this.getSkills().add(::new("scripts/skills/special/rf_follow_up_proccer"));
-		this.getSkills().add(::new("scripts/skills/special/rf_inspiring_presence_buff_effect"));
 		this.getSkills().add(::new("scripts/skills/special/rf_weapon_mastery_standardization"));
 
 		local flags = this.getFlags();

--- a/mod_reforged/hooks/entity/tactical/enemies/orc_warlord.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/orc_warlord.nut
@@ -56,7 +56,7 @@
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_stalwart"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_shield_bash"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_fearsome"));
-		this.m.Skills.add(this.new("scripts/skills/effects/captain_effect"));
+		// this.m.Skills.add(this.new("scripts/skills/effects/captain_effect"));	// Now only added onCombatStarted with a captain present
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.Orc;

--- a/mod_reforged/hooks/entity/tactical/enemies/orc_warrior.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/orc_warrior.nut
@@ -55,7 +55,7 @@
 			this.m.Skills.add(this.new("scripts/skills/actives/wake_ally_skill"));
 		}
 
-		this.m.Skills.add(this.new("scripts/skills/effects/captain_effect"));
+		// this.m.Skills.add(this.new("scripts/skills/effects/captain_effect"));	// Now only added onCombatStarted with a captain present
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.Orc;

--- a/mod_reforged/hooks/entity/tactical/enemies/orc_young.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/orc_young.nut
@@ -54,7 +54,7 @@
 			this.m.Skills.add(this.new("scripts/skills/actives/wake_ally_skill"));
 		}
 
-		this.m.Skills.add(this.new("scripts/skills/effects/captain_effect"));
+		// this.m.Skills.add(this.new("scripts/skills/effects/captain_effect"));	// Now only added onCombatStarted with a captain present
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.Orc;

--- a/mod_reforged/hooks/entity/tactical/goblin.nut
+++ b/mod_reforged/hooks/entity/tactical/goblin.nut
@@ -32,7 +32,7 @@
 		this.addSprite("helmet_damage");
 		local body_blood = this.addSprite("body_blood");
 		body_blood.Visible = false;
-		this.m.Skills.add(this.new("scripts/skills/effects/captain_effect"));
+		// this.m.Skills.add(this.new("scripts/skills/effects/captain_effect"));	// Now only added onCombatStarted with a captain present
 		this.m.Skills.add(this.new("scripts/skills/special/double_grip"));
 		this.m.Skills.add(this.new("scripts/skills/actives/hand_to_hand"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_pathfinder"));

--- a/mod_reforged/hooks/entity/tactical/human.nut
+++ b/mod_reforged/hooks/entity/tactical/human.nut
@@ -4,5 +4,6 @@
 	{
 		onInit();
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.Human;
+		this.getSkills().removeByID("effects.captain", true);	// silent removal without triggering a logInfo entry
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -13,6 +13,7 @@
 		onInit();
 		this.getSkills().add(::new("scripts/skills/actives/rf_adjust_dented_armor_ally_skill"));
 		this.getSkills().add(::new("scripts/skills/special/rf_veteran_levels"));
+		this.getSkills().removeByID("effects.battle_standard", true);	// silent removal without triggering a logInfo entry
 	}
 
 	o.getProjectedAttributes <- function()

--- a/mod_reforged/hooks/items/tools/player_banner.nut
+++ b/mod_reforged/hooks/items/tools/player_banner.nut
@@ -1,0 +1,10 @@
+::mods_hookExactClass("items/tools/player_banner", function(o) {
+	o.onCombatStarted <- function()		// overwrite of base item function
+    {
+		local allies = ::Tactical.Entities.getInstancesOfFaction(this.getContainer().getActor().getFaction());
+		foreach (ally in allies)
+		{
+			ally.getSkills().add(::new("scripts/skills/effects/battle_standard_effect"));
+		}
+    }
+});

--- a/mod_reforged/hooks/skills/effects/battle_standard_effect.nut
+++ b/mod_reforged/hooks/skills/effects/battle_standard_effect.nut
@@ -1,0 +1,8 @@
+::mods_hookExactClass("skills/effects/battle_standard_effect", function (o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.IsRemovedAfterBattle = true;		// This effect is now only added during combats with a banner present
+	}
+});

--- a/mod_reforged/hooks/skills/effects/captain_effect.nut
+++ b/mod_reforged/hooks/skills/effects/captain_effect.nut
@@ -1,0 +1,8 @@
+::mods_hookExactClass("skills/effects/captain_effect", function (o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.IsRemovedAfterBattle = true;		// This effect is now only added during combats with a captain present
+	}
+});

--- a/mod_reforged/hooks/skills/perks/perk_captain.nut
+++ b/mod_reforged/hooks/skills/perks/perk_captain.nut
@@ -1,0 +1,10 @@
+::mods_hookExactClass("skills/perks/perk_captain", function(o) {
+	o.onCombatStarted <- function()		// overwrite of base skill function
+    {
+		local allies = ::Tactical.Entities.getInstancesOfFaction(this.getContainer().getActor().getFaction());
+		foreach (ally in allies)
+		{
+			ally.getSkills().add(::new("scripts/skills/effects/captain_effect"));
+		}
+    }
+});

--- a/mod_reforged/hooks/skills/perks/perk_inspiring_presence.nut
+++ b/mod_reforged/hooks/skills/perks/perk_inspiring_presence.nut
@@ -47,5 +47,10 @@
 	// Overwrite the vanilla function to be empty.
 	o.onCombatStarted = function()
 	{
+		local allies = ::Tactical.Entities.getInstancesOfFaction(this.getContainer().getActor().getFaction());
+		foreach (ally in allies)
+		{
+			ally.getSkills().add(::new("scripts/skills/special/rf_inspiring_presence_buff_effect"));
+		}
 	}
 });

--- a/scripts/skills/special/rf_inspiring_presence_buff_effect.nut
+++ b/scripts/skills/special/rf_inspiring_presence_buff_effect.nut
@@ -20,6 +20,7 @@ this.rf_inspiring_presence_buff_effect <- ::inherit("scripts/skills/skill", {
 		this.m.IsStacking = false;
 		this.m.IsHidden = false;
 		this.m.IsSerialized = false;
+		this.m.IsRemovedAfterBattle = true;		// This effect is only added during combats with a inspire person present
 	}
 
 	function isHidden()


### PR DESCRIPTION
- battle_standard_effect is now only added to your brothers on battles with a standard present
- captain_effect is now only added to allies of a faction with a captain present
- Orc Berserker are now affected by Orc Warlords resolve aura

**Upside:**
- Small performance boost in every fight because brothers previously had the **Captain** effect scanning for a captain on every update loop but you were never able to gain someone with this perk
- Additional performance boost in every fight where you don't bring a banner
- Additional performance boost in every fight with/against humans/orcs/goblins that do not field a Captain

**Sideeffects:**
battle_standard_effect & captain_effect are now spawned on **every** ally of the same faction. 
- Orc Berserker now also gain this effect which they never had in vanilla. 
- When there are ever mixed armies where only part of them is supposed to be affected by a captain_effect then currently all of them are being affected
- When you spawn in a Captain or Banner wielder mid-fight then their effect might not work during this fight unless their onCombatStarted function is being called in this case
- Troops that are spawned mid-fight will no longer be affected by those buffs. Current examples of such spawns would be spiders, golems, zombies and unleashed animals. But all of those are not affected by those effects anyways
- Entities that change their faction mid-fight (mindcontrol from hexen for example) may not profit from those auras while in that new faction