### PR TITLE
Ai tweaks onslaught holdsteady

### DIFF
--- a/mod_reforged/hooks/ai/tactical/behaviors/ai_line_breaker.nut
+++ b/mod_reforged/hooks/ai/tactical/behaviors/ai_line_breaker.nut
@@ -1,4 +1,5 @@
 ::Reforged.HooksMod.hook("scripts/ai/tactical/behaviors/ai_line_breaker", function(q) {
 	q.m.PossibleSkills.push("actives.rf_swordmaster_push_through");
 	q.m.PossibleSkills.push("actives.rf_swordmaster_tackle");
+	q.m.PossibleSkills.push("actives.rf_line_breaker");
 });

--- a/scripts/ai/tactical/behaviors/ai_rf_onslaught.nut
+++ b/scripts/ai/tactical/behaviors/ai_rf_onslaught.nut
@@ -36,48 +36,52 @@ this.ai_rf_onslaught <- ::inherit("scripts/ai/tactical/behavior", {
 
 		score = score * this.getFatigueScoreMult(this.m.Skill);
 		local myTile = _entity.getTile();
-		local allies = ::Tactical.Entities.getInstancesOfFaction(_entity.getFaction());
-		local enemies = ::Tactical.Entities.getHostileActors(_entity.getFaction());
 		local useScore = 0.0;
 		local numTargets = 0;
 
-		foreach( ally in allies )
+		foreach (ally in ::Tactical.Entities.getInstancesOfFaction(_entity.getFaction()))
 		{
-			if (ally.getTile().getDistanceTo(myTile) > 4 || !ally.hasZoneOfControl() || ally.getSkills().hasSkill("effects.rf_onslaught"))
+			local allyTile = ally.getTile();
+			if (allyTile.getDistanceTo(myTile) > 4 || !ally.hasZoneOfControl() || ally.getSkills().hasSkill("effects.rf_onslaught"))
 			{
 				continue;
 			}
-			
-			local bestTarget = this.queryBestMeleeTarget(ally, null, enemies).Target;
 
-			if (bestTarget == null)
+			local zocCount = allyTile.getZoneOfControlCountOtherThan(ally.getAlliedFactions());
+			if (zocCount < 2)
 			{
 				continue;
 			}
 
 			local allyAttack = ally.getSkills().getAttackOfOpportunity();
-			if (!allyAttack.verifyTargetAndRange(bestTarget.getTile(), ally.getTile()))
+			for (local i = 0; i < 6; i++)
 			{
-				continue;
-			}
+				if (!allyTile.hasNextTile(i)) continue;
 
-			local hitChance = allyAttack.getHitchance(bestTarget);
-			if (hitChance < 20 || hitChance > 85)
-			{
-				continue;
-			}
+				local nextTile = allyTile.getNextTile(i);
+				if (!nextTile.IsOccupiedByActor) continue;
 
-			numTargets++;
-			useScore = useScore + hitChance - 40;
+				local adjacentEntity = nextTile.getEntity();
+				if (adjacentEntity.isAlliedWith(ally) || !adjacentEntity.hasZoneOfControl()) continue;
+
+				local allyHitChance = allyAttack.getHitchance(adjacentEntity);
+				if (allyHitChance < 20) continue;
+
+				if (allyHitChance > adjacentEntity.getSkills().getAttackOfOpportunity().getHitchance(ally) * 0.7)
+				{
+					numTargets++;
+					useScore += 40 * zocCount;
+					break;
+				}
+			}
 		}
 
-		if (numTargets < 5)
+		if (numTargets < 3)
 		{
 			return ::Const.AI.Behavior.Score.Zero;
 		}
 
-		score = score * (useScore * 0.01);
-		return ::Const.AI.Behavior.Score.RF_Onslaught * score;
+		return ::Const.AI.Behavior.Score.RF_Onslaught * score * useScore * 0.01;
 	}
 
 	function onExecute( _entity )


### PR DESCRIPTION
The previous ai package for these skills wasn't even working properly due to some logical issues in the algorithm. I've tested this new implementation and it works. We can tweak the AI over time more based on feedback.

It now uses the number of enemies adjacent to relevant allies and checks the hit-chance of allies vs enemies to determine whether to hold steady or to onslaught. Basically if enemies have a much greater hitchance than allies, then usage of Hold Steady is preferred, and if allies have hitchance close to enemy hit-chance or better than enemy hitchance, then usage of Onslaught is preferred. In both cases at least 3 relevant allies are required, otherwise the skills won't be triggered.