### PR TITLE
fix: nine lives perk being hidden until reload of game after procced

### DIFF
--- a/mod_reforged/hooks/skills/perks/perk_nine_lives.nut
+++ b/mod_reforged/hooks/skills/perks/perk_nine_lives.nut
@@ -27,6 +27,13 @@
         if (proc) this.onProc();
 	}
 
+	local onCombatFinished = o.onCombatFinished;
+	o.onCombatFinished = function()
+	{
+		this.m.IsHidden = false;
+		onCombatFinished();
+	}
+
     // New function that is called after vanilla just applied the 11-15 hitpoints reset, removal of Dots and addition of the temporary nine_lives_effect
     o.onProc <- function()
     {


### PR DESCRIPTION
Currently the Nine Lives miniicon hides forever after the skill has been procced up until the player reloads a campaign.
That is because `this.m.Hidden` was never reset back to false anywhere.
This commit fixes that visual bug.