### PR TITLE
refactor: add dynamic self multiplier for ranged perk group

### DIFF
--- a/mod_reforged/config/talent_multipliers.nut
+++ b/mod_reforged/config/talent_multipliers.nut
@@ -21,7 +21,6 @@
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedSkill, "pg.rf_bow", 3);
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedSkill, "pg.rf_crossbow", 2);
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedSkill, "pg.rf_throwing", 1.5);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedSkill, "pg.rf_ranged", 2);
 
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeDefense, "pg.rf_resilient", 1.2);
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeDefense, "pg.rf_trained", 1.2);

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_ranged.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_ranged.nut
@@ -20,4 +20,20 @@ this.pg_rf_ranged <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 			]
 		};
 	}
+
+	function getSelfMultiplier( _perkTree )
+	{
+		local ret = 0;
+		if (_perkTree.hasPerkGroup("pg.rf_bow")) ret += 1.0;
+		if (_perkTree.hasPerkGroup("pg.rf_crossbow")) ret += 1.0;
+		if (_perkTree.hasPerkGroup("pg.rf_throwing")) ret += 1.0;
+
+		if (ret == 0)
+			return ret;
+
+		local talents = _perkTree.getActor().getTalents();
+		if (talents.len() != 0) ret += talents[::Const.Attributes.RangedSkill]; // += is intended
+
+		return ret;
+	}
 });


### PR DESCRIPTION
- At least one ranged weapon perk group must be present (bow, crossbow or throwing). Otherwise the ranged perk group cannot be rolled.
- For each ranged weapon perk group present, the multiplier increases by 1. 
- For each talent star in Ranged Skill the multiplier increases by 1.