### PR TITLE
fix: add hook on rebuke onTurnStart to remove itself

### DIFF
--- a/scripts/skills/actives/rf_en_garde_toggle_skill.nut
+++ b/scripts/skills/actives/rf_en_garde_toggle_skill.nut
@@ -96,6 +96,14 @@ this.rf_en_garde_toggle_skill <- ::inherit("scripts/skills/skill", {
 		{
 			local rebuke = ::new("scripts/skills/effects/rf_rebuke_effect");
 			rebuke.m.BaseChance += 10;
+			local onTurnStart = "onTurnStart" in rebuke ? rebuke.onTurnStart : null;
+			local parentName = rebuke.SuperName;
+			rebuke.onTurnStart <- function()
+			{
+				if (onTurnStart != null) onTurnStart();
+				else this[parentName].onTurnStart();
+				this.removeSelf();
+			}
 			return rebuke;
 		}
 	}


### PR DESCRIPTION
@Darxo Let me know if you can think of a better solution, otherwise we can go with this.

EDIT: Uberbagel playtested it and it works. So unless there is a better solution, we can implement this.