### PR TITLE
refactor: add an offset for location banner to prevent an overlap

### DIFF
--- a/mod_reforged/config/config.nut
+++ b/mod_reforged/config/config.nut
@@ -3,4 +3,8 @@
 	HiringCostVariance = 0.2,	// Hiring cost for recruits after gear is randomized +- this value. 0.0 = no variance. 0.2 = it varies between 80% and 120% of its original cost
 	HiringCostLuck = 200,	// Luck for rerolling hiring cost. Every 100 luck = 1 reroll. With multiple rerolls present only the closest to the original hiring cost is taken. 0 luck = to linear distribution between min and max,
 	XPOverride = false, // Is set to true during actor.onActorKilled to prevent any xp gain via player.getXP function. Then set to false afterwards. This is to do our own override of XP gain system based on damage dealt ratios.
+
+	UI = {
+		WorldBannerYOffset = 50
+	}
 }

--- a/mod_reforged/hooks/entity/world/location.nut
+++ b/mod_reforged/hooks/entity/world/location.nut
@@ -1,7 +1,28 @@
 ::Reforged.HooksMod.hook("scripts/entity/world/location", function(q) {
+	q.setBanner = @(__original) function( _banner )
+	{
+		__original(_banner);
+		this.adjustBannerOffset();
+	}
+
+	q.onAfterInit = @(__original) function()
+	{
+		__original();
+		this.adjustBannerOffset();
+	}
+
 	q.onLeave = @(__original) function()
 	{
 		__original();
 		::World.State.setPause(true);
+	}
+
+// New Functions
+	q.adjustBannerOffset <- function()	// This has to be called everytime that a brush for the banner sprite is set because that will reset the previous offset
+	{
+		if (this.hasSprite("location_banner"))
+		{
+			this.getSprite("location_banner").setOffset(::createVec(0, ::Reforged.Config.UI.WorldBannerYOffset));
+		}
 	}
 });

--- a/mod_reforged/hooks/entity/world/settlement.nut
+++ b/mod_reforged/hooks/entity/world/settlement.nut
@@ -1,4 +1,16 @@
 ::Reforged.HooksMod.hook("scripts/entity/world/settlement", function(q) {
+	q.setOwner = @(__original) function( _owner )
+	{
+		__original(_owner);
+		this.adjustBannerOffset();
+	}
+
+	q.setActive = @(__original) function( _a, _burn = true )
+	{
+		__original(_a, _burn);
+		this.adjustBannerOffset();
+	}
+
 	q.onUpdateShopList = @(__original) function( _id, _list )
 	{
 		switch (_id)


### PR DESCRIPTION
This change was meant to affect all locations but during my tests only settlements were affected. But that is not even bad because the Settlements were the most important ones to fix anyways.

I haven't tested this exact implementation yet. 
The test I showed you didn't utilize a central `adjustBannerOffset` and wasn't based on Modern Hooks.