### PR TITLE
fix: hidden permanent injuries

### DIFF
--- a/mod_reforged/actor_tooltip_functions.nut
+++ b/mod_reforged/actor_tooltip_functions.nut
@@ -49,7 +49,7 @@
     local collapseThreshold = ::Reforged.Mod.ModSettings.getSetting("CollapseEffectsWhenX").getValue();
     local effectList = [];
 
-    local statusEffects = _actor.getSkills().query(::Const.SkillType.StatusEffect, false, true);
+    local statusEffects = _actor.getSkills().query(::Const.SkillType.StatusEffect | ::Const.SkillType.PermanentInjury, false, true);
     if (statusEffects.len() != 0 || ::Reforged.Mod.ModSettings.getSetting("HeaderForEmptyCategories").getValue() == true) ::Reforged.TacticalTooltip.pushSectionName(effectList, "Effects", currentID);
     currentID++;
 

--- a/mod_reforged/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/mod_reforged/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -25,6 +25,23 @@
 		initNextRound();
 	}
 
+	// We replace the vanilla function for performance reason and because it is a simple function. We don't want to query an entitys skills twice for no reason.
+	o.convertEntityStatusEffectsToUIData = function( _entity )
+	{
+		if (!_entity.isPlayerControlled()) return null;
+
+		local result = [];
+		foreach (statusEffect in _entity.getSkills().query(::Const.SkillType.StatusEffect | ::Const.SkillType.PermanentInjury, false, true))
+		{
+			result.push({
+				id = statusEffect.getID(),
+				imagePath = statusEffect.getIcon()
+			});
+		}
+
+		return result;
+	}
+
 // New Functions:
 	o.onWaitTurnAllButtonPressed <- function()
 	{


### PR DESCRIPTION
Currently permanent Injuries are not shown on combat tooltips or above the turn sequence bar overlay (left side by the stats)
This is because those only query and show:
- ::Const.SkillType.StatusEffect
- ::Const.SkillType.Perk (For Combat Tooltips only)
But permanent injuries are, unlike normal injuries, not of type `::Const.SkillType.StatusEffect`.

As a result you will sometimes wonder why your some fodder brother is so weak/slow even though they don't have any statuseffects.

This is where permanent injuries will now are displayed after this fix, which wasn't the case before:

![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/1076dcad-0d03-4ff1-b3bb-13354a8e8e6e)
