### PR TITLE
refactor: rework inspiring presence to not require a banner anymore

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1130,12 +1130,13 @@ foreach (vanillaDesc in vanillaDescriptions)
 		}]
  	}),
 	InspiringPresence = ::UPD.getDescription({
- 		Fluff = "Standing next to the company\'s banner inspires your men to go beyond their limits!",
- 		Requirement = "Banner",
+ 		Fluff = "Standing next to a company\'s leader figure inspires your men to go beyond their limits!",
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Any member of your company who is adjacent to an enemy, or is adjacent to an ally who is adjacent to an enemy, gains " + ::MSU.Text.colorGreen("+3") + " [Action Points|Concept.ActionPoints] as long as they start their [turn|Concept.Turn] adjacent to you."
+				"At the start of each battle, if you have the highest Resolve out of all Brothers with this perk, gain the [Inspiring Presence|Skill+perk_inspiring_presence] effect until the end of this battle.",
+				"While you have that effect: Any ally that starts their turn adjacent to you gains " + ::MSU.Text.colorGreen("+3") + " Action Points if they are adjacent to an enemy, or have an adjacent ally who is adjacent to an enemy.",
+				"Only affects allies that have less Resolve than you."
 			]
 		}]
  	}),

--- a/mod_reforged/hooks/skills/perks/perk_inspiring_presence.nut
+++ b/mod_reforged/hooks/skills/perks/perk_inspiring_presence.nut
@@ -1,5 +1,7 @@
 ::mods_hookExactClass("skills/perks/perk_inspiring_presence", function(o) {
 	o.m.IsForceEnabled <- false;
+	o.m.IsEnabledForThisCombat <- false;
+	o.m.BonusActionPoints <- 3;
 
 	local create = o.create;
 	o.create = function()
@@ -23,9 +25,35 @@
 			id = 11,
 			type = "text",
 			icon = "ui/icons/special.png",
-			text = "Allies who start their turn adjacent to this character will gain additional Action Points when engaged in melee or being adjacent to an ally engaged in melee"
+			text = "Any ally with less Resolve that starts their turn adjacent to you gains " + ::MSU.Text.colorizeValue(this.m.BonusActionPoints) + " Action Points if they are adjacent to an enemy, or have an adjacent ally who is adjacent to an enemy."
 		});
 		return tooltip;
+	}
+
+	// Overwrite the vanilla function to nullify its effects. Reverting the effect of making allies confident is annoying
+	o.onCombatStarted = function()
+	{
+		this.skill.onCombatStarted();
+		local actor = this.getContainer().getActor();
+		foreach (ally in ::Tactical.Entities.getInstancesOfFaction(this.getContainer().getActor().getFaction()))
+		{
+			if (ally.getID() == actor.getID()) continue;	// We don't check ourself
+
+			local inspiringPresencePerk = ally.getSkills().getSkillByID(this.getID());
+			if (inspiringPresencePerk == null) continue;					// Only other brothers with this exact perk may prevent our perk from going active
+			if (inspiringPresencePerk.m.IsForceEnabled) return;				// If that other perk is force enabled then we don't activate, because we still respect the limit of 1
+			if (inspiringPresencePerk.m.IsEnabledForThisCombat) return;		// If that other perk is already active then we can't also go active
+			if (ally.getCurrentProperties().getBravery() > actor.getCurrentProperties().getBravery()) return;	// Another Inspire brother has more resolve than us
+		}
+
+		this.m.IsEnabledForThisCombat = true;
+		::logWarning("Inspiring Presence is Active for " + actor.getName());
+	}
+
+	o.onCombatFinished <- function()
+	{
+		this.m.IsEnabledForThisCombat = false;
+		this.skill.onCombatFinished();
 	}
 
 	o.isEnabled <- function()
@@ -35,17 +63,6 @@
 			return true;
 		}
 
-		local weapon = this.getContainer().getActor().getMainhandItem();
-		if (weapon != null && weapon.getID().find("banner") != null)
-		{
-			return true;
-		}
-
-		return false;
-	}
-
-	// Overwrite the vanilla function to be empty.
-	o.onCombatStarted = function()
-	{
+		return this.m.IsEnabledForThisCombat;
 	}
 });

--- a/scripts/skills/special/rf_inspiring_presence_buff_effect.nut
+++ b/scripts/skills/special/rf_inspiring_presence_buff_effect.nut
@@ -46,7 +46,7 @@ this.rf_inspiring_presence_buff_effect <- ::inherit("scripts/skills/skill", {
 		if (this.m.IsInEffect)
 		{
 			_properties.ActionPoints += this.m.BonusActionPoints;
-			
+
 			if (this.m.IsStartingTurn)
 			{
 				this.getContainer().getActor().setActionPoints(this.getContainer().getActor().getActionPointsMax() + this.m.BonusActionPoints);
@@ -73,9 +73,10 @@ this.rf_inspiring_presence_buff_effect <- ::inherit("scripts/skills/skill", {
 			if (!hasInspirer)
 			{
 				local inspiringPresence = ally.getSkills().getSkillByID("perk.inspiring_presence");
-				if (inspiringPresence != null && inspiringPresence.isEnabled())
+				if (inspiringPresence != null && inspiringPresence.isEnabled() && ally.getCurrentProperties().getBravery() > actor.getCurrentProperties().getBravery())
 				{
 					hasInspirer = true;
+					this.m.BonusActionPoints = inspiringPresence.m.BonusActionPoints;
 				}
 			}
 


### PR DESCRIPTION
Inspiring Presence now only turns on for the brother with the highest resolve if multiple perks are present 
Inspiring Presence only affects allies that have less resolve than the emitter