### PR TITLE
refactor: improve description of nimble and poise

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -525,12 +525,10 @@ local vanillaDescriptions = [
  				Description = [
  					"Damage to [Hitpoints|Concept.Hitpoints] is reduced by " + ::MSU.Text.colorGreen("50%") + " and that to armor by " + ::MSU.Text.colorGreen("25%") + ".",
  					"The bonus drops exponentially when wearing head and body armor with a total penalty to [Maximum Fatigue|Concept.MaximumFatigue] above 15. The lighter your armor and helmet, the more you benefit.",
- 					"Does not affect damage from mental attacks or status effects, but can help to avoid receiving them.",
- 					"[Brawny|Perk+perk_brawny] does not affect this perk.",
- 					"Cannot be picked if you have [Poise|Perk+perk_rf_poise]."
-
+ 					"Does not affect damage from mental attacks or status effects."
  				]
- 			}]
+ 			}],
+			Footer = ::MSU.Text.colorRed("Cannot be picked if you have [Poise|Perk+perk_rf_poise].")
 	 	}),
 	},
 	{
@@ -1310,11 +1308,10 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Type = ::UPD.EffectType.Passive,
 			Description = [
 				"Damage to [Hitpoints|Concept.Hitpoints] is reduced by " + ::MSU.Text.colorRed("30%") + " and to Armor by " + ::MSU.Text.colorRed("20%") + ".",
-				"The bonus drops exponentially when wearing head and body armor with a total penalty to [Maximum Fatigue|Concept.MaximumFatigue] above 35.",
-				"[Brawny|Perk+perk_brawny] does not affect this perk.",
-				"Cannot be picked if you have [Nimble|Perk+perk_nimble]."
+				"The bonus drops exponentially when wearing head and body armor with a total penalty to [Maximum Fatigue|Concept.MaximumFatigue] above 35."
 			]
-		}]
+		}],
+		Footer = ::MSU.Text.colorRed("Cannot be picked if you have [Nimble|Perk+perk_nimble].")
  	}),
 	RF_LongReach = ::UPD.getDescription({
  		Fluff = "\'If the target is watchin\' the head of yer pike, they\'re sure not watchin\' their back!\'",


### PR DESCRIPTION
The line about Brawny is already flawed when we also have Wears it Well that does the same effect. It's an artifact from Vanilla.
And with the "Weight Rework" it will be more redundant.

### This is how the perk descriptions look now:

![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/79a92ea7-1e99-4f1d-a786-1111136288c8)

![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/e0740c09-25d0-4733-b958-e842d8696f5a)
