### PR TITLE
refactor: combine sprint into footwork and rename it "Escape Artist"

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -152,12 +152,20 @@ local vanillaDescriptions = [
 		ID = "perk.footwork",
 		Key = "Footwork",
 		Description = ::UPD.getDescription({
-	 		Effects = [{
- 				Type = ::UPD.EffectType.Active,
- 				Description = [
-					"Unlocks the [Footwork|Skill+footwork] skill which allows you to leave a [Zone of Control|Concept.ZoneOfControl] without triggering free attacks."
-				]
- 			}]
+	 		Effects = [
+				{
+					Type = ::UPD.EffectType.Active,
+					Description = [
+						"Unlocks the [Footwork|Skill+footwork] skill which allows you to leave a [Zone of Control|Concept.ZoneOfControl] without triggering free attacks.",
+					]
+				},
+				{
+					Type = ::UPD.EffectType.Active,
+					Description = [
+						"Unlocks the [Sprint|Skill+rf_sprint_skill] skill that allows you to travel longer distances during your [turn|Concept.Turn]."
+					]
+				}
+			]
 	 	}),
 	},
 	{
@@ -513,12 +521,6 @@ local vanillaDescriptions = [
 	 				Description = [
 	 					"[Action Point|Concept.ActionPoints] costs for movement on all terrain is reduced by " + ::MSU.Text.colorRed("-1") + " to a minimum of 2 [Action Points|Concept.ActionPoints] per tile, and [Fatigue|Concept.Fatigue] cost is reduced to half.",
 	 					"Changing height levels also has no additional [Action Point|Concept.ActionPoints] cost anymore."
-	 				]
-	 			},
-	 			{
-	 				Type = ::UPD.EffectType.Active,
-	 				Description = [
-	 					"Unlocks the [Sprint|Skill+rf_sprint_skill] skill that allows you to travel longer distances during your [turn|Concept.Turn]."
 	 				]
 	 			}
  			]
@@ -1924,3 +1926,6 @@ foreach (key, string in ::Const.Strings.PerkDescription)
 
 ::Const.Strings.Distance[4] = "far away";
 ::Const.Strings.Distance[5] = "very far away";
+
+::Const.Strings.PerkName.Footwork = "Escape Artist";
+::Const.Perks.findById("perk.footwork").Name = ::Const.Strings.PerkName.Footwork;

--- a/mod_reforged/hooks/skills/perks/perk_footwork.nut
+++ b/mod_reforged/hooks/skills/perks/perk_footwork.nut
@@ -1,0 +1,15 @@
+::mods_hookExactClass("skills/perks/perk_dodge", function (o) {
+	local onAdded = o.onAdded;
+	o.onAdded = function()
+	{
+		onAdded();
+		this.getContainer().add(::new("scripts/skills/actives/rf_sprint_skill"));
+	}
+
+	local onRemoved = o.onRemoved;
+	o.onRemoved <- function()
+	{
+		onRemoved();
+		this.getContainer().removeByID("actives.rf_sprint");
+	}
+});

--- a/mod_reforged/hooks/skills/perks/perk_pathfinder.nut
+++ b/mod_reforged/hooks/skills/perks/perk_pathfinder.nut
@@ -1,11 +1,3 @@
 ::mods_hookExactClass("skills/perks/perk_pathfinder", function (o) {
-	o.onAdded <- function()
-	{
-		this.getContainer().add(::new("scripts/skills/actives/rf_sprint_skill"));
-	}
 
-	o.onRemoved <- function()
-	{
-		this.getContainer().removeByID("actives.rf_sprint");
-	}
 });

--- a/scripts/skills/actives/rf_sprint_skill.nut
+++ b/scripts/skills/actives/rf_sprint_skill.nut
@@ -20,7 +20,7 @@ this.rf_sprint_skill <- ::inherit("scripts/skills/skill", {
 		this.m.IsStacking = false;
 		this.m.IsAttack = false;
 		this.m.IsIgnoredAsAOO = true;
-		this.m.ActionPointCost = 0;
+		this.m.ActionPointCost = 1;
 		this.m.FatigueCost = 10;
 		this.m.MinRange = 0;
 		this.m.MaxRange = 0;
@@ -36,13 +36,13 @@ this.rf_sprint_skill <- ::inherit("scripts/skills/skill", {
 				type = "text",
 				icon = "ui/icons/action_points.png",
 				text = "Action Point cost for movement on all terrain will be reduced by " + ::MSU.Text.colorGreen(1)
-			},
+			}/*,
 			{
 				id = 10,
 				type = "text",
 				icon = "ui/icons/fatigue.png",
 				text = "Fatigue cost for movement on all terrain will be increased by " + ::MSU.Text.colorRed("100%")
-			}
+			}*/
 		]);
 
 		if (this.getContainer().getActor().getCurrentProperties().IsRooted)

--- a/scripts/skills/effects/rf_sprint_effect.nut
+++ b/scripts/skills/effects/rf_sprint_effect.nut
@@ -24,12 +24,12 @@ this.rf_sprint_effect <- ::inherit("scripts/skills/skill", {
 				icon = "ui/icons/action_points.png",
 				text = ::MSU.Text.colorGreen(-1) + " Action Points spent per tile traveled"
 			},
-			{
+			/*{
 				id = 10,
 				type = "text",
 				icon = "ui/icons/fatigue.png",
 				text = ::MSU.Text.colorRed("100%") + " more Fatigue built per tile traveled"
-			}
+			},*/
 			{
 				id = 10,
 				type = "text",
@@ -44,7 +44,7 @@ this.rf_sprint_effect <- ::inherit("scripts/skills/skill", {
 	function onUpdate( _properties )
 	{
 		_properties.MovementAPCostAdditional -= 1;
-		_properties.MovementFatigueCostMult *= 2.0;
+		// _properties.MovementFatigueCostMult *= 2.0;
 	}
 
 	function onBeforeAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )


### PR DESCRIPTION
- "Footwork" perk is renamed to "Escape Artist"
- Sprint is now part of "Escape Artist" perk.
- Sprint now also costs 1 AP and no longer increases fatigue cost for moving