### PR TITLE
refactor: separate name and title with newline in combat tooltip

### DIFF
--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -59,6 +59,12 @@
 		if (this.isDiscovered() == false) return ret;
 		if (this.isHiddenToPlayer()) return ret;
 
+		local function verifySettingValue( _settingID )
+		{
+			local value = ::Reforged.Mod.ModSettings.getSetting(_settingID).getValue();
+			return (value == "All" || (value == "Player Only" && this.isPlayerControlled()) || (value == "AI Only" && !this.isPlayerControlled()));
+		}
+
 		// Adjust existing progressbars displayed by Vanilla
 		for (local index = (ret.len() - 1); index >= 0; index--)	// we move through it backwards to safely remove entries during it
 		{
@@ -71,7 +77,10 @@
 
 			else if (entry.id == 1 && entry.text == this.getName() && this.getTile() != "")
 			{
-				entry.text = this.getNameOnly() + "\n" + this.getTitle();
+				if (verifySettingValue("TacticalTooltip_SeparateNameTitle"))
+				{
+					entry.text = this.getNameOnly() + "\n" + this.getTitle();
+				}
 			}
 
 			else if (entry.id == 8)	// Replace Morale-Bar with Action-Point-Bar
@@ -88,12 +97,6 @@
 
 			// Remove all vanilla generated effect entries but possible also most mod-generated entries
 			if (entry.id >= 100) ret.remove(index);
-		}
-
-		local function verifySettingValue( _settingID )
-		{
-			local value = ::Reforged.Mod.ModSettings.getSetting(_settingID).getValue();
-			return value != "None" && (value == "All" || (value == "Player Only" && this.isPlayerControlled()) || (value == "AI Only" && !this.isPlayerControlled()))
 		}
 
 		if (verifySettingValue("TacticalTooltip_Attributes")) ret.extend(::Reforged.TacticalTooltip.getTooltipAttributesSmall(this, 100));

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -69,7 +69,12 @@
 				entry.text = " " + entry.value + " / " + entry.valueMax;
 			}
 
-			if (entry.id == 8)	// Replace Morale-Bar with Action-Point-Bar
+			else if (entry.id == 1 && entry.text == this.getName() && this.getTile() != "")
+			{
+				entry.text = this.getNameOnly() + "\n" + this.getTitle();
+			}
+
+			else if (entry.id == 8)	// Replace Morale-Bar with Action-Point-Bar
 			{
 				local turnsToGo = ::Tactical.TurnSequenceBar.getTurnsUntilActive(this.getID());
 

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -20,3 +20,5 @@ tacticalTooltipPage.addRangeSetting("CollapseActivesWhenX", 5, 0, 20, 1, "Collap
 tacticalTooltipPage.addBooleanSetting("TacticalTooltip_CollapseAsText", false, "Collapse as Text", "If enabled, then skills collapse using their names as text, otherwise they collapse using their icons.");
 tacticalTooltipPage.addBooleanSetting("ShowStatusPerkAndEffect", true, "Show Status Perk And Effect", "Some Perks are also Status Effects. Usually their Effect is hidden until some condition is fulfilled. When this setting is enabled, these perks show up in the Perks category even when they show up under Effects (e.g. when their effect is active). When disabled, when they appear under Effects, they will be hidden from the Perks category. This can help save space on the tooltip.");
 tacticalTooltipPage.addBooleanSetting("HeaderForEmptyCategories", false, "Show Header for empty categories");
+
+tacticalTooltipPage.addEnumSetting("TacticalTooltip_SeparateNameTitle", "Never", ["All", "AI Only", "Player Only", "Never"], "Separate Name and Title", "Separates the Name and the Title of an entity into two different lines in the combat tooltip.");


### PR DESCRIPTION
Currently every actor that a title will have that one displayed alongside their names on the combat tooltip.

Problem:
Both strings are stuffed into the same line overflowing to the next one.
A brother called **Basti** with the title **Nimble Forge Angler** will have it displayed the following:

``` 
Basti Nimble Forge
Angler
```

This PR will add a newline in such cases so that the title is displayed on the second line.
This should improve readability on the battlefield. For example to quickly identify fodder brothers.

So the example above would be displayed like so:
``` 
Basti 
Nimble Forge Angler
```
