### PR TITLE
Swordmaster perks hybrid swords

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1665,13 +1665,13 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
 	RF_SwordmasterMetzger = ::UPD.getDescription({
  		Fluff = "A sword, too, can take someone\'s head off just fine!",
- 		Requirement = "Southern Sword"
+ 		Requirement = "Southern Sword or a Sword/Cleaver Hybrid"
  		Effects = [
 	 		{
 				Type = ::UPD.EffectType.Passive,
 				Description = [
 					"Adds the [Decapitate|Skill+decapitate] skill to southern swords.",
-					"Grants the [Sanguinary|Perk+perk_rf_sanguinary] and [Bloodbath|Perk+perk_rf_bloodbath] perks for free as long as a southern sword is equipped.",
+					"Grants the [Sanguinary|Perk+perk_rf_sanguinary] and [Bloodbath|Perk+perk_rf_bloodbath] perks for free as long as a valid weapon is equipped.",
 					"Attacks inflict [Bleeding|Skill+bleeding_effect] on the target for " + ::MSU.Text.colorRed(10) + " damage."
 				]
 			},

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1606,7 +1606,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
 	RF_SwordmasterBladeDancer = ::UPD.getDescription({
  		Fluff = "Let's Dance!",
- 		Requirement = "Non-hybrid Sword"
+ 		Requirement = "Sword"
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
@@ -1619,7 +1619,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
 	RF_SwordmasterGrappler = ::UPD.getDescription({
  		Fluff = "You have to fight for your place in this world.",
- 		Requirement = "Non-hybrid Sword"
+ 		Requirement = "Sword"
  		Effects = [
 	 		{
 				Type = ::UPD.EffectType.Active,
@@ -1646,7 +1646,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
 	RF_SwordmasterJuggernaut = ::UPD.getDescription({
  		Fluff = "There\'s a fine line between bravery and stupidity.",
- 		Requirement = "Non-hybrid Two-Handed Sword"
+ 		Requirement = "Two-Handed Sword"
  		Effects = [
 	 		{
 				Type = ::UPD.EffectType.Passive,
@@ -1665,7 +1665,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
 	RF_SwordmasterMetzger = ::UPD.getDescription({
  		Fluff = "A sword, too, can take someone\'s head off just fine!",
- 		Requirement = "Non-hybrid Southern Sword"
+ 		Requirement = "Southern Sword"
  		Effects = [
 	 		{
 				Type = ::UPD.EffectType.Passive,
@@ -1686,7 +1686,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
  	RF_SwordmasterPrecise = ::UPD.getDescription({
  		Fluff = "Let me show you how to thread a needle... blindfolded!",
- 		Requirement = "Non-hybrid Sword"
+ 		Requirement = "Sword"
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
@@ -1698,7 +1698,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
 	RF_SwordmasterReaper = ::UPD.getDescription({
  		Fluff = "Bring in the harvest!",
- 		Requirement = "Non-Hybrid Sword"
+ 		Requirement = "Sword"
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
@@ -1709,7 +1709,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
 	RF_SwordmasterVersatileSwordsman = ::UPD.getDescription({
  		Fluff = "King of all trades. Jack of none.",
- 		Requirement = "Non-hybrid Sword"
+ 		Requirement = "Sword"
  		Effects = [{
 			Type = ::UPD.EffectType.Active,
 			Description = [

--- a/scripts/skills/actives/rf_swordmaster_active_abstract.nut
+++ b/scripts/skills/actives/rf_swordmaster_active_abstract.nut
@@ -22,7 +22,7 @@ this.rf_swordmaster_active_abstract <- ::inherit("scripts/skills/skill", {
 		if (this.getContainer().getActor().isDisarmed()) return false;
 
 		local weapon = this.getContainer().getActor().getMainhandItem();
-		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Sword, true, true))
+		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Sword))
 		{
 			return false;
 		}
@@ -38,7 +38,7 @@ this.rf_swordmaster_active_abstract <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/warning.png",
-				text = "[color=" + ::Const.UI.Color.NegativeValue + "]Requires a non-hybrid sword[/color]"
+				text = "[color=" + ::Const.UI.Color.NegativeValue + "]Requires a sword[/color]"
 			});
 		}
 	}

--- a/scripts/skills/effects/rf_swordmasters_finesse_effect.nut
+++ b/scripts/skills/effects/rf_swordmasters_finesse_effect.nut
@@ -20,7 +20,7 @@ this.rf_swordmasters_finesse_effect <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/warning.png",
-				text = "[color=" + ::Const.UI.Color.NegativeValue + "]Requires a Sword to be equipped. Hybrid weapons do not count.[/color]"
+				text = "[color=" + ::Const.UI.Color.NegativeValue + "]Requires a Sword to be equipped[/color]"
 			});
 		}
 		else
@@ -87,7 +87,7 @@ this.rf_swordmasters_finesse_effect <- ::inherit("scripts/skills/skill", {
 	function isEnabled()
 	{
 		local weapon = this.getContainer().getActor().getMainhandItem();
-		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Sword, true, true))
+		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Sword))
 		{
 			return false;
 		}

--- a/scripts/skills/perks/perk_rf_swordmaster_abstract.nut
+++ b/scripts/skills/perks/perk_rf_swordmaster_abstract.nut
@@ -18,7 +18,7 @@ this.perk_rf_swordmaster_abstract <- ::inherit("scripts/skills/skill", {
 		if (this.getContainer().getActor().isDisarmed()) return false;
 
 		local weapon = this.getContainer().getActor().getMainhandItem();
-		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Sword, true, true))
+		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Sword))
 		{
 			return false;
 		}
@@ -34,7 +34,7 @@ this.perk_rf_swordmaster_abstract <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/warning.png",
-				text = "[color=" + ::Const.UI.Color.NegativeValue + "]Requires a non-hybrid sword[/color]"
+				text = "[color=" + ::Const.UI.Color.NegativeValue + "]Requires a sword[/color]"
 			});
 		}
 	}

--- a/scripts/skills/perks/perk_rf_swordmaster_metzger.nut
+++ b/scripts/skills/perks/perk_rf_swordmaster_metzger.nut
@@ -16,7 +16,9 @@ this.perk_rf_swordmaster_metzger <- ::inherit("scripts/skills/perks/perk_rf_swor
 		local ret = this.perk_rf_swordmaster_abstract.isEnabled();
 		if (ret)
 		{
-			if (!this.getContainer().getActor().getMainhandItem().isItemType(::Const.Items.ItemType.RF_Southern))
+			local weapon = this.getContainer().getActor().getMainhandItem();
+			// If it's neither a southern sword nor a sword/cleaver hybrid
+			if (!weapon.isItemType(::Const.Items.ItemType.RF_Southern) && !weapon.isWeaponType(::Const.Items.WeaponType.Cleaver))
 				return false;
 		}
 

--- a/scripts/skills/perks/perk_rf_swordmaster_metzger.nut
+++ b/scripts/skills/perks/perk_rf_swordmaster_metzger.nut
@@ -75,7 +75,8 @@ this.perk_rf_swordmaster_metzger <- ::inherit("scripts/skills/perks/perk_rf_swor
 
 	function onTargetHit( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
 	{
-		if (!_targetEntity.isAlive() || _targetEntity.isDying() || !this.isEnabled()) return;
+		if (!_targetEntity.isAlive() || _targetEntity.isDying() || _skill.getID() == "actives.cleave" || !this.isEnabled())
+			return;
 
 		if (!_targetEntity.getCurrentProperties().IsImmuneToBleeding && _damageInflictedHitpoints >= ::Const.Combat.MinDamageToApplyBleeding)
 		{


### PR DESCRIPTION
- Allow hybrid swords to be used for Swordmaster perks.
- Allow Sword/Cleaver hybrids to be a valid weapon for Metzger (in addition to southern swords).

If we run into particular issues where the perks feel weird with certain weapons, we can then exclude them as necessary.