### PR TITLE
Feat damage based xp system

### DIFF
--- a/mod_reforged/config/config.nut
+++ b/mod_reforged/config/config.nut
@@ -1,5 +1,6 @@
 ::Reforged.Config <- {
 	IsLegendaryDifficulty = true,
 	HiringCostVariance = 0.2,	// Hiring cost for recruits after gear is randomized +- this value. 0.0 = no variance. 0.2 = it varies between 80% and 120% of its original cost
-	HiringCostLuck = 200,	// Luck for rerolling hiring cost. Every 100 luck = 1 reroll. With multiple rerolls present only the closest to the original hiring cost is taken. 0 luck = to linear distribution between min and max
+	HiringCostLuck = 200,	// Luck for rerolling hiring cost. Every 100 luck = 1 reroll. With multiple rerolls present only the closest to the original hiring cost is taken. 0 luck = to linear distribution between min and max,
+	XPOverride = false, // Is set to true during actor.onActorKilled to prevent any xp gain via player.getXP function. Then set to false afterwards. This is to do our own override of XP gain system based on damage dealt ratios.
 }

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -184,6 +184,30 @@
 
 	q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )
 	{
+		if ((::Const.Faction.Player in this.m.RF_DamageReceived) && this.m.RF_DamageReceived[::Const.Faction.Player].Total / this.m.RF_DamageReceived.Total >= 0.5)
+		{
+			// If player faction did at least 50% of total damage to this actor,
+			// we award the kill to the bro who did the most damage (for the purposes of loot drop)
+			// Note: This may have unintended consequences if someone expects `_killer` to be the actual killer.
+			local max = 0;
+			local killer;
+			foreach (broID, damage in this.m.RF_DamageReceived[::Const.Faction.Player])
+			{
+				if (broID == "Total") continue;
+				if (damage > max)
+				{
+					local entity = ::Tactical.getEntityByID(id);
+					if (entity != null && entity.isAlive())
+					{
+						max = damage;
+						killer = entity;
+					}
+				}
+			}
+			if (killer != null)
+				_killer = killer;
+		}
+
 		__original(_killer, _skill, _tile, _fatalityType);
 
 		// The following is an override of the XP gain system. We award XP based on ratio of total damage dealt to an entity.

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -16,6 +16,9 @@
 
 	q.addXP = @(__original) function( _xp, _scale = true )
 	{
+		if (::Reforged.Config.XPOverride)
+			return;
+
 		while (this.m.Level >= ::Const.LevelXP.len())
 		{
 			::Const.LevelXP.push(::Const.LevelXP.top() + 4000 + 1000 * (::Const.LevelXP.len() - 11));

--- a/mod_reforged/hooks/skills/skill_container.nut
+++ b/mod_reforged/hooks/skills/skill_container.nut
@@ -1,0 +1,22 @@
+::Reforged.HooksMod.hook("scripts/skills/skill_container", function(q) {
+	q.onDamageReceived = @(__original) function( _attacker, _damageHitpoints, _damageArmor )
+	{
+		local damage = _damageArmor + ::Math.min(_damageHitpoints, this.getActor().getHitpoints());
+
+		__original(_attacker, _damageHitpoints, _damageArmor);
+
+		if (_attacker != null)
+		{
+			// We store the damage done by the attacker. This is used to
+			// calculate XP distribution when this actor dies.
+			local t = this.getActor().m.RF_DamageReceived;
+
+			if (!(_attacker.getFaction() in t)) t[_attacker.getFaction()] <- { Total = 0.0 };
+			if (!(_attacker.getID() in t[_attacker.getFaction()])) t[_attacker.getFaction()][_attacker.getID()] <- 0.0;
+
+			t.Total += damage;
+			t[_attacker.getFaction()].Total += damage;
+			t[_attacker.getFaction()][_attacker.getID()] += damage;
+		}
+	}
+});


### PR DESCRIPTION
I have left many `logInfo` in the code for now so you can test the PR on your own if you want. These should be removed before merging.

- XP is now awarded based on the percentage of total damage dealt to an entity.
- Loot should now drop if the player faction did at least 50% of damage. But this is implemented in a hacky way, and we should really think this through if we want to do it like this, or if there is a better solution.

![XP sharing](https://cdn.discordapp.com/attachments/996543320320921722/1161168642038308914/image.png?ex=65375191&is=6524dc91&hm=3d73e333ef48ef2acd393649ca4183df6a7cca99c8e19d6954883c2778c23cce&)