### PR TITLE
Ai behaviors assignment following msu update

### DIFF
--- a/mod_reforged/config/ai.nut
+++ b/mod_reforged/config/ai.nut
@@ -1,0 +1,44 @@
+::Reforged.AI <- {
+	ExcludedBehaviors = {
+		orc_young_agent = [
+			::Const.AI.Behavior.ID.Riposte,
+			::Const.AI.Behavior.ID.Puncture,
+			::Const.AI.Behavior.ID.RF_KataStep,
+			::Const.AI.Behavior.ID.RF_CoverAlly
+		],
+		orc_warlord_agent = [
+			::Const.AI.Behavior.ID.Riposte,
+			::Const.AI.Behavior.ID.Puncture,
+			::Const.AI.Behavior.ID.RF_KataStep,
+			::Const.AI.Behavior.ID.RF_CoverAlly
+		],
+		orc_berserker_agent = [
+			::Const.AI.Behavior.ID.Riposte,
+			::Const.AI.Behavior.ID.Puncture,
+			::Const.AI.Behavior.ID.RF_KataStep,
+			::Const.AI.Behavior.ID.RF_CoverAlly
+		],
+		orc_warrior_agent = [
+			::Const.AI.Behavior.ID.Riposte,
+			::Const.AI.Behavior.ID.Puncture,
+			::Const.AI.Behavior.ID.RF_KataStep,
+			::Const.AI.Behavior.ID.RF_CoverAlly
+		],
+		zombie_agent = [
+			::Const.AI.Behavior.ID.Riposte,
+			::Const.AI.Behavior.ID.Gash,
+			::Const.AI.Behavior.ID.Decapitate,
+			::Const.AI.Behavior.ID.Puncture,
+			::Const.AI.Behavior.ID.RF_KataStep,
+			::Const.AI.Behavior.ID.RF_CoverAlly
+		],
+		zombie_bodyguard_agent = [
+			::Const.AI.Behavior.ID.Riposte,
+			::Const.AI.Behavior.ID.Gash,
+			::Const.AI.Behavior.ID.Decapitate,
+			::Const.AI.Behavior.ID.Puncture,
+			::Const.AI.Behavior.ID.RF_KataStep,
+			::Const.AI.Behavior.ID.RF_CoverAlly
+		]
+	}
+};

--- a/mod_reforged/hooks/ai/tactical/agent.nut
+++ b/mod_reforged/hooks/ai/tactical/agent.nut
@@ -1,0 +1,17 @@
+::mods_hookNewObject("ai/tactical/agent", function (o) {
+	local addBehavior = o.addBehavior;
+	o.addBehavior = function( _behavior )
+	{
+		local obj = this;
+		while ("SuperName" in obj)
+		{
+			if ((obj.ClassName in ::Reforged.AI.ExcludedBehaviors) && ::Reforged.AI.ExcludedBehaviors[obj.ClassName].find(_behavior.getID()) != null)
+			{
+				return;
+			}
+			obj = obj[obj.SuperName];
+		}
+
+		return addBehavior(_behavior);
+	}
+});

--- a/mod_reforged/hooks/ai/tactical/behaviors/ai_defend_knock_back.nut
+++ b/mod_reforged/hooks/ai/tactical/behaviors/ai_defend_knock_back.nut
@@ -1,3 +1,4 @@
 ::mods_hookExactClass("ai/tactical/behaviors/ai_defend_knock_back", function (o) {
 	o.m.PossibleSkills.push("actives.rf_swordmaster_kick");
+	o.m.PossibleSkills.push("actives.rf_net_pull");
 });

--- a/mod_reforged/hooks/skills/actives/decapitate_skill.nut
+++ b/mod_reforged/hooks/skills/actives/decapitate_skill.nut
@@ -1,0 +1,8 @@
+::mods_hookExactClass("skills/actives/decapitate_skill", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.Decapitate;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/gash_skill.nut
+++ b/mod_reforged/hooks/skills/actives/gash_skill.nut
@@ -4,6 +4,7 @@
 	{
 		create();
 		this.m.HitChanceBonus = 5;
+		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.Gash;
 	}
 
 	o.getTooltip = function()

--- a/mod_reforged/hooks/skills/actives/puncture.nut
+++ b/mod_reforged/hooks/skills/actives/puncture.nut
@@ -1,0 +1,8 @@
+::mods_hookExactClass("skills/actives/puncture", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.Puncture;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/riposte.nut
+++ b/mod_reforged/hooks/skills/actives/riposte.nut
@@ -1,0 +1,8 @@
+::mods_hookExactClass("skills/actives/riposte", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.Riposte;
+	}
+});

--- a/scripts/skills/actives/rf_net_pull_skill.nut
+++ b/scripts/skills/actives/rf_net_pull_skill.nut
@@ -33,6 +33,7 @@ this.rf_net_pull_skill <- ::inherit("scripts/skills/skill", {
 		this.m.MinRange = 2;
 		this.m.MaxRange = 2;
 		this.m.MaxLevelDifference = 1;
+		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.KnockBack;
 	}
 
 	function getTooltip()


### PR DESCRIPTION
Previous MSU build automatically added `AIBehaviorID` to all vanilla skills. This meant that the behavior for said skills was also automatically added to any entity who got the skill. This resulted in Zombies using stuff like Gash, Decapitate, Puncture etc. 

The recent MSU build fixed this by no longer adding `AIBehaviorID` to skills automatically. This means mods now have to add them manually, but then also have to care about which agents they don't want those behaviors to be added to.