### PR TITLE
Refactor daily cost rewrite

### DIFF
--- a/mod_reforged/config/config.nut
+++ b/mod_reforged/config/config.nut
@@ -5,6 +5,11 @@
 	XPOverride = false, // Is set to true during actor.onActorKilled to prevent any xp gain via player.getXP function. Then set to false afterwards. This is to do our own override of XP gain system based on damage dealt ratios.
 	VeteranPerksLevelStep = 4, // During veteran character levels, a new perk point is gained every this many levels.
 
+	Player = {
+		DailyCostMultPerLevelRegular = 1.1,		// Exponential increase of daily cost for each level before max level
+		DailyCostMultPerLevelParagon = 1.03		// Exponential increase of daily cost for each level after max level
+	}
+
 	UI = {
 		WorldBannerYOffset = 50
 	}

--- a/mod_reforged/config/config.nut
+++ b/mod_reforged/config/config.nut
@@ -1,11 +1,11 @@
 ::Reforged.Config <- {
 	IsLegendaryDifficulty = true,
-	HiringCostVariance = 0.2,	// Hiring cost for recruits after gear is randomized +- this value. 0.0 = no variance. 0.2 = it varies between 80% and 120% of its original cost
-	HiringCostLuck = 200,	// Luck for rerolling hiring cost. Every 100 luck = 1 reroll. With multiple rerolls present only the closest to the original hiring cost is taken. 0 luck = to linear distribution between min and max,
-	XPOverride = false, // Is set to true during actor.onActorKilled to prevent any xp gain via player.getXP function. Then set to false afterwards. This is to do our own override of XP gain system based on damage dealt ratios.
-	VeteranPerksLevelStep = 4, // During veteran character levels, a new perk point is gained every this many levels.
 
 	Player = {
+		HiringCostVariance = 0.2,	// Hiring cost for recruits after gear is randomized +- this value. 0.0 = no variance. 0.2 = it varies between 80% and 120% of its original cost
+		HiringCostLuck = 200,	// Luck for rerolling hiring cost. Every 100 luck = 1 reroll. With multiple rerolls present only the closest to the original hiring cost is taken. 0 luck = to linear distribution between min and max,
+		XPOverride = false, // Is set to true during actor.onActorKilled to prevent any xp gain via player.getXP function. Then set to false afterwards. This is to do our own override of XP gain system based on damage dealt ratios.
+		VeteranPerksLevelStep = 4, // During veteran character levels, a new perk point is gained every this many levels.
 		DailyCostMultPerLevelRegular = 1.1,		// Exponential increase of daily cost for each level before max level
 		DailyCostMultPerLevelParagon = 1.03		// Exponential increase of daily cost for each level after max level
 	}

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -176,10 +176,10 @@
 ::Reforged.HooksMod.hookTree("scripts/entity/tactical/actor", function(q) {
 	q.onActorKilled = @(__original) function( _actor, _tile, _skill )
 	{
-		local wasOverriding = ::Reforged.Config.XPOverride;
-		::Reforged.Config.XPOverride = true;
+		local wasOverriding = ::Reforged.Config.Player.XPOverride;
+		::Reforged.Config.Player.XPOverride = true;
 		__original(_actor, _tile, _skill);
-		::Reforged.Config.XPOverride = wasOverriding;
+		::Reforged.Config.Player.XPOverride = wasOverriding;
 	}
 
 	q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )

--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -16,7 +16,7 @@
 
 	q.addXP = @(__original) function( _xp, _scale = true )
 	{
-		if (::Reforged.Config.XPOverride)
+		if (::Reforged.Config.Player.XPOverride)
 			return;
 
 		while (this.m.Level >= ::Const.LevelXP.len())

--- a/mod_reforged/hooks/skills/backgrounds/character_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/character_background.nut
@@ -25,7 +25,7 @@
 	// Overwrite to increase overall performance. The Wage for this background is no longer calculated newly during every update loop
 	q.onUpdate = @() function( _properties )
 	{
-		_properties.DailyWage = this.calculateDailyCost();
+		_properties.DailyWage = this.m.CalculatedDailyCost;
 
 		if (("State" in ::World) && ::World.State != null && ::World.Assets.getOrigin() != null && ::World.Assets.getOrigin().getID() == "scenario.manhunters" && this.getID() != "background.slave")
 		{

--- a/mod_reforged/hooks/skills/backgrounds/character_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/character_background.nut
@@ -39,8 +39,8 @@
 		__original();
 		local actor = this.getContainer().getActor();
 		local hiringCost = actor.m.HiringCost;
-		local minimum = hiringCost * (1.0 - ::Reforged.Config.HiringCostVariance);
-		local maximum = hiringCost * (1.0 + ::Reforged.Config.HiringCostVariance);
+		local minimum = hiringCost * (1.0 - ::Reforged.Config.Player.HiringCostVariance);
+		local maximum = hiringCost * (1.0 + ::Reforged.Config.Player.HiringCostVariance);
 		hiringCost = ::Reforged.Math.luckyRoll(minimum, maximum, hiringCost, ::Reforged.Config.HiringCostLuck);		// Randomizes this value an additional time for every 100 luck and picks the one closest to the original
 		hiringCost = ::Reforged.Math.ceil(hiringCost, -1);		// Makes sure this unsigned integer ends with a 0 one again
 		actor.m.HiringCost = hiringCost;

--- a/mod_reforged/hooks/skills/traits/player_character_trait.nut
+++ b/mod_reforged/hooks/skills/traits/player_character_trait.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/skills/traits/player_character_trait", function(q) {
+	q.onUpdate = @(__original) function( _properties )
+	{
+		__original(_properties);
+		_properties.DailyCostMult = 0.0;	// In Vanilla this property of player trait was controlled in the character_background.nut
+	}
+});

--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -27,7 +27,7 @@
 					{
 						id = 2,
 						type = "description",
-						text = ::Reforged.Mod.Tooltips.parseString("The character\'s level measures [experience|Concept.Experience] in battle. Characters rise in levels as they gain experience and are able to increase their [attributes|Concept.CharacterAttribute] and gain [perks|Concept.Perk] that make them better at the mercenary profession.\n\nBeyond the " + ::Const.XP.MaxLevelWithPerkpoints + "th character level, characters are veterans and gain perk points " + (::Reforged.Config.VeteranPerksLevelStep == 1 ? "" : "only") + " every " + ::Reforged.Config.VeteranPerksLevelStep + "th level. They can still improve their attributes but the attribute gain per level is small.")
+						text = ::Reforged.Mod.Tooltips.parseString("The character\'s level measures [experience|Concept.Experience] in battle. Characters rise in levels as they gain experience and are able to increase their [attributes|Concept.CharacterAttribute] and gain [perks|Concept.Perk] that make them better at the mercenary profession.\n\nBeyond the " + ::Const.XP.MaxLevelWithPerkpoints + "th character level, characters are veterans and gain perk points " + (::Reforged.Config.Player.VeteranPerksLevelStep == 1 ? "" : "only") + " every " + ::Reforged.Config.Player.VeteranPerksLevelStep + "th level. They can still improve their attributes but the attribute gain per level is small.")
 					}
 				];
 		}

--- a/scripts/skills/special/rf_veteran_levels.nut
+++ b/scripts/skills/special/rf_veteran_levels.nut
@@ -15,7 +15,7 @@ this.rf_veteran_levels <- ::inherit("scripts/skills/skill", {
 	function onUpdateLevel()
 	{
 		local diff = this.getContainer().getActor().getLevel() - ::Const.XP.MaxLevelWithPerkpoints;
-		if (diff > 0 && diff % ::Reforged.Config.VeteranPerksLevelStep == 0)
+		if (diff > 0 && diff % ::Reforged.Config.Player.VeteranPerksLevelStep == 0)
 		{
 			this.getContainer().getActor().m.PerkPoints++;
 		}


### PR DESCRIPTION
This rewrite achieves two things:
- Overall Performance improvement by no longer doing a costly daily cost calculation for every brother during every updateProperties call
- Introduction of two new global config variables to control how the DailyCost of brothers increases during regular and paragon levelups

In the second commit I took the liberty to move existing config variables into the new Player namespace.