### PR TITLE
feat: implement new stun threshold system

### DIFF
--- a/mod_reforged/config/poise.nut
+++ b/mod_reforged/config/poise.nut
@@ -1,0 +1,13 @@
+::Reforged.Poise <- {
+	Default = {
+		Default = 100,	// Any entity that doesn't define a PoiseValue will get this assigned
+
+		Goblin = 60,
+		Human = 100,
+		Orc = 150,
+
+		Beast = 100,	// Direwolf, Hyena, Snake, Ghoul
+		Unhold = 300,
+		Lindwurm = 450,
+	}
+}

--- a/mod_reforged/config/z_nested_tooltips.nut
+++ b/mod_reforged/config/z_nested_tooltips.nut
@@ -12,8 +12,20 @@ local dummyItemContainer = ::new("scripts/items/item_container");
 	Tooltips = {
 		Concept = {
 			Wait = ::MSU.Class.BasicTooltip("Wait", ::Reforged.Mod.Tooltips.parseString(format("If you are not the last character in the [turn order|Concept.Turn] in a [round|Concept.Round], you may use the Wait action. This moves you to the end of the current [turn order|Concept.Turn], allowing you to act again before the end of the [round|Concept.Round].\n\nYou can only use Wait once per [turn|Concept.Turn].%s", ::Const.CharacterProperties.InitiativeAfterWaitMult == 1.0 ? "" : "\n\nUsing Wait causes your [turn order|Concept.Turn] in the next [round|Concept.Round] to be calculated with " + ::MSU.Text.colorizeMult(::Const.CharacterProperties.InitiativeAfterWaitMult) + " " + (::Const.CharacterProperties.InitiativeAfterWaitMult > 1.0 ? "more" : "less") + " [Initiative|Concept.Initiative]."))),
+			Poise = ::MSU.Class.BasicTooltip(
+				"Poise",
+				::Reforged.Mod.Tooltips.parseString("Poise depicts how well an entity resists stuns. It is reduced by [stunning attacks|Concept.StunningAttack] and some other skills which can damage Poise. At the start of an entities turn or whenever its Poise reaches 0, it is reset to the maximum value.")
+			),
 			Perk = ::MSU.Class.BasicTooltip("Perk", ::Reforged.Mod.Tooltips.parseString("As characters gain levels, they unlock perk points which can be spent to unlock powerful perks. Perks grant a character permanent bonuses or unlock new skills for use. The character\'s current [perk tier|Concept.PerkTier] increases by 1 each time a perk point is spent.")),
 			StatusEffect = ::MSU.Class.BasicTooltip("Status Effect", ::Reforged.Mod.Tooltips.parseString("Status effects are positive or negative effects on a character, which are mostly temporary. A status effect can have various effects ranging from increasing/decreasing [attributes|Concept.CharacterAttribute] to unlocking new abilities.")),
+			PoiseDamage = ::MSU.Class.BasicTooltip(
+				"Poise Damage",
+				::Reforged.Mod.Tooltips.parseString("Poise Damage is granted by certain weapons and improved by various skills. It determines how well [stunning attacks|Concept.StunningAttack] perform.")
+			),
+			StunningAttack = ::MSU.Class.BasicTooltip(
+				"Stunning Attack",
+				::Reforged.Mod.Tooltips.parseString("A Stunning Attack subtracts the [Poise Damage|Concept.PoiseDamage] for this attack from the targets [Poise|Concept.Poise] on a hit. If it reduces the targets [Poise|Concept.Poise] to 0 or below, the target will be stunned. Does not affect enemies who are immune to stuns.")
+			),
 			Injury = ::MSU.Class.BasicTooltip("Injury", ::Reforged.Mod.Tooltips.parseString("If sufficient damage is dealt to [Hitpoints|Concept.Hitpoints] during combat, characters can sustain an injury. Injuries are [status effects|Concept.StatusEffect] that confer various maluses.\n\nInjuries sustained during combat are [temporary|Concept.InjuryTemporary], and will heal over time. Such injuries can be treated at a Temple for faster healing.\n\nIf a character is killed during combat, they have a chance to be struck down instead of being killed and survive the battle with a [permanent injury|Concept.InjuryPermanent]"))
 			InjuryTemporary = ::MSU.Class.BasicTooltip("Temporary Injury", ::Reforged.Mod.Tooltips.parseString("Temporary injuries are received during combat when the damage to [Hitpoints|Concept.Hitpoints] received by a character exceeds the injury threshold. These injuries heal over time, but can be treated at a Temple for faster healing."))
 			InjuryPermanent = ::MSU.Class.BasicTooltip("Permanent Injury", ::Reforged.Mod.Tooltips.parseString("Permanent injuries are received when a character is \'struck down\' during combat instead of being killed. These injuries, and the maluses they incur, are forever.")),

--- a/mod_reforged/hooks/config/character.nut
+++ b/mod_reforged/hooks/config/character.nut
@@ -25,6 +25,21 @@ local getClone = ::Const.CharacterProperties.getClone;
 ::Const.CharacterProperties.OffensiveReachIgnore <- 0;
 ::Const.CharacterProperties.BonusPerReachAdvantage <- 0;
 
+::Const.CharacterProperties.IsImmuneToStunFromPoise <- false;
+::Const.CharacterProperties.PoiseMax <- 100;
+::Const.CharacterProperties.PoiseMult <- 1.0;
+::Const.CharacterProperties.getPoiseMax <- function()
+{
+	return ::Math.floor(this.PoiseMax * this.PoiseMult);
+}
+::Const.CharacterProperties.PoiseDamage <- 0.0;		// Only weapons are meant to provide and set this value
+::Const.CharacterProperties.PoiseDamageMult <- 1.0;
+::Const.CharacterProperties.getPoiseDamage <- function()
+{
+	return ::Math.floor(this.PoiseDamage * this.PoiseDamageMult);
+}
+
+
 ::Const.ProjectileType.FlamingArrow <- ::Const.ProjectileType.COUNT;
 ::Const.ProjectileType.COUNT += 1;
 ::Const.ProjectileDecals.push(clone ::Const.ProjectileDecals[::Const.ProjectileType.Arrow]);

--- a/mod_reforged/hooks/config/character.nut
+++ b/mod_reforged/hooks/config/character.nut
@@ -26,7 +26,7 @@ local getClone = ::Const.CharacterProperties.getClone;
 ::Const.CharacterProperties.BonusPerReachAdvantage <- 0;
 
 ::Const.CharacterProperties.IsImmuneToStunFromPoise <- false;
-::Const.CharacterProperties.PoiseMax <- 100;
+::Const.CharacterProperties.PoiseMax <- ::Reforged.Poise.Default.Default;
 ::Const.CharacterProperties.PoiseMult <- 1.0;
 ::Const.CharacterProperties.getPoiseMax <- function()
 {

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -293,6 +293,22 @@ local vanillaDescriptions = [
 	 	}),
 	},
 	{
+		ID = "perk.mastery.mace",
+		Key = "SpecMace",
+		Description = ::UPD.getDescription({
+			Fluff = "Master maces to beat your opponents into submission, armored or not.",
+			Requirement = "Mace",
+	 		Effects = [{
+ 				Type = ::UPD.EffectType.Passive,
+ 				Description = [
+					"Skills build up " + ::MSU.Text.colorGreen("25%") + " less Fatigue.",
+					"[Poise Damage|Concept.PoiseDamage] is increased by 50% while wielding a mace.",
+					"The Polemace no longer has a penalty for attacking targets directly adjacent.",
+				],
+ 			}],
+	 	}),
+	},
+	{
 		ID = "perk.adrenaline",
 		Key = "Adrenaline",
 		Description = ::UPD.getDescription({
@@ -417,6 +433,21 @@ local vanillaDescriptions = [
  			}],
  			Footer = ::MSU.Text.colorRed("This perk ONLY works with melee attacks that have a Base Maximum Range of 1 tile, with the exception of [Lunge|Skill+lunge_skill].")
 	 	})
+	},
+	{
+		ID = "perk.hold_out",
+		Key = "HoldOut",	// Current name is 'Resilient'
+		Description = ::UPD.getDescription({
+			Fluff = "Keep it together!",
+	 		Effects = [{
+ 				Type = ::UPD.EffectType.Passive,
+ 				Description = [
+					"[Poise|Concept.Poise] is increased by " + ::MSU.Text.colorGreen("50%"),
+					"Any negative status effect with a finite duration (e.g. Bleeding, Charmed) has its duration reduced to " + ::MSU.Text.colorGreen(1) + " turn.",
+					"Status effects that have their effects grow weaker over several turns (e.g. Goblin Poison) are at their weakest state from the start."
+				]
+ 			}]
+	 	}),
 	},
 	{
 		ID = "perk.indomitable",
@@ -746,7 +777,6 @@ local vanillaDescriptions = [
  					"When attacking a target against whom you have a [Reach Disadvantage|Concept.ReachAdvantage], reduce this disadvantage by " + ::MSU.Text.colorGreen(1) + " if your [Initiative|Concept.Initiative] is higher than that of your target."
  					"[Brawny|Perk+perk_brawny] does not affect this perk.",
  					"Cannot be picked if you have [Poise|Perk+perk_rf_poise]."
-
  				]
  			}]
 	 	}),
@@ -826,8 +856,9 @@ local vanillaDescriptions = [
 	 		Effects = [{
  				Type = ::UPD.EffectType.Passive,
  				Description = [
- 					"Hits to the head no longer cause critical damage to this character, which also lowers the risk of sustaining debilitating head [injuries|Concept.Injury] significantly."
- 					"Grants passive immunity against [Cull|Perk+perk_rf_cull]."
+ 					"Hits to the head no longer cause critical damage to this character, which also lowers the risk of sustaining debilitating head [injuries|Concept.Injury] significantly.",
+ 					"Hits to the head no longer cause this character to take increased Poise Damage.",
+ 					"Grants passive immunity against [Cull|Perk+perk_rf_cull].",
  				]
  			}]
 	 	}),
@@ -2263,9 +2294,10 @@ foreach (vanillaDesc in vanillaDescriptions)
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"At the end of your [turn|Concept.Turn], gain " + ::MSU.Text.colorGreen("half") + " of your remaining [Action Points|Concept.ActionPoints], rounded down, as additional [Action Points|Concept.ActionPoints] during your next [turn|Concept.Turn]."
-			]
-		}]
+				"At the end of your [turn|Concept.Turn], gain " + ::MSU.Text.colorGreen("half") + " of your remaining [Action Points|Concept.ActionPoints], rounded down, as additional [Action Points|Concept.ActionPoints] during your next [turn|Concept.Turn].",
+				"At the end of your [turn|Concept.Turn], gain " + ::MSU.Text.colorGreen("+10") + " Poise for every unspent [Action Point|Concept.ActionPoints] until the start of your next [turn|Concept.Turn].",
+			],
+		}],
  	}),
 	RF_VigorousAssault = ::UPD.getDescription({
  		Fluff = "You\'ve learned to use the very momentum of your movement as a weapon unto itself!",

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -23,6 +23,7 @@
 		this.getSkills().add(::new("scripts/skills/special/rf_reach"));
 		this.getSkills().add(::new("scripts/skills/special/rf_formidable_approach_manager"));
 		this.getSkills().add(::new("scripts/skills/special/rf_direct_damage_limiter"));
+		this.getSkills().add(::new("scripts/skills/special/rf_poise_effect"));
 		this.getSkills().add(::new("scripts/skills/special/rf_polearm_adjacency"));
 		this.getSkills().add(::new("scripts/skills/special/rf_follow_up_proccer"));
 		this.getSkills().add(::new("scripts/skills/special/rf_inspiring_presence_buff_effect"));
@@ -245,6 +246,13 @@
 		::Reforged.Config.XPOverride = true;
 		__original(_actor, _tile, _skill);
 		::Reforged.Config.XPOverride = wasOverriding;
+	}
+
+	// When entities are permanently stun immune then they should probably also be immune from poise stuns.
+	q.onInit = @(__original) function()
+	{
+		__original();
+		this.m.BaseProperties.IsImmuneToStunFromPoise = this.m.BaseProperties.IsImmuneToStun;
 	}
 
 	q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -1,6 +1,8 @@
 ::Reforged.HooksMod.hook("scripts/entity/tactical/actor", function(q) {
+	// Private
 	q.m.IsWaitingTurn <- false;		// Is only set true when using the new Wait-All button. While true this entity will try to use Wait when its their turn
 	q.m.RF_DamageReceived <- null; // Table with faction number as key and tables as values. These tables have actor ID as key and the damage dealt as their value. Is populated during skill_container.onDamageReceived
+	q.m.InversePoise <- 0;			// This is the inverse of Poise and counts upwards instead of downwards as Poise damage is received
 
 	q.isDisarmed <- function()
 	{
@@ -221,6 +223,28 @@
 	}
 
 // New Functions:
+/*
+Internally we calculate the current threshold inversely. That makes it much cleaner in code to handle increases and reduction of PoiseMax.
+Our intended behavior is that a change in PoiseMax also changes the Poise of that character by the same amount:
+
+The PoiseMax is purely handled in the Properties while the current Poise is handled in this skill.
+It is much cleaner when a change to PoiseMax can solely focus on changing variables in Properties.
+*/
+	q.getPoise <- function()
+	{
+		return this.getCurrentProperties().getPoiseMax() - this.m.InversePoise;
+	}
+
+	q.addPoise <- function( _additionalPoise )
+	{
+		this.m.InversePoise -= _additionalPoise;
+	}
+
+	q.resetPoise <- function()
+	{
+		this.m.InversePoise = 0;
+	}
+
 	q.getSurroundedBonus <- function( _targetEntity )
 	{
 		local surroundedCount = _targetEntity.getSurroundedCount();

--- a/mod_reforged/hooks/entity/tactical/enemies/direwolf.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/direwolf.nut
@@ -45,6 +45,7 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastMedium;
+		this.m.BaseProperties.PoiseMax = ::Reforged.Poise.Default.Beast;
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_backstabber"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_battle_flow"));
 		this.m.Skills.add(::MSU.new("scripts/skills/perks/perk_rf_from_all_sides", function(o) {

--- a/mod_reforged/hooks/entity/tactical/enemies/ghoul.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/ghoul.nut
@@ -38,6 +38,7 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastSmall + 1;
+		this.m.BaseProperties.PoiseMax = ::Reforged.Poise.Default.Beast;
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_colossus"));
 		this.m.Skills.add(this.new("scripts/skills/perks/perk_rf_deep_cuts"));
 	}

--- a/mod_reforged/hooks/entity/tactical/enemies/hyena.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/hyena.nut
@@ -44,6 +44,7 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastMedium - 1;
+		this.m.BaseProperties.PoiseMax = ::Reforged.Poise.Default.Beast;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_sundering_strikes"));
 	}
 

--- a/mod_reforged/hooks/entity/tactical/enemies/lindwurm.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/lindwurm.nut
@@ -97,6 +97,7 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastHuge + 2;
+		this.m.BaseProperties.PoiseMax = ::Reforged.Poise.Default.Lindwurm;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_survival_instinct"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_menacing"));
 	}

--- a/mod_reforged/hooks/entity/tactical/enemies/serpent.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/serpent.nut
@@ -61,6 +61,7 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastLarge;
+		this.m.BaseProperties.PoiseMax = ::Reforged.Poise.Default.Beast;
 		this.m.BaseProperties.MeleeDefense = 15;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_backstabber"));
 		this.m.Skills.add(::MSU.new("scripts/skills/perks/perk_rf_from_all_sides", function(o) {

--- a/mod_reforged/hooks/entity/tactical/goblin.nut
+++ b/mod_reforged/hooks/entity/tactical/goblin.nut
@@ -49,6 +49,7 @@
 		// Reforged
 		b.RangedDefense += 10;
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.Goblin;
+		this.m.BaseProperties.PoiseMax = ::Reforged.Poise.Default.Goblin;
 
 		this.m.Skills.add(::new("scripts/skills/perks/perk_footwork"));
 	}

--- a/mod_reforged/hooks/entity/tactical/human.nut
+++ b/mod_reforged/hooks/entity/tactical/human.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.Human;
+		this.m.BaseProperties.PoiseMax = ::Reforged.Poise.Default.Human;
 		this.m.Skills.add(::new("scripts/skills/actives/recover_skill"));
 	}
 });

--- a/mod_reforged/hooks/items/weapons/barbarians/claw_club.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/claw_club.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 80;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/barbarians/two_handed_spiked_mace.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/two_handed_spiked_mace.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 5;
+		this.m.PoiseDamage = 160;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/bludgeon.nut
+++ b/mod_reforged/hooks/items/weapons/bludgeon.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 80;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/goedendag.nut
+++ b/mod_reforged/hooks/items/weapons/goedendag.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 5;
+		this.m.PoiseDamage = 120;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/greenskins/goblin_staff.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/goblin_staff.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 4;
+		this.m.PoiseDamage = 80;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/greenskins/orc_flail_2h.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/orc_flail_2h.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 5;
+		this.m.PoiseDamage = 40;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/greenskins/orc_metal_club.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/orc_metal_club.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 120;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/greenskins/orc_wooden_club.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/orc_wooden_club.nut
@@ -3,5 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 120;
 	}
 });

--- a/mod_reforged/hooks/items/weapons/morning_star.nut
+++ b/mod_reforged/hooks/items/weapons/morning_star.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 80;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/oriental/heavy_southern_mace.nut
+++ b/mod_reforged/hooks/items/weapons/oriental/heavy_southern_mace.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 80;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/oriental/light_southern_mace.nut
+++ b/mod_reforged/hooks/items/weapons/oriental/light_southern_mace.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 80;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/oriental/nomad_mace.nut
+++ b/mod_reforged/hooks/items/weapons/oriental/nomad_mace.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 80;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/oriental/polemace.nut
+++ b/mod_reforged/hooks/items/weapons/oriental/polemace.nut
@@ -3,5 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 6;
+		this.m.PoiseDamage = 120;
 	}
 });

--- a/mod_reforged/hooks/items/weapons/two_handed_flail.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_flail.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 5;
+		this.m.PoiseDamage = 40;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/two_handed_flanged_mace.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_flanged_mace.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 5;
+		this.m.PoiseDamage = 160;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/two_handed_mace.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_mace.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 5;
+		this.m.PoiseDamage = 160;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/two_handed_wooden_flail.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_wooden_flail.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 5;
+		this.m.PoiseDamage = 40;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -1,5 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/items/weapons/weapon", function(q) {
 	q.m.Reach <- 1;
+	q.m.PoiseDamage <- 0;
 
 	q.getTooltip = @(__original) function()
 	{
@@ -12,6 +13,16 @@
 				type = "text",
 				icon = "ui/icons/reach.png",
 				text = "Has a reach of " + this.m.Reach
+			});
+		}
+
+		if (this.getPoiseDamage() != 0)
+		{
+			tooltip.push({
+				id = 21,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("[Poise Damage|Concept.PoiseDamage]: " + this.getPoiseDamage()),
 			});
 		}
 
@@ -77,14 +88,25 @@
 	q.onUpdateProperties = @(__original) function( _properties )
 	{
 		__original(_properties);
-		if (this.isItemType(::Const.Items.ItemType.MeleeWeapon) && !this.getContainer().getActor().isDisarmed())
+		if (!this.getContainer().getActor().isDisarmed())
 		{
-			_properties.Reach += this.m.Reach;
+			_properties.PoiseDamage += this.getPoiseDamage();
+
+			if (this.isItemType(::Const.Items.ItemType.MeleeWeapon))
+			{
+				_properties.Reach += this.m.Reach;
+			}
 		}
 	}
 
+// New Functions
 	q.getReach <- function()
 	{
 		return this.m.Reach;
+	}
+
+	q.getPoiseDamage <- function()
+	{
+		return this.m.PoiseDamage;
 	}
 });

--- a/mod_reforged/hooks/items/weapons/winged_mace.nut
+++ b/mod_reforged/hooks/items/weapons/winged_mace.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 80;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/wooden_stick.nut
+++ b/mod_reforged/hooks/items/weapons/wooden_stick.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 3;
+		this.m.PoiseDamage = 80;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/msu.nut
+++ b/mod_reforged/hooks/msu.nut
@@ -197,7 +197,8 @@
 			RangeIdeal = baseWeapon.m.RangeIdeal,
 
 			// Reforged stuff -- should be removed when porting to MSU
-			Reach = baseWeapon.m.Reach
+			Reach = baseWeapon.m.Reach,
+			PoiseDamage = baseWeapon.m.PoiseDamage,
 		};
 	}
 

--- a/mod_reforged/hooks/skills/actives/charge.nut
+++ b/mod_reforged/hooks/skills/actives/charge.nut
@@ -1,0 +1,141 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/charge", function(q) {
+	q.m.BasePoiseDamage <- 100;
+	q.m.MaxHeightDifference <- 1;
+
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.IsDamagingPoise = true;		// Just for the tooltip
+		this.m.IsStunningFromPoise = true;	// Just for the tooltip
+	}
+
+	// This is just so that the tooltip will display the correct poise damage
+	q.onAnySkillUsed = @() function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+		if (_skill == this)
+		{
+			_properties.PoiseDamage = this.m.BasePoiseDamage;
+		}
+	}
+
+	// Full rewrite as too many things of the original changed
+	q.onTeleportDone = @() function( _user, _tag )
+	{
+		local myTile = _user.getTile();
+		local potentialVictims = [];
+		local dirToTarget = _tag.OldTile.getDirectionTo(myTile);
+
+		// Look for potential targets
+		for (local i = 0; i != 6; i++)
+		{
+			if (!myTile.hasNextTile(i)) continue;
+
+			local tile = myTile.getNextTile(i);
+			if (!tile.IsOccupiedByActor) continue;
+			if (::Math.abs(tile.Level - myTile.Level) < this.m.MaxHeightDifference) continue;	// This is new. Charges will now ignore enemies that are too high/low
+
+			local actor = myTile.getNextTile(i).getEntity();
+			if (actor.isAlliedWith(_user) || actor.getCurrentProperties().IsStunned) continue;
+
+			potentialVictims.push(actor);
+		}
+
+		// Potentially repel this attack? Currently only by spearwall
+		foreach (actor in potentialVictims)
+		{
+			if (this.handlePotentialRepel(_tag, _user, actor) == true) return;	// If any of the victims repel this attack it is ended early
+		}
+
+		if (_tag.OldTile.IsVisibleForPlayer || myTile.IsVisibleForPlayer)
+		{
+			::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " charges");
+		}
+
+		if (potentialVictims.len() != 0)
+		{
+			this.applyEffectToTarget(_user, ::MSU.Array.rand(potentialVictims));
+		}
+	}
+
+// New Functions
+	// Returns true if the charge was repelled or failed otherwise; returns false otherwise
+	q.handlePotentialRepel <- function( _tag, _myself, _targetEntity )
+	{
+		if (_targetEntity.onMovementInZoneOfControl(_myself, true) && _targetEntity.onAttackOfOpportunity(_myself, true))
+		{
+			if (_tag.OldTile.IsVisibleForPlayer || myTile.IsVisibleForPlayer)
+			{
+				::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_myself) + " charges and is repelled");
+			}
+
+			if (!_myself.isAlive() || _myself.isDying()) return true;
+
+			local dir = myTile.getDirectionTo(_tag.OldTile);
+			if (myTile.hasNextTile(dir))
+			{
+				local tile = myTile.getNextTile(dir);
+
+				if (tile.IsEmpty && ::Math.abs(tile.Level - myTile.Level) <= 1 && tile.getDistanceTo(_targetEntity.getTile()) > 1)
+				{
+					_tag.TargetTile = tile;
+					::Time.scheduleEvent(::TimeUnit.Virtual, 50, _tag.OnRepelled, _tag);
+					return true;
+				}
+			}
+
+			for (local i = 0; i != 6; i++)
+			{
+				if (!myTile.hasNextTile(i)) continue;
+
+				local tile = myTile.getNextTile(i);
+				if (tile.IsEmpty && ::Math.abs(tile.Level - myTile.Level) <= 1)
+				{
+					if (tile.getZoneOfControlCountOtherThan(_myself.getAlliedFactions()) != 0) continue;
+
+					_tag.TargetTile = tile;
+					::Time.scheduleEvent(::TimeUnit.Virtual, 50, _tag.OnRepelled, _tag);
+					return true;
+				}
+			}
+
+			_tag.TargetTile = _tag.OldTile;
+			::Time.scheduleEvent(::TimeUnit.Virtual, 50, _tag.OnRepelled, _tag);
+			return true;
+		}
+
+		return false;
+	}
+
+	// Applies the appropriate effect to the target that was chosen. This is similar to the unstoppable_charge_skill function
+	q.applyEffectToTarget <- function( _user, _target )
+	{
+		if (!_target.isHiddenToPlayer())
+		{
+			// Sound is no longer played if the target is hidden to the player
+			if (_tag.Skill.m.SoundOnHit.len() != 0)
+			{
+				::Sound.play(::MSU.Array.rand(_tag.Skill.m.SoundOnHit), ::Const.Sound.Volume.Skill, _target.getPos());
+			}
+
+			local layers = ::Const.ShakeCharacterLayers[::Const.BodyPart.Body];
+			::Tactical.getShaker().shake(_target, _user.getTile(), 2);
+		}
+
+		// Apply effect to _target
+		local targetPoiseSkill = _target.getSkills().getSkillByID("effects.poise");
+		local inflictedPoiseDamage = this.m.BasePoiseDamage * _user.getCurrentProperties().PoiseDamageMult;
+		local turnsStunned = targetPoiseSkill.onPoiseDamageReceived(_user, _tag.Skill, inflictedPoiseDamage);
+
+		// Apply dazed to the _target if it wasn't stunned - this is new
+		if (turnsStunned == 0 && !_target.getCurrentProperties().IsImmuneToDaze)
+		{
+			_target.getSkills().add(::new("scripts/skills/effects/dazed_effect"));
+
+			if (!_user.isHiddenToPlayer() && !_target.isHiddenToPlayer())
+			{
+				::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " dazes " + ::Const.UI.getColorizedEntityName(_target) + " for 1 turn");
+			}
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/knock_out.nut
+++ b/mod_reforged/hooks/skills/actives/knock_out.nut
@@ -1,0 +1,8 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/knock_out", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.IsDamagingPoise = true;
+		this.m.IsStunningFromPoise = true;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/knock_over_skill.nut
+++ b/mod_reforged/hooks/skills/actives/knock_over_skill.nut
@@ -1,0 +1,8 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/knock_over_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.IsDamagingPoise = true;
+		this.m.IsStunningFromPoise = true;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/pound.nut
+++ b/mod_reforged/hooks/skills/actives/pound.nut
@@ -1,0 +1,38 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/pound", function(q) {
+	q.m.PoiseDamageMult <- 2.0;	// This will make Pound able to stun humans on a head hit as most 2 handed flails have 40 PoiseDamage
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+
+		if (this.m.IsDamagingPoise)
+		{
+			ret.extend([
+				{
+					id = 10,
+					type = "text",
+					icon = "ui/icons/special.png",
+					text = "Poise Damage is increased by " + ::MSU.Text.colorizePercentage((this.m.PoiseDamageMult - 1.0) * 100, {AddSign = false})
+				}
+			]);
+		}
+
+		return ret;
+	}
+
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.IsDamagingPoise = true;
+		this.m.IsStunningFromPoise = true;
+	}
+
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+		if (_skill == this)
+		{
+			_properties.PoiseDamageMult *= this.m.PoiseDamageMult;
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/shieldwall.nut
+++ b/mod_reforged/hooks/skills/actives/shieldwall.nut
@@ -2,14 +2,13 @@
 	q.getTooltip = @(__original) function()
 	{
 		local tooltip = __original();
-		tooltip.push(
-			{
-				id = 6,
-				type = "text",
-				icon = "ui/icons/special.png",
-				text = "Grants immunity to the next stun, but will be lost upon receiving the stun"
-			}
-		);
+
+		tooltip.push({
+			id = 6,
+			type = "text",
+			icon = "ui/icons/sturdiness.png",
+			text = ::Reforged.Mod.Tooltips.parseString("[Poise|Concept.Poise] is increased by " + ::MSU.Text.colorizeMult(1.25))
+		});
 
 		tooltip.push({
 			id = 6,

--- a/mod_reforged/hooks/skills/actives/strike_down_skill.nut
+++ b/mod_reforged/hooks/skills/actives/strike_down_skill.nut
@@ -1,0 +1,8 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/strike_down_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.IsDamagingPoise = true;
+		this.m.IsStunningFromPoise = true;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/thresh.nut
+++ b/mod_reforged/hooks/skills/actives/thresh.nut
@@ -1,0 +1,8 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/thresh", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.IsDamagingPoise = true;
+		this.m.IsStunningFromPoise = true;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/unstoppable_charge_skill.nut
+++ b/mod_reforged/hooks/skills/actives/unstoppable_charge_skill.nut
@@ -1,0 +1,91 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/unstoppable_charge_skill", function(q) {
+	q.m.BasePoiseDamage <- 150;
+
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.IsDamagingPoise = true;		// Just for the tooltip
+		this.m.IsStunningFromPoise = true;	// Just for the tooltip
+	}
+
+	// This is just so that the tooltip will display the correct poise damage
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+		if (_skill == this)
+		{
+			_properties.PoiseDamage = this.m.PoiseDamageOverwrite;
+		}
+	}
+
+	// Full rewrite as too many things of the original changed
+	q.applyEffectToTarget = @() function( _user, _target, _targetTile )
+	{
+		if (_target.isNonCombatant())
+		{
+			return;
+		}
+
+		if (::Math.rand(1, 2) == 1)		// Maybe stun, stagger otherwise
+		{
+			local targetPoiseSkill = _target.getSkills().getSkillByID("effects.poise");
+			local inflictedPoiseDamage = this.m.BasePoiseDamage * _user.getCurrentProperties().PoiseDamageMult;
+			local turnsStunned = targetPoiseSkill.onPoiseDamageReceived(_user, this, inflictedPoiseDamage);
+			if (turnsStunned == 0)
+			{
+				_target.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
+
+				if (!_user.isHiddenToPlayer() && _targetTile.IsVisibleForPlayer)
+				{
+					::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " has staggered " + ::Const.UI.getColorizedEntityName(_target) + " for 1 turn");
+				}
+			}
+		}
+		else	// Always Stagger, maybe knock back
+		{
+			_target.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
+			if (!_user.isHiddenToPlayer() && _targetTile.IsVisibleForPlayer)
+			{
+				::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " has staggered " + ::Const.UI.getColorizedEntityName(_target) + " for 1 turn");
+			}
+
+			local knockToTile = this.findTileToKnockBackTo(_user.getTile(), _targetTile);
+			if (knockToTile == null) return;
+
+			this.m.TilesUsed.push(knockToTile.ID);
+			if (!_user.isHiddenToPlayer() && (_targetTile.IsVisibleForPlayer || knockToTile.IsVisibleForPlayer))
+			{
+				::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " has knocked back " + ::Const.UI.getColorizedEntityName(_target));
+			}
+
+			// Interrupt some target abilities
+			local skills = _target.getSkills();
+			skills.removeByID("effects.shieldwall");
+			skills.removeByID("effects.spearwall");
+			skills.removeByID("effects.riposte");
+			_target.setCurrentMovementType(::Const.Tactical.MovementType.Involuntary);
+
+			// Potential Falldamage
+			local damage = ::Math.max(0, ::Math.abs(knockToTile.Level - _targetTile.Level) - 1) * ::Const.Combat.FallingDamage;
+			if (damage == 0)
+			{
+				::Tactical.getNavigator().teleport(_target, knockToTile, null, null, true);
+			}
+			else
+			{
+				local p = this.getContainer().getActor().getCurrentProperties();
+				local tag = {
+					Attacker = _user,
+					Skill = this,
+					HitInfo = clone ::Const.Tactical.HitInfo
+				};
+				tag.HitInfo.DamageRegular = damage;
+				tag.HitInfo.DamageDirect = 1.0;
+				tag.HitInfo.BodyPart = ::Const.BodyPart.Body;
+				tag.HitInfo.BodyDamageMult = 1.0;
+				tag.HitInfo.FatalityChanceMult = 1.0;
+				::Tactical.getNavigator().teleport(_target, knockToTile, this.onKnockedDown, tag, true);
+			}
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/effects/shieldwall_effect.nut
+++ b/mod_reforged/hooks/skills/effects/shieldwall_effect.nut
@@ -1,15 +1,16 @@
 ::Reforged.HooksMod.hook("scripts/skills/effects/shieldwall_effect", function(q) {
+	q.m.PoiseMult <- 1.25;
+
 	q.getTooltip = @(__original) function()
 	{
 		local tooltip = __original();
-		tooltip.push(
-			{
-				id = 6,
-				type = "text",
-				icon = "ui/icons/special.png",
-				text = "Immune to the next stun, but will be lost upon receiving the stun"
-			}
-		);
+
+		tooltip.push({
+			id = 8,
+			type = "text",
+			icon = "ui/icons/sturdiness.png",
+			text = ::Reforged.Mod.Tooltips.parseString("[Poise|Concept.Poise] is increased by " + ::MSU.Text.colorizeMult(this.m.PoiseMult))
+		});
 
 		tooltip.push({
 			id = 6,
@@ -19,15 +20,16 @@
 		});
 
 		return tooltip;
-	}		
+	}
 
-	q.onSkillsUpdated <- function()
+	q.onUpdate = @(__original) function( _properties )
 	{
-		local stun = this.getContainer().getSkillByID("effects.stunned");
-		if (stun != null)
+		__original(_properties);
+
+		local item = this.getContainer().getActor().getItems().getItemAtSlot(::Const.ItemSlot.Offhand);
+		if (item.isItemType(::Const.Items.ItemType.Shield) && item.getCondition() > 0)
 		{
-			stun.removeSelf();
-			::Tactical.EventLog.logEx(::Const.UI.getColorizedEntityName(this.getContainer().getActor()) + " shakes off the stun but loses " + this.getName());
+			_properties.PoiseMult *= this.m.PoiseMult;
 		}
 	}
 });

--- a/mod_reforged/hooks/skills/perks/perk_battering_ram.nut
+++ b/mod_reforged/hooks/skills/perks/perk_battering_ram.nut
@@ -1,0 +1,9 @@
+::Reforged.HooksMod.hook("scripts/skills/perks/perk_battering_ram", function(q) {
+	q.m.PoiseMult <- 1.5;
+
+	q.onUpdate = @(__original) function( _properties )
+	{
+		__original(_properties);
+		_properties.PoiseMult *= this.m.PoiseMult;
+	}
+});

--- a/mod_reforged/hooks/skills/perks/perk_hold_out.nut
+++ b/mod_reforged/hooks/skills/perks/perk_hold_out.nut
@@ -1,0 +1,15 @@
+::Reforged.HooksMod.hook("scripts/skills/perks/perk_hold_out", function(q) {
+	q.m.PoiseMult <- 1.5;
+
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.Icon = "ui/perks/rf_battle_flow.png"
+	}
+
+	q.onUpdate = @(__original) function( _properties )
+	{
+		__original(_properties);
+		_properties.PoiseMult *= this.m.PoiseMult;
+	}
+});

--- a/mod_reforged/hooks/skills/perks/perk_mastery_mace.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_mace.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/skills/perks/perk_mastery_mace", function(q) {
+	q.m.PoiseDamageMult <- 1.5;
+
 	q.onAdded = @(__original) function()
 	{
 		__original();
@@ -12,5 +14,18 @@
 	{
 		__original();
 		this.getContainer().removeByID("perk.rf_bear_down");
+	}
+
+	q.onUpdate = @(__original) function( _properties )
+	{
+		__original(_properties);
+		_properties.IsSpecializedInMaces = false;	//
+
+		if (this.getContainer().getActor().isDisarmed()) return false;
+
+		local weapon = this.getContainer().getActor().getMainhandItem();
+		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Mace)) return false;
+
+		_properties.PoiseDamageMult *= this.m.PoiseDamageMult;	// Currently this improves global poise damage while wielding a mace and is not limited to only mace skills
 	}
 });

--- a/mod_reforged/hooks/skills/racial/unhold_racial.nut
+++ b/mod_reforged/hooks/skills/racial/unhold_racial.nut
@@ -28,6 +28,7 @@
 
 		baseProperties.IsImmuneToDisarm = true;
 		baseProperties.IsImmuneToRotation = true;
+		baseProperties.PoiseMax = ::Reforged.Poise.Default.Unhold;
 	}
 
 	q.onTurnStart = @(__original) function()

--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -116,7 +116,7 @@
 
 			if (this.m.IsStunningFromPoise)
 			{
-				if ("StunChance" in this.m)
+				if (::MSU.isIn("StunChance", this.m))
 				{
 					this.m.StunChance = 0;	// Skills that now use the Composure system should no longer use the StunChance
 				}
@@ -162,13 +162,15 @@
 
 	q.onUse = @(__original) function( _user, _targetTile )
 	{
-		local actor = this.getContainer().getActor();
 		if (this.m.IsStunningFromPoise)
 		{
+			local actor = this.getContainer().getActor();
+
 			local oldMaceSpec = actor.getCurrentProperties().IsSpecializedInMaces;
 			actor.getCurrentProperties().IsSpecializedInMaces = false;	// This will disable all vanilla StunChance based stuns
 			local ret = __original(_user, _targetTile);
 			actor.getCurrentProperties().IsSpecializedInMaces = oldMaceSpec;
+
 			return ret;
 		}
 		else

--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -85,8 +85,8 @@
 			if (!targetEntity.getCurrentProperties().IsImmuneToStun && this.m.IsStunningFromPoise)
 			{
 				local targetThresholdSkill = targetEntity.getSkills().getSkillByID("effects.poise");
-				local turnsStunnedBody = targetThresholdSkill.wouldStun(this.getContainer().getActor(), this, false);
-				local turnsStunnedHead = targetThresholdSkill.wouldStun(this.getContainer().getActor(), this, true);
+				local turnsStunnedBody = targetThresholdSkill.wouldStun(this.getContainer().getActor(), this, ::Const.BodyPart.Body);
+				local turnsStunnedHead = targetThresholdSkill.wouldStun(this.getContainer().getActor(), this, ::Const.BodyPart.Head);
 
 				ret.push({
 					icon = "ui/tooltips/positive.png",

--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -66,15 +66,31 @@
 		}
 
 		// New Entries
-		if (!this.m.IsShieldRelevant && _targetTile.IsOccupiedByActor && _targetTile.getEntity().isArmedWithShield())
+		if (_targetTile.IsOccupiedByActor)
 		{
-			local shield = _targetTile.getEntity().getItems().getItemAtSlot(::Const.ItemSlot.Offhand);
-			local bonus = (this.isRanged()) ? shield.getRangedDefenseBonus() : shield.getMeleeDefenseBonus();
-			if (bonus > 0)
+			local targetEntity = _targetTile.getEntity();
+			if (!this.m.IsShieldRelevant && targetEntity.isArmedWithShield())
 			{
+				local shield = targetEntity.getItems().getItemAtSlot(::Const.ItemSlot.Offhand);
+				local bonus = (this.isRanged()) ? shield.getRangedDefenseBonus() : shield.getMeleeDefenseBonus();
+				if (bonus > 0)
+				{
+					ret.push({
+						icon = "ui/tooltips/positive.png",
+						text = ::MSU.Text.colorGreen(bonus + "%") + " Ignores Shield",
+					});
+				}
+			}
+
+			if (!targetEntity.getCurrentProperties().IsImmuneToStun && this.m.IsStunningFromPoise)
+			{
+				local targetThresholdSkill = targetEntity.getSkills().getSkillByID("effects.poise");
+				local turnsStunnedBody = targetThresholdSkill.wouldStun(this.getContainer().getActor(), this, false);
+				local turnsStunnedHead = targetThresholdSkill.wouldStun(this.getContainer().getActor(), this, true);
+
 				ret.push({
 					icon = "ui/tooltips/positive.png",
-					text = ::MSU.Text.colorGreen(bonus + "%") + " Ignores Shield"
+					text = "Will stun for " + ::MSU.Text.colorGreen(turnsStunnedBody) + "/" + ::MSU.Text.colorGreen(turnsStunnedHead) + " turns",
 				});
 			}
 		}

--- a/scripts/!mods_preload/mod_reforged.nut
+++ b/scripts/!mods_preload/mod_reforged.nut
@@ -103,6 +103,7 @@ foreach (requirement in requiredMods)
 	{
 		::include(file);
 	}
+	::include("mod_reforged/config/poise.nut");	// The default must have been defined so that it can be used in character.nut
 
 	::MSU.AI.addBehavior("RF_AttackLunge", "RF.AttackLunge", ::Const.AI.Behavior.Order.Darkflight, ::Const.AI.Behavior.Score.Attack);
 	::MSU.AI.addBehavior("RF_CoverAlly", "RF.CoverAlly", ::Const.AI.Behavior.Order.Adrenaline, 60);

--- a/scripts/skills/perks/perk_rf_vigilant.nut
+++ b/scripts/skills/perks/perk_rf_vigilant.nut
@@ -1,12 +1,13 @@
 this.perk_rf_vigilant <- ::inherit("scripts/skills/skill", {
 	m = {
-		CurrBonus = 0
+		CurrAPBonus = 0,
+		CurrPoiseBonus = 0,
 	},
 	function create()
 	{
 		this.m.ID = "perk.rf_vigilant";
 		this.m.Name = ::Const.Strings.PerkName.RF_Vigilant;
-		this.m.Description = "This character\'s eye is keen, his movements keener. Gain a portion of unspent Action Points from the previous turn.";
+		this.m.Description = ::Reforged.Mod.Tooltips.parseString("This character\'s eye is keen, his movements keener. Gain a portion of unspent Action Points from the previous turn and additional [Poise|Concept.Poise] for every available Action Point whenever you end your turn.");
 		this.m.Icon = "ui/perks/rf_vigilant.png";
 		this.m.Type = ::Const.SkillType.Perk | ::Const.SkillType.StatusEffect;
 		this.m.Order = ::Const.SkillOrder.Perk;
@@ -17,36 +18,57 @@ this.perk_rf_vigilant <- ::inherit("scripts/skills/skill", {
 
 	function isHidden()
 	{
-		return this.m.CurrBonus == 0;
+		return (this.m.CurrAPBonus == 0 && this.m.CurrPoiseBonus == 0);
 	}
 
 	function getTooltip()
 	{
 		local tooltip = this.skill.getTooltip();
 
-		tooltip.push({
-			id = 6,
-			type = "text",
-			icon = "ui/icons/action_points.png",
-			text = ::MSU.Text.colorizeValue(this.m.CurrBonus) + " Action Points"
-		});
+		if (this.m.CurrAPBonus != 0)
+		{
+			tooltip.push({
+				id = 6,
+				type = "text",
+				icon = "ui/icons/action_points.png",
+				text = ::MSU.Text.colorizeValue(this.m.CurrAPBonus) + " Action Points"
+			});
+		}
+
+		if (this.m.CurrPoiseBonus != 0)
+		{
+			tooltip.push({
+				id = 7,
+				type = "text",
+				icon = "ui/icons/sturdiness.png",
+				text = ::MSU.Text.colorizeValue(this.m.CurrPoiseBonus) + ::Reforged.Mod.Tooltips.parseString(" [Poise|Concept.Poise]")
+			});
+		}
 
 		return tooltip;
 	}
 
+	function onTurnStart()
+	{
+		this.m.CurrPoiseBonus = 0;
+	}
+
 	function onTurnEnd()
 	{
-		this.m.CurrBonus = this.getContainer().getActor().getActionPoints() / 2;
+		this.m.CurrAPBonus = this.getContainer().getActor().getActionPoints() / 2;
+		this.m.CurrPoiseBonus = 10 * this.getContainer().getActor().getActionPoints();
 	}
 
 	function onUpdate( _properties )
 	{
-		_properties.ActionPoints += this.m.CurrBonus;
+		_properties.ActionPoints += this.m.CurrAPBonus;
+		_properties.PoiseMax += this.m.CurrPoiseBonus;
 	}
 
 	function onCombatFinished()
 	{
 		this.skill.onCombatFinished();
-		this.m.CurrBonus = 0;
+		this.m.CurrAPBonus = 0;
+		this.m.CurrPoiseBonus = 0;
 	}
 });

--- a/scripts/skills/racial/rf_orc_racial.nut
+++ b/scripts/skills/racial/rf_orc_racial.nut
@@ -13,6 +13,12 @@ this.rf_orc_racial <- ::inherit("scripts/skills/skill", {
 		this.m.IsHidden = false;
 	}
 
+	function onAdded()
+	{
+		this.getContainer().add(::new("scripts/skills/traits/iron_jaw_trait"));
+		this.getContainer().getActor().m.BaseProperties.PoiseMax = ::Reforged.Poise.Default.Orc;
+	}
+
 	function getTooltip()
 	{
 		local ret = this.skill.getTooltip();

--- a/scripts/skills/special/rf_poise_effect.nut
+++ b/scripts/skills/special/rf_poise_effect.nut
@@ -1,0 +1,142 @@
+/*
+Internally we calculate the current threshold inversely. That makes it much cleaner in code to handle increases and reduction of PoiseMax.
+Our intended behavior is that a change in PoiseMax also changes the Poise of that character by the same amount:
+
+The PoiseMax is purely handled in the Properties while the current Poise is handled in this skill.
+It is much cleaner when a change to PoiseMax can solely focus on changing variables in Properties.
+*/
+
+this.rf_poise_effect <- ::inherit("scripts/skills/skill", {
+	m = {
+		// Config
+		HeadshotMult = 1.5,	// multiplier for incoming poise damage on a hit to the head (unless steelbrow was learned)
+
+		// Private
+		InversePoise = 0,	// This is the inverse of Poise and counts upwards instead of downwards as Poise damaged is received
+	},
+
+	function create()
+	{
+		this.m.ID = "effects.poise";
+		this.m.Name = "Poise";
+		this.m.Description = ::Reforged.Mod.Tooltips.parseString("Certain skills, like [stunning attacks|Concept.StunningAttack], damage your [Poise|Concept.Poise] and apply an effect when they reduce it to 0 or below. If that happens or at the start of your turn your Poise is reset back to your maximum Poise.");
+		this.m.Icon = "ui/traits/trait_icon_15.png";	// Placeholder - TODO: create unique icon instead of usin
+		this.m.Type = ::Const.SkillType.StatusEffect;
+		this.m.Order = ::Const.SkillOrder.Any;
+		this.m.IsActive = false;
+		this.m.IsHidden = false;
+		this.m.IsSerialized = false;
+		this.m.IsRemovedAfterBattle = false;
+	}
+
+	function getTooltip()
+	{
+		local tooltip = this.skill.getTooltip();
+		return tooltip;
+	}
+
+	function getName()
+	{
+		if (::MSU.isNull(this.getContainer())) return this.m.Name;
+
+		local properties = this.getContainer().getActor().getCurrentProperties();
+		local suffix = properties.IsImmuneToStunFromPoise ? " (Immune)" : " (" + this.getPoise(properties) + " / " + properties.getPoiseMax() + ")";
+
+		return this.m.Name + suffix;
+	}
+
+	function onTurnStart()
+	{
+		this.resetPoise();
+	}
+
+	function onBeforeDamageReceived( _attacker, _skill, _hitInfo, _properties )
+	{
+		if (_skill == null || !_skill.m.IsDamagingPoise) return;
+
+		local attackPower = this.calculatePoiseDamage(_attacker, _skill, _hitInfo.BodyPart == ::Const.BodyPart.Head);
+		if (attackPower == 0) return;
+
+		this.onPoiseDamageReceived(_attacker, _skill, attackPower, true, _properties);
+	}
+
+// New Functions
+	function getPoise( _properties = null )
+	{
+		if (_properties == null) _properties = this.getContainer().getActor().getCurrentProperties();
+
+		return _properties.getPoiseMax() - this.m.InversePoise;
+	}
+
+	function resetPoise()
+	{
+		this.m.InversePoise = 0;
+	}
+
+	// Can be called manually from the outside, e.g. by charge skills that do not use attacks
+	// Returns the amount of turns that the target was stunned. Can be used to apply other effects/behaviors when called manually
+	function onPoiseDamageReceived( _attacker, _skill, _attackPower, _printLog = true, _properties = null )
+	{
+		this.m.InversePoise += _attackPower;
+
+		local turnsStunned = 0;
+		if (_skill.m.IsStunningFromPoise)
+		{
+			if (_properties == null) _properties = this.getContainer().getActor().getCurrentProperties();
+
+			turnsStunned = this.calculateTurnsStunned(_properties.getPoiseMax());
+			if (turnsStunned == 0) return;
+
+			local stunnedEffect = this.getContainer().getSkillByID("effects.stunned");
+			if (stunnedEffect == null)
+			{
+				stunnedEffect = ::new("scripts/skills/effects/stunned_effect");
+				this.getContainer().add(stunnedEffect);
+			}
+
+			stunnedEffect.setTurns(turnsStunned);
+			if (_printLog)
+			{
+				::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_attacker) + " has stunned " + ::Const.UI.getColorizedEntityName(this.getContainer().getActor()) + " for " + ::MSU.Text.colorGreen(turnsStunned) + " turn");
+			}
+
+			this.resetPoise();
+		}
+
+		return turnsStunned;
+	}
+
+	// Returns, for how long we are being stunned right now (1 parameter) or would be, if given a simulated attack power
+	function calculateTurnsStunned( _PoiseMax, _simulatedAttackPower = 0 )	// _simulatedAttackPower is only used here when simulating whether something would stun
+	{
+		if (this.m.ReversePoise + _simulatedAttackPower < _PoiseMax) return 0;
+		if (this.m.ReversePoise + _simulatedAttackPower < (_PoiseMax * 2)) return 1;
+		return 2;
+	}
+
+	function calculatePoiseDamage( _attacker, _skill, _isHeadshot)
+	{
+		if (!_skill.m.IsDamagingPoise) return 0;
+
+		local poiseDamage = _attacker.getSkills().buildPropertiesForUse(_skill, null).getPoiseDamage();
+		if (poiseDamage == 0) return;
+
+		if (_isHeadshot && !this.getContainer().hasSkill("perk.steel_brow"))
+		{
+			poiseDamage *= this.m.HeadshotMult;
+		}
+		poiseDamage = ::Math.floor(poiseDamage);
+
+		return poiseDamage;
+	}
+
+	// Returns amount of turns that a target would be stunned. Is used for tooltips predicting this
+	function wouldStun( _attacker, _skill, _isHeadshot)
+	{
+		local poiseDamage = this.calculatePoiseDamage(_attacker, _skill, _isHeadshot);
+		if (poiseDamage == 0) return 0;
+
+		local myProperties = this.getContainer().buildPropertiesForDefense(_attacker, _skill);
+		return this.calculateTurnsStunned(myProperties.getPoiseMax(), poiseDamage);
+	}
+});


### PR DESCRIPTION
# Current Summary

### Terms
- **StunPower** : New stat on weapons and some active skills that determines how strong stunning attacks with them are
- **ComposureMax**: New character stat on entities that determines how well they can resist stunning attacks
- **Composure**: New stat on entities that is lost upon receiving stunning attacks and reset when it hits 0 or at the start of an entities turn

## Overview
- All Maces and all two-handed flails have a fixed StunPower. 
  - 2H Flails: **40**
  - 1H Human Maces: **80**
  - 1H Orc Maces: **120**
  - 2H Polemace/Goedendag; **120** 
  - remaining 2H Maces: **160**
- Most Races have a set ComposureMax (everyone else is treated as Human). E.g. Goblins have 60, Humans have 100 and Orcs have 150
- All stunning attacks now attack the Composure of the target
- Reducing the Composure below 0 with a stunning attack will stun them
- Reducing the enemy Composure to a value equal or below their negative max Composure will apply a double stun
- Headshots grant 50% increased StunPower
- Enemies that are immune to stuns (eg BaseProperties) are also immune to stuns from Composure
- Enemies that gain their stun immunity from effects (like Battering Ram on Orcs) are now susceptible to stuns from composure loss

### Perk Adjustments
- **Resilient** grants 50% increased Composure 
- **Battering Ram** grants 50% increased Composure 
- **Steelbrow** negates the Headshot bonus on StunPower
- **Mace Mastery** grants 50% increased StunPower while a Mace is equipped
- **Vigilant** grants +10 ComposureMax for every current Action Point

### Skill Adjustments
- All skills that had a Stun Chance (!= 0) before now use the Composure system
- **Shieldwall** grants 25% increased Composure (and no longer ignores the first stun)
- **Pound** grants 100% increased StunPower
- **Charge** inflicts 100 StunPower and Dazes the target if no stun was applied
- **Unstoppable Charge** inflicts 150 StunPower (if stun was rolled as opposed to knock back) and staggers the target if no stun was applied

## Todo
- Icon for new Composure effect
- Icon for Composure stat lines
- Ingame explanations about this system
- Nested Tooltips for StunPower and Composure atleast
- Smarter enemy AI that can predict stuns
- Some casual playtesting
- Review

### Maybe Todo
- Balance tweaks of certain weapon/skill values related to stun threshold