### PR TITLE
feat: allow leveling up indefinitely

### DIFF
--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -14,6 +14,16 @@
 		this.getSkills().add(::new("scripts/skills/special/rf_veteran_levels"));
 	}
 
+	q.addXP = @(__original) function( _xp, _scale = true )
+	{
+		while (this.m.Level >= ::Const.LevelXP.len())
+		{
+			::Const.LevelXP.push(::Const.LevelXP.top() + 4000 + 1000 * (::Const.LevelXP.len() - 11));
+		}
+
+		return __original(_xp, _scale);
+	}
+
 	q.getProjectedAttributes <- function()
 	{
 		local baseProperties = this.getBaseProperties();


### PR DESCRIPTION
In vanilla the `::Const.LevelXP` array has a length of 33 and the `addXP` function does an early return if the character's level is equal to or greater than its length. This means that characters stop gaining XP at level 33. In this hook we expand the array as necessary when the level value reaches its length. The calculation used for adding the XP requirement is taken from the vanilla calculation.