### PR TITLE
Attribute bleed damage to last attacker when bleed was applied

### DIFF
--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -2,6 +2,7 @@
 	q.m.IsPerformingAttackOfOpportunity <- false;
 	q.m.IsWaitingTurn <- false;		// Is only set true when using the new Wait-All button. While true this entity will try to use Wait when its their turn
 	q.m.RF_DamageReceived <- null; // Table with faction number as key and tables as values. These tables have actor ID as key and the damage dealt as their value. Is populated during skill_container.onDamageReceived
+	q.m.LastAttacker <- null; // Set during this.onAttacked and used in places such as bleeding_effect to determine attacker
 
 	q.isDisarmed <- function()
 	{
@@ -42,6 +43,11 @@
 				this.m.ExcludedInjuries.extend(::Const.Injury.ExcludedInjuries.get(::Const.Injury.ExcludedInjuries.RF_Undead));
 			}
 		}
+	}
+
+	q.onAttacked = @(__original) function( _attacker )
+	{
+		this.m.LastAttacker = ::MSU.asWeakTableRef(_attacker);
 	}
 
 	q.onAttackOfOpportunity = @(__original) function( _entity, _isOnEnter )

--- a/mod_reforged/hooks/skills/effects/bleeding_effect.nut
+++ b/mod_reforged/hooks/skills/effects/bleeding_effect.nut
@@ -1,0 +1,44 @@
+::Reforged.HooksMod.hook("scripts/skills/effects/bleeding_effect", function(q) {
+	q.m.Attacker <- null;
+
+	q.onAdded = @(__original) function()
+	{
+		__original();
+		if (!this.isGarbage())
+		{
+			this.m.Attacker = this.getContainer().getActor().getLastAttacker();
+		}
+	}
+
+	q.applyDamage = @() function()
+	{
+		if (this.m.LastRoundApplied != ::Time.getRound())
+		{
+			this.m.LastRoundApplied = ::Time.getRound();
+			local actor = this.getContainer().getActor();
+			this.spawnIcon("status_effect_01", actor.getTile());
+			local hitInfo = clone ::Const.Tactical.HitInfo;
+			hitInfo.DamageRegular = this.m.Damage * (actor.getSkills().hasSkill("effects.hyena_potion") ? 0.5 : 1.0);
+			hitInfo.DamageDirect = 1.0;
+			hitInfo.BodyPart = ::Const.BodyPart.Body;
+			hitInfo.BodyDamageMult = 1.0;
+			hitInfo.FatalityChanceMult = 0.0;
+			actor.onDamageReceived(this.getAttacker(), this, hitInfo);
+
+			if (--this.m.TurnsLeft <= 0)
+			{
+				this.removeSelf();
+			}
+		}
+	}
+
+	q.getAttacker <- function()
+	{
+		if (!::MSU.isNull(this.m.Attacker) && this.m.Attacker.isAlive() && this.m.Attacker.isPlacedOnMap())
+		{
+			return this.m.Attacker;
+		}
+
+		return this.getContainer().getActor();
+	}
+});


### PR DESCRIPTION
This ensures that the "bleeding_effect", no matter applied by which skill (as long as the skill is an attack), always keeps track of the attacker and attributes the bleeding damage to that attacker.

This is important for the damage-based XP system we now use in Reforged.