### PR TITLE
feat: add face warpaint to all bandits from the fast block

### DIFF
--- a/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
@@ -26,6 +26,9 @@ this.rf_bandit_bandit <- this.inherit("scripts/entity/tactical/human", {
 		this.m.CurrentProperties = clone b;
 		this.setAppearance();
 		this.getSprite("socket").setBrush("bust_base_bandits");
+		local tattoo_head = this.actor.getSprite("tattoo_head");
+		tattoo_head.setBrush("warpaint_0" + ::Math.rand(2, 3) + "_head");	// Currently only two variants of warpaint exists, that's why they are hardcoded here
+		tattoo_head.Visible = true;
 		local dirt = this.getSprite("dirt");
 		dirt.Visible = true;
 		dirt.Alpha = ::Math.rand(150, 255);

--- a/scripts/entity/tactical/enemies/rf_bandit_killer.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_killer.nut
@@ -26,6 +26,9 @@ this.rf_bandit_killer <- this.inherit("scripts/entity/tactical/human", {
 		this.m.CurrentProperties = clone b;
 		this.setAppearance();
 		this.getSprite("socket").setBrush("bust_base_bandits");
+		local tattoo_head = this.actor.getSprite("tattoo_head");
+		tattoo_head.setBrush("warpaint_0" + ::Math.rand(2, 3) + "_head");	// Currently only two variants of warpaint exists, that's why they are hardcoded here
+		tattoo_head.Visible = true;
 		local dirt = this.getSprite("dirt");
 		dirt.Visible = true;
 		dirt.Alpha = ::Math.rand(150, 255);

--- a/scripts/entity/tactical/enemies/rf_bandit_robber.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_robber.nut
@@ -26,6 +26,9 @@ this.rf_bandit_robber <- this.inherit("scripts/entity/tactical/human", {
 		this.m.CurrentProperties = clone b;
 		this.setAppearance();
 		this.getSprite("socket").setBrush("bust_base_bandits");
+		local tattoo_head = this.actor.getSprite("tattoo_head");
+		tattoo_head.setBrush("warpaint_0" + ::Math.rand(2, 3) + "_head");	// Currently only two variants of warpaint exists, that's why they are hardcoded here
+		tattoo_head.Visible = true;
 		local dirt = this.getSprite("dirt");
 		dirt.Visible = true;
 		dirt.Alpha = ::Math.rand(150, 255);


### PR DESCRIPTION
This change will make Fast Bandits stand out more during battles.
It can be explained by those types of Brigands usually ambushing others from dark corners. That's why they apply face paint to darken their skin