### PR TITLE
refactor: rework swordmaster grappler skills

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1668,21 +1668,19 @@ foreach (vanillaDesc in vanillaDescriptions)
 	 		{
 				Type = ::UPD.EffectType.Active,
 				Description = [
-					"Unlocks the [Kick|Skill+rf_swordmaster_kick_skill] skill which allows you to knock back and [stagger|Skill+staggered_effect] a target."
-					"When using a two-handed sword or double-gripping a one-handed sword, the [Action Point|Concept.ActionPoints] cost is reduced by " + ::MSU.Text.colorGreen(1) + " and the [Fatigue|Concept.Fatigue] Cost by " + ::MSU.Text.colorGreen(5) + "."
-
+					"Unlocks the [Kick|Skill+rf_swordmaster_kick_skill] skill which allows you to stagger a target, perform a free attack against them. If the attack is successful, the target is knocked back a tile."
 				]
 			},
 			{
 				Type = ::UPD.EffectType.Active,
 				Description = [
-					"Unlocks the [Push Through|Skill+rf_swordmaster_push_through_skill] skill which allows you to knock back and stagger a target while moving into their tile in one action."
+					"Unlocks the [Push Through|Skill+rf_swordmaster_push_through_skill] skill which allows you to stagger a target and perform a free attack against them. If the attack is successful, the target is knocked back a tile and you move into their place."
 				]
 			},
 			{
 				Type = ::UPD.EffectType.Active,
 				Description = [
-					"Unlocks the [Tackle|Skill+rf_swordmaster_tackle_skill] which allows you to exchange positions with and stagger an adjacent target."
+					"Unlocks the [Tackle|Skill+rf_swordmaster_tackle_skill] which allows you to stagger a target and perform a free attack against them. If the attack is successful you exchange positions with the target."
 				]
 			}
 		],

--- a/scripts/skills/actives/rf_swordmaster_kick_skill.nut
+++ b/scripts/skills/actives/rf_swordmaster_kick_skill.nut
@@ -26,8 +26,8 @@ this.rf_swordmaster_kick_skill <- ::inherit("scripts/skills/actives/rf_swordmast
 		this.m.IsStacking = false;
 		this.m.IsAttack = true;
 		this.m.IsIgnoredAsAOO = true;
-		this.m.ActionPointCost = 4;
-		this.m.FatigueCost = 20;
+		this.m.ActionPointCost = 6;
+		this.m.FatigueCost = 15;
 		this.m.MinRange = 1;
 		this.m.MaxRange = 1;
 	}
@@ -40,21 +40,27 @@ this.rf_swordmaster_kick_skill <- ::inherit("scripts/skills/actives/rf_swordmast
 			id = 7,
 			type = "text",
 			icon = "ui/icons/special.png",
-			text = "Has a [color=" + ::Const.UI.Color.PositiveValue + "]100%[/color] chance to stagger on a hit"
+			text = "Has a [color=" + ::Const.UI.Color.PositiveValue + "]100%[/color] chance to stagger the target"
+		});
+
+		local attack = this.getContainer().getAttackOfOpportunity();
+		tooltip.push({
+			id = 7,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString(format("Perform a free [%s|Skill+%s] on the target", attack.getName(), split(::IO.scriptFilenameByHash(attack.ClassNameHash), "/").top()))
+		});
+
+		tooltip.push({
+			id = 7,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = "If the attack is successful, the target is pushed back a tile"
 		});
 
 		this.addEnabledTooltip(tooltip);
 
 		return tooltip;
-	}
-
-	function onAfterUpdate( _properties )
-	{
-		if (this.getContainer().getActor().isArmedWithTwoHandedWeapon() || this.getContainer().getActor().isDoubleGrippingWeapon())
-		{
-			this.m.ActionPointCost -= 1;
-			this.m.FatigueCost -= 5;
-		}
 	}
 
 	function findTileToKnockBackTo( _userTile, _targetTile )
@@ -117,76 +123,71 @@ this.rf_swordmaster_kick_skill <- ::inherit("scripts/skills/actives/rf_swordmast
 	{
 		local target = _targetTile.getEntity();
 
-		if (this.m.SoundOnUse.len() != 0)
+		target.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
+		if (!_user.isHiddenToPlayer() && _targetTile.IsVisibleForPlayer)
 		{
-			this.Sound.play(this.m.SoundOnUse[this.Math.rand(0, this.m.SoundOnUse.len() - 1)], ::Const.Sound.Volume.Skill, _user.getPos());
+			::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " has kicked and staggered " + ::Const.UI.getColorizedEntityName(target));
 		}
 
-		if (this.Math.rand(1, 100) > this.getHitchance(_targetTile.getEntity()))
-		{
-			target.onMissed(this.getContainer().getActor(), this);
-			return false;
-		}
+		local aoo = this.getContainer().getAttackOfOpportunity();
+		local overlay = aoo.m.Overlay;
+		aoo.m.Overlay = "";
+		local success = aoo.useForFree(_targetTile);
+		aoo.m.Overlay = overlay;
 
-		local knockToTile = this.findTileToKnockBackTo(_user.getTile(), _targetTile);
-
-		if (knockToTile == null)
+		if (success && target.isAlive())
 		{
-			target.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
-			if (!_user.isHiddenToPlayer() && _targetTile.IsVisibleForPlayer)
+			if (this.m.SoundOnUse.len() != 0)
 			{
-				::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " has kicked and staggered " + ::Const.UI.getColorizedEntityName(target));
+				this.Sound.play(this.m.SoundOnUse[this.Math.rand(0, this.m.SoundOnUse.len() - 1)], ::Const.Sound.Volume.Skill, _user.getPos());
 			}
 
-			return true;
+			local knockToTile = this.findTileToKnockBackTo(_user.getTile(), _targetTile);
+			if (knockToTile == null)
+			{
+				return success;
+			}
+
+			this.applyFatigueDamage(target, 10);
+
+			local skills = target.getSkills();
+			skills.removeByID("effects.shieldwall");
+			skills.removeByID("effects.spearwall");
+			skills.removeByID("effects.riposte");
+
+			if (this.m.SoundOnHit.len() != 0)
+			{
+				this.Sound.play(this.m.SoundOnHit[this.Math.rand(0, this.m.SoundOnHit.len() - 1)], ::Const.Sound.Volume.Skill, _user.getPos());
+			}
+
+			target.setCurrentMovementType(::Const.Tactical.MovementType.Involuntary);
+			local damage = this.Math.max(0, this.Math.abs(knockToTile.Level - _targetTile.Level) - 1) * ::Const.Combat.FallingDamage;
+
+			if (damage == 0)
+			{
+				::Tactical.getNavigator().teleport(target, knockToTile, null, null, true);
+			}
+			else
+			{
+				local p = this.getContainer().getActor().getCurrentProperties();
+				local tag = {
+					Attacker = _user,
+					Skill = this,
+					HitInfo = clone ::Const.Tactical.HitInfo,
+					HitInfoBash = null
+				};
+				tag.HitInfo.DamageRegular = damage;
+				tag.HitInfo.DamageFatigue = ::Const.Combat.FatigueReceivedPerHit;
+				tag.HitInfo.DamageDirect = 1.0;
+				tag.HitInfo.BodyPart = ::Const.BodyPart.Body;
+				tag.HitInfo.BodyDamageMult = 1.0;
+				tag.HitInfo.FatalityChanceMult = 1.0;
+
+				::Tactical.getNavigator().teleport(target, knockToTile, this.onKnockedDown, tag, true);
+			}
 		}
 
-		this.applyFatigueDamage(target, 10);
-
-		local skills = target.getSkills();
-		skills.removeByID("effects.shieldwall");
-		skills.removeByID("effects.spearwall");
-		skills.removeByID("effects.riposte");
-
-		target.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
-
-		if (!_user.isHiddenToPlayer() && (_targetTile.IsVisibleForPlayer || knockToTile.IsVisibleForPlayer))
-		{
-			::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " has kicked back and staggered " + ::Const.UI.getColorizedEntityName(target));
-		}
-
-		if (this.m.SoundOnHit.len() != 0)
-		{
-			this.Sound.play(this.m.SoundOnHit[this.Math.rand(0, this.m.SoundOnHit.len() - 1)], ::Const.Sound.Volume.Skill, _user.getPos());
-		}
-
-		target.setCurrentMovementType(::Const.Tactical.MovementType.Involuntary);
-		local damage = this.Math.max(0, this.Math.abs(knockToTile.Level - _targetTile.Level) - 1) * ::Const.Combat.FallingDamage;
-
-		if (damage == 0)
-		{
-			::Tactical.getNavigator().teleport(target, knockToTile, null, null, true);
-		}
-		else
-		{
-			local p = this.getContainer().getActor().getCurrentProperties();
-			local tag = {
-				Attacker = _user,
-				Skill = this,
-				HitInfo = clone ::Const.Tactical.HitInfo,
-				HitInfoBash = null
-			};
-			tag.HitInfo.DamageRegular = damage;
-			tag.HitInfo.DamageFatigue = ::Const.Combat.FatigueReceivedPerHit;
-			tag.HitInfo.DamageDirect = 1.0;
-			tag.HitInfo.BodyPart = ::Const.BodyPart.Body;
-			tag.HitInfo.BodyDamageMult = 1.0;
-			tag.HitInfo.FatalityChanceMult = 1.0;
-
-			::Tactical.getNavigator().teleport(target, knockToTile, this.onKnockedDown, tag, true);
-		}
-
-		return true;
+		return success;
 	}
 
 	function onKnockedDown( _entity, _tag )

--- a/scripts/skills/actives/rf_swordmaster_push_through_skill.nut
+++ b/scripts/skills/actives/rf_swordmaster_push_through_skill.nut
@@ -86,7 +86,7 @@ this.rf_swordmaster_push_through_skill <- ::inherit("scripts/skills/actives/line
 		if (perk == null || !perk.isEnabled()) return false;
 
 		local actor = this.getContainer().getActor();
-		return this.skill.isUsable() && !actor.getCurrentProperties().IsRooted && !actor.getCurrentProperties().IsStunned;
+		return this.line_breaker.isUsable() && !actor.getCurrentProperties().IsRooted && !actor.getCurrentProperties().IsStunned;
 	}
 
 	function onUse( _user, _targetTile )


### PR DESCRIPTION
- Set AP cost to 6 and Fatigue cost to 15.
- Always stagger the target.
- Perform a free attack.
- If the attack is successful: Kick moves the target back a tile, Push Through moves the target back and you move into their place, Tackle exchanges positions.

I had a discussion with some players. Apparently no one picks Grappler because it is currently very weak compared to the other swordmaster perks. With these changes, it's now more competitive - although probably still overshadowed by a couple other perks. But seems like a step in the right direction.