### PR TITLE
refactor: add equal number of low and high rolls to two star talents

### DIFF
--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -149,7 +149,7 @@
 				local numIndicesToRandomize = ::Math.rand(2, _amount);
 				if (numIndicesToRandomize % 2 != 0) numIndicesToRandomize--; // Ensure that we have an even number to randomize
 
-				local change = ::Math.rand(-1, 1);
+				local change = 1;
 				for (local j = 0; j < numIndicesToRandomize; j++)
 				{
 					this.m.Attributes[i][indices.remove(::Math.rand(0, indices.len() - 1))] += change;

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -24,12 +24,9 @@
 		{
 			if (attribute == ::Const.Attributes.COUNT) continue;
 
-			local attributeMin = ::Const.AttributesLevelUp[attribute].Min;
-			if (this.m.Talents[attribute] >= 1) attributeMin++;
-			if (this.m.Talents[attribute] == 3) attributeMin++;
-
+			local attributeMin = ::Const.AttributesLevelUp[attribute].Min + ::Math.min(this.m.Talents[attribute], 2);
 			local attributeMax = ::Const.AttributesLevelUp[attribute].Max;
-			if (this.m.Talents[attribute] >= 2) attributeMax++;
+			if (this.m.Talents[attribute] == 2) attributeMax++;
 
 			local levelUpsRemaining = ::Math.max(::Const.XP.MaxLevelWithPerkpoints - this.getLevel() + this.getLevelUps(), 0);
 			local attributeValue = attributeName == "Fatigue" ? baseProperties["Stamina"] : baseProperties[attributeName]; // Thank you Overhype
@@ -134,11 +131,23 @@
 
 		for (local i = 0; i != ::Const.Attributes.COUNT; i++)
 		{
-			if (this.m.Talents[i] == 2)
+			if (this.m.Talents[i] == 2 && _amount > 2)
 			{
-				for (local j = 0; j < _amount; j++)
+				local indices = array(_amount);
+				indices.apply(@(val, idx) idx);
+				local indicesToRandomize = array(::Math.rand(2, _amount));
+				if (indicesToRandomize.len() % 2 != 0) indicesToRandomize.pop(); // Ensure that we have an even number to randomize
+
+				for (local j = 0; j < indicesToRandomize.len(); j++)
 				{
-					this.m.Attributes[i][j] += ::Math.rand(-1, 1);
+					indicesToRandomize[j] = indices.remove(::Math.rand(0, indices.len() - 1));
+				}
+
+				local change = ::Math.rand(-1, 1);
+				foreach (idx in indicesToRandomize)
+				{
+					this.m.Attributes[i][idx] += change;
+					change *= -1;
 				}
 			}
 		}

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -126,12 +126,12 @@
 	{
 		fillAttributeLevelUpValues(_amount, _maxOnly, _minOnly);
 
-		if (_amount == 0) return;
+		if (_amount < 3) return;
 		if (_maxOnly || _minOnly) return;	// Stars do not influence these level-ups
 
 		for (local i = 0; i != ::Const.Attributes.COUNT; i++)
 		{
-			if (this.m.Talents[i] == 2 && _amount > 2)
+			if (this.m.Talents[i] == 2)
 			{
 				local indices = array(_amount);
 				indices.apply(@(val, idx) idx);

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -146,19 +146,14 @@
 				{
 					indices[i] = i;
 				}
-				local indicesToRandomize = array(::Math.rand(2, _amount));
-				if (indicesToRandomize.len() % 2 != 0) indicesToRandomize.pop(); // Ensure that we have an even number to randomize
-
-				for (local j = 0; j < indicesToRandomize.len(); j++)
-				{
-					indicesToRandomize[j] = indices.remove(::Math.rand(0, indices.len() - 1));
-				}
+				local numIndicesToRandomize = ::Math.rand(2, _amount);
+				if (numIndicesToRandomize % 2 != 0) numIndicesToRandomize--; // Ensure that we have an even number to randomize
 
 				local change = ::Math.rand(-1, 1);
-				foreach (idx in indicesToRandomize)
+				for (local j = 0; j < numIndicesToRandomize; j++)
 				{
-					this.m.Attributes[i][idx] += change;
-					change *= -1;
+					this.m.Attributes[i][indices.remove(::Math.rand(0, indices.len() - 1))] += change;
+					change *= 1;
 				}
 			}
 		}

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -142,9 +142,9 @@
 			if (this.m.Talents[i] == 2)
 			{
 				local indices = array(_amount);
-				foreach (i, _ in indices)
+				foreach (j, _ in indices)
 				{
-					indices[i] = i;
+					indices[j] = j;
 				}
 				local numIndicesToRandomize = ::Math.rand(2, _amount);
 				if (numIndicesToRandomize % 2 != 0) numIndicesToRandomize--; // Ensure that we have an even number to randomize

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -31,6 +31,14 @@
 			local levelUpsRemaining = ::Math.max(::Const.XP.MaxLevelWithPerkpoints - this.getLevel() + this.getLevelUps(), 0);
 			local attributeValue = attributeName == "Fatigue" ? baseProperties["Stamina"] : baseProperties[attributeName]; // Thank you Overhype
 
+			if (this.m.Talents[attribute] == 2)
+			{
+				foreach (value in this.m.Attributes[attribute])
+				{
+					attributeValue += value - attributeMax;
+				}
+			}
+
 			ret[attribute] <- [
 				attributeValue + attributeMin * levelUpsRemaining,
 				attributeValue + attributeMax * levelUpsRemaining

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -26,7 +26,7 @@
 
 			local attributeMin = ::Const.AttributesLevelUp[attribute].Min + ::Math.min(this.m.Talents[attribute], 2);
 			local attributeMax = ::Const.AttributesLevelUp[attribute].Max;
-			if (this.m.Talents[attribute] == 2) attributeMax++;
+			if (this.m.Talents[attribute] == 3) attributeMax++;
 
 			local levelUpsRemaining = ::Math.max(::Const.XP.MaxLevelWithPerkpoints - this.getLevel() + this.getLevelUps(), 0);
 			local attributeValue = attributeName == "Fatigue" ? baseProperties["Stamina"] : baseProperties[attributeName]; // Thank you Overhype
@@ -126,13 +126,16 @@
 	{
 		fillAttributeLevelUpValues(_amount, _maxOnly, _minOnly);
 
-		if (_amount < 3) return;
+		if (_amount < 2) return;
 		if (_maxOnly || _minOnly) return;	// Stars do not influence these level-ups
 
 		for (local i = 0; i != ::Const.Attributes.COUNT; i++)
 		{
 			if (this.m.Talents[i] == 2)
 			{
+				local targetValue = ::Math.maxf(::Const.AttributesLevelUp[i].Max * 0.833, ::Const.AttributesLevelUp[i].Max * 1.166);
+				local defaultLevelup = ::Math.round(targetValue / _amount);
+
 				local indices = array(_amount);
 				indices.apply(@(val, idx) idx);
 				local indicesToRandomize = array(::Math.rand(2, _amount));

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -133,11 +133,11 @@
 		{
 			if (this.m.Talents[i] == 2)
 			{
-				local targetValue = ::Math.maxf(::Const.AttributesLevelUp[i].Max * 0.833, ::Const.AttributesLevelUp[i].Max * 1.166);
-				local defaultLevelup = ::Math.round(targetValue / _amount);
-
 				local indices = array(_amount);
-				indices.apply(@(val, idx) idx);
+				foreach (i, _ in indices)
+				{
+					indices[i] = i;
+				}
 				local indicesToRandomize = array(::Math.rand(2, _amount));
 				if (indicesToRandomize.len() % 2 != 0) indicesToRandomize.pop(); // Ensure that we have an even number to randomize
 


### PR DESCRIPTION
Instead of pure randomization. This makes it so that the total attribute change over the course of 10 levels remains the same as vanilla behavior (i.e. equal to a max roll every level). However, it adds randomization to some rolls: the number of rolls with -1 will be equal to the number of rolls with +1.