### PR TITLE
Dynamic spawns data copy

### DIFF
--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
@@ -7,11 +7,11 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.20, RatioMax = 0.70},
-			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20}
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.20, RatioMax = 0.70 },
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.40 },
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.40 },
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.35 },
+			{ ID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20 }
 		]
 	},
 	{
@@ -22,11 +22,11 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70},
-			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20}
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70 },
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30 },
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30 },
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40 },
+			{ ID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20 }
 		]
 	},
 	{
@@ -37,12 +37,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70},
-			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
-			{ ID = "UnitBlock.RF.BanditBoss", RatioMin = 0.00, RatioMax = 0.11, StartingResourceMin = 180, DeterminesFigure = true}
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70 },
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.25 },
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.25 },
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.35 },
+			{ ID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320 },
+			{ ID = "UnitBlock.RF.BanditBoss", RatioMin = 0.00, RatioMax = 0.11, StartingResourceMin = 180, DeterminesFigure = true }
 		]
 	},
 	{
@@ -53,12 +53,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70},
-			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
-			{ ID = "UnitBlock.RF.BanditBoss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 180}
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70 },
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30 },
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30 },
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.25 },
+			{ ID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320 },
+			{ ID = "UnitBlock.RF.BanditBoss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 180 }
 		]
 	},
 	{
@@ -69,12 +69,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70},
-			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
-			{ ID = "UnitBlock.RF.BanditBoss", RatioMin = 0.01, RatioMax = 0.11}				// One boss is always guaranteed
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70 },
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30 },
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30 },
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.25 },
+			{ ID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320 },
+			{ ID = "UnitBlock.RF.BanditBoss", RatioMin = 0.01, RatioMax = 0.11 }				// One boss is always guaranteed
 		]
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
@@ -7,11 +7,11 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Balanced", RatioMin = 0.20, RatioMax = 0.70},
-			{ ID = "Bandit.Fast", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "Bandit.Tough", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "Bandit.Dogs", RatioMin = 0.00, RatioMax = 0.20}
+			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.20, RatioMax = 0.70},
+			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.40},
+			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.40},
+			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.35},
+			{ ID = "UnitBlock.BanditDogs", RatioMin = 0.00, RatioMax = 0.20}
 		]
 	},
 	{
@@ -22,11 +22,11 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Balanced", RatioMin = 0.30, RatioMax = 0.70},
-			{ ID = "Bandit.Fast", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "Bandit.Tough", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "Bandit.Dogs", RatioMin = 0.00, RatioMax = 0.20}
+			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70},
+			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.40},
+			{ ID = "UnitBlock.BanditDogs", RatioMin = 0.00, RatioMax = 0.20}
 		]
 	},
 	{
@@ -37,12 +37,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Balanced", RatioMin = 0.30, RatioMax = 0.70},
-			{ ID = "Bandit.Fast", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "Bandit.Tough", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "Bandit.Elite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
-			{ ID = "Bandit.Boss", RatioMin = 0.00, RatioMax = 0.11, StartingResourceMin = 180, DeterminesFigure = true}
+			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70},
+			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.25},
+			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.25},
+			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.35},
+			{ ID = "UnitBlock.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
+			{ ID = "UnitBlock.BanditBoss", RatioMin = 0.00, RatioMax = 0.11, StartingResourceMin = 180, DeterminesFigure = true}
 		]
 	},
 	{
@@ -53,12 +53,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Balanced", RatioMin = 0.40, RatioMax = 0.70},
-			{ ID = "Bandit.Fast", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "Bandit.Tough", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "Bandit.Elite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
-			{ ID = "Bandit.Boss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 180}
+			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70},
+			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.25},
+			{ ID = "UnitBlock.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
+			{ ID = "UnitBlock.BanditBoss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 180}
 		]
 	},
 	{
@@ -69,12 +69,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Balanced", RatioMin = 0.40, RatioMax = 0.70},
-			{ ID = "Bandit.Fast", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "Bandit.Tough", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "Bandit.Elite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
-			{ ID = "Bandit.Boss", RatioMin = 0.01, RatioMax = 0.11}				// One boss is always guaranteed
+			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70},
+			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.25},
+			{ ID = "UnitBlock.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
+			{ ID = "UnitBlock.BanditBoss", RatioMin = 0.01, RatioMax = 0.11}				// One boss is always guaranteed
 		]
 	},
 	{
@@ -85,7 +85,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.DisguisedDirewolf" }
+			{ ID = "UnitBlock.BanditDisguisedDirewolf" }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
@@ -11,7 +11,7 @@ local parties = [
 			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.40},
 			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.40},
 			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "UnitBlock.BanditDogs", RatioMin = 0.00, RatioMax = 0.20}
+			{ ID = "UnitBlock.BanditDog", RatioMin = 0.00, RatioMax = 0.20}
 		]
 	},
 	{
@@ -26,7 +26,7 @@ local parties = [
 			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
 			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
 			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "UnitBlock.BanditDogs", RatioMin = 0.00, RatioMax = 0.20}
+			{ ID = "UnitBlock.BanditDog", RatioMin = 0.00, RatioMax = 0.20}
 		]
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
@@ -7,11 +7,11 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.20, RatioMax = 0.70},
-			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "UnitBlock.BanditDog", RatioMin = 0.00, RatioMax = 0.20}
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.20, RatioMax = 0.70},
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.40},
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.40},
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.35},
+			{ ID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20}
 		]
 	},
 	{
@@ -22,11 +22,11 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70},
-			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "UnitBlock.BanditDog", RatioMin = 0.00, RatioMax = 0.20}
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70},
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40},
+			{ ID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20}
 		]
 	},
 	{
@@ -37,12 +37,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70},
-			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "UnitBlock.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
-			{ ID = "UnitBlock.BanditBoss", RatioMin = 0.00, RatioMax = 0.11, StartingResourceMin = 180, DeterminesFigure = true}
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 0.70},
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.25},
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.25},
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.35},
+			{ ID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
+			{ ID = "UnitBlock.RF.BanditBoss", RatioMin = 0.00, RatioMax = 0.11, StartingResourceMin = 180, DeterminesFigure = true}
 		]
 	},
 	{
@@ -53,12 +53,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70},
-			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "UnitBlock.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
-			{ ID = "UnitBlock.BanditBoss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 180}
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70},
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.25},
+			{ ID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
+			{ ID = "UnitBlock.RF.BanditBoss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 180}
 		]
 	},
 	{
@@ -69,12 +69,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70},
-			{ ID = "UnitBlock.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
-			{ ID = "UnitBlock.BanditRanged", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "UnitBlock.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
-			{ ID = "UnitBlock.BanditBoss", RatioMin = 0.01, RatioMax = 0.11}				// One boss is always guaranteed
+			{ ID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.40, RatioMax = 0.70},
+			{ ID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30},
+			{ ID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.25},
+			{ ID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35, StartingResourceMin = 320},
+			{ ID = "UnitBlock.RF.BanditBoss", RatioMin = 0.01, RatioMax = 0.11}				// One boss is always guaranteed
 		]
 	},
 	{
@@ -85,7 +85,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "UnitBlock.BanditDisguisedDirewolf" }
+			{ ID = "UnitBlock.RF.BanditDisguisedDirewolf" }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
@@ -1,0 +1,75 @@
+local parties = [
+	{
+		ID = "Barbarians",
+		HardMin = 6,
+		DefaultFigure = "figure_wildman_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BarbarianFrontline", 	RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.BarbarianSupport", 	RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10, StartingResourceMin = 200 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
+			{ BaseID = "UnitBlock.BarbarianDogs", 		RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
+			{ BaseID = "UnitBlock.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5, StartingResourceMin = 195 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
+		]
+	},
+	{
+		ID = "BarbarianHunters",
+		HardMin = 5,
+		DefaultFigure = "figure_wildman_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.BarbarianDogs", 			RatioMin = 0.20, RatioMax = 0.45 }
+		]
+	},
+	{
+		ID = "BarbarianKing",
+		DefaultFigure = "figure_wildman_06",
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.BarbarianKing" }
+		]
+	},
+
+	// SubParties
+	{
+		ID = "OneUnhold",
+		HardMin = 1,
+		HardMax = 1,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BarbarianUnholds"}
+		]
+	},
+	{
+		ID = "TwoUnhold",
+		HardMin = 2,
+		HardMax = 2,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BarbarianUnholds"}
+		]
+	},
+	{
+		ID = "OneFrostUnhold",
+		HardMin = 1,
+		HardMax = 1,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BarbarianUnholdsFrost"}
+		]
+	},
+	{
+		ID = "TwoFrostUnhold",
+		HardMin = 2,
+		HardMax = 2,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BarbarianUnholdsFrost"}
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}
+

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
@@ -7,9 +7,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BarbarianFrontline", 	RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.BarbarianSupport", 	RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
-			{ BaseID = "UnitBlock.RF.BarbarianDog", 		RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
+			{ BaseID = "UnitBlock.RF.BarbarianFrontline", RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.BarbarianSupport", RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
+			{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
 			{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
 		]
 	},
@@ -22,7 +22,7 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.BarbarianDog", 			RatioMin = 0.20, RatioMax = 0.45 }
+			{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.20, RatioMax = 0.45 }
 		]
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
@@ -8,9 +8,9 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.BarbarianFrontline", 	RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.BarbarianSupport", 	RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10, StartingResourceMin = 200 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
+			{ BaseID = "UnitBlock.BarbarianSupport", 	RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
 			{ BaseID = "UnitBlock.BarbarianDog", 		RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
-			{ BaseID = "UnitBlock.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5, StartingResourceMin = 195 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
+			{ BaseID = "UnitBlock.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
 		]
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
@@ -9,7 +9,7 @@ local parties = [
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.BarbarianFrontline", 	RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
 			{ BaseID = "UnitBlock.BarbarianSupport", 	RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10, StartingResourceMin = 200 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
-			{ BaseID = "UnitBlock.BarbarianDogs", 		RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
+			{ BaseID = "UnitBlock.BarbarianDog", 		RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
 			{ BaseID = "UnitBlock.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5, StartingResourceMin = 195 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
 		]
 	},
@@ -22,7 +22,7 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.BarbarianDogs", 			RatioMin = 0.20, RatioMax = 0.45 }
+			{ BaseID = "UnitBlock.BarbarianDog", 			RatioMin = 0.20, RatioMax = 0.45 }
 		]
 	},
 	{
@@ -39,7 +39,7 @@ local parties = [
 		HardMin = 1,
 		HardMax = 1,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianUnholds"}
+			{ BaseID = "UnitBlock.BarbarianUnhold"}
 		]
 	},
 	{
@@ -47,7 +47,7 @@ local parties = [
 		HardMin = 2,
 		HardMax = 2,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianUnholds"}
+			{ BaseID = "UnitBlock.BarbarianUnhold"}
 		]
 	},
 	{
@@ -55,7 +55,7 @@ local parties = [
 		HardMin = 1,
 		HardMax = 1,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianUnholdsFrost"}
+			{ BaseID = "UnitBlock.BarbarianUnholdFrost"}
 		]
 	},
 	{
@@ -63,7 +63,7 @@ local parties = [
 		HardMin = 2,
 		HardMax = 2,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianUnholdsFrost"}
+			{ BaseID = "UnitBlock.BarbarianUnholdFrost"}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
@@ -7,10 +7,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianFrontline", 	RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.BarbarianSupport", 	RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
-			{ BaseID = "UnitBlock.BarbarianDog", 		RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
-			{ BaseID = "UnitBlock.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
+			{ BaseID = "UnitBlock.RF.BarbarianFrontline", 	RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.BarbarianSupport", 	RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
+			{ BaseID = "UnitBlock.RF.BarbarianDog", 		RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
+			{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
 		]
 	},
 	{
@@ -21,15 +21,15 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.BarbarianDog", 			RatioMin = 0.20, RatioMax = 0.45 }
+			{ BaseID = "UnitBlock.RF.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.BarbarianDog", 			RatioMin = 0.20, RatioMax = 0.45 }
 		]
 	},
 	{
 		ID = "BarbarianKing",
 		DefaultFigure = "figure_wildman_06",
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.BarbarianKing" }
+			{ BaseID = "UnitBlock.RF.BarbarianKing" }
 		]
 	},
 
@@ -39,7 +39,7 @@ local parties = [
 		HardMin = 1,
 		HardMax = 1,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianUnhold"}
+			{ BaseID = "UnitBlock.RF.BarbarianUnhold"}
 		]
 	},
 	{
@@ -47,7 +47,7 @@ local parties = [
 		HardMin = 2,
 		HardMax = 2,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianUnhold"}
+			{ BaseID = "UnitBlock.RF.BarbarianUnhold"}
 		]
 	},
 	{
@@ -55,7 +55,7 @@ local parties = [
 		HardMin = 1,
 		HardMax = 1,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianUnholdFrost"}
+			{ BaseID = "UnitBlock.RF.BarbarianUnholdFrost"}
 		]
 	},
 	{
@@ -63,7 +63,7 @@ local parties = [
 		HardMin = 2,
 		HardMax = 2,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BarbarianUnholdFrost"}
+			{ BaseID = "UnitBlock.RF.BarbarianUnholdFrost"}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastDirewolves", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Direwolf", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastGhouls", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Ghoul", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -29,7 +29,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastLindwurms", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Lindwurm", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -40,7 +40,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastUnholds", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Unholds", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -51,7 +51,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastUnholdsFrost", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.UnholdFrost", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -62,7 +62,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastUnholdsBog", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.UnholdBog", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -73,7 +73,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastSpiders", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Spider", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -84,7 +84,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastAlps", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Alp", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -95,7 +95,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastSchrats", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Schrat", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -106,18 +106,18 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.BeastHexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+			{ BaseID = "UnitBlock.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastHexenWithBodyguards", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
-			{ BaseID = "UnitBlock.BeastSpiders", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.BeastGhouls", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.BeastSchrats", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
-			{ BaseID = "UnitBlock.BeastUnholds", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ BaseID = "UnitBlock.BeastUnholdsBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
-			{ BaseID = "UnitBlock.BeastDirewolves", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.BeastHexenBandits", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ BaseID = "UnitBlock.BeastHexenBanditsRanged", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 200 }
+			{ BaseID = "UnitBlock.HexeWithBodyguard", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.Spider", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.Ghoul", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.Schras", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "UnitBlock.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+			{ BaseID = "UnitBlock.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.HexeBandit", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "UnitBlock.HexenBanditRanged", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 200 }
 		]
 	},
 	{
@@ -128,16 +128,16 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.BeastHexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+			{ BaseID = "UnitBlock.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastHexenNoSpiders", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
-			{ BaseID = "UnitBlock.BeastGhouls", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
-			{ BaseID = "UnitBlock.BeastSchrats", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
-			{ BaseID = "UnitBlock.BeastUnholds", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ BaseID = "UnitBlock.BeastUnholdsBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
-			{ BaseID = "UnitBlock.BeastDirewolves", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.BeastHexenBandits", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 }
+			{ BaseID = "UnitBlock.HexeNoSpider", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.Ghoul", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
+			{ BaseID = "UnitBlock.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "UnitBlock.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+			{ BaseID = "UnitBlock.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.HexeBandit", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 }
 		]
 	},
 	{
@@ -148,7 +148,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastHexenNoBodyguards", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.HexeNoBodyguard", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 
@@ -161,7 +161,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastHyenas", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Hyena", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -172,7 +172,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastSerpents", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Serpent", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -183,7 +183,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastSandGolems", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.SandGolem", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	}
 
@@ -191,13 +191,13 @@ local parties = [
 	{
 		ID = "SpiderBodyguards",
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastSpiderBodyguards"}
+			{ BaseID = "UnitBlock.SpiderBodyguard"}
 		]
 	},
 	{
 		ID = "DirewolfBodyguards",
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BeastDirewolfBodyguards"}
+			{ BaseID = "UnitBlock.DirewolfBodyguard"}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
@@ -109,15 +109,15 @@ local parties = [
 			{ BaseID = "UnitBlock.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HexeWithBodyguard", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.HexeWithBodyguard", RatioMin = 0.00, RatioMax = 0.13 },
 			{ BaseID = "UnitBlock.Spider", RatioMin = 0.00, RatioMax = 1.00 },
 			{ BaseID = "UnitBlock.Ghoul", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.Schras", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
 			{ BaseID = "UnitBlock.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
 			{ BaseID = "UnitBlock.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
 			{ BaseID = "UnitBlock.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.HexeBandit", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ BaseID = "UnitBlock.HexenBanditRanged", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 200 }
+			{ BaseID = "UnitBlock.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.HexenBanditRanged", RatioMin = 0.00, RatioMax = 0.13 }
 		]
 	},
 	{
@@ -131,13 +131,13 @@ local parties = [
 			{ BaseID = "UnitBlock.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HexeNoSpider", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.HexeNoSpider", RatioMin = 0.00, RatioMax = 0.13 },
 			{ BaseID = "UnitBlock.Ghoul", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
 			{ BaseID = "UnitBlock.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
 			{ BaseID = "UnitBlock.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
 			{ BaseID = "UnitBlock.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
 			{ BaseID = "UnitBlock.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.HexeBandit", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 }
+			{ BaseID = "UnitBlock.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -29,7 +29,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Lindwurm", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Lindwurm", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -40,7 +40,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -51,7 +51,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.UnholdFrost", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.UnholdFrost", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -62,7 +62,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -73,7 +73,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Spider", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Spider", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -84,7 +84,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Alp", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Alp", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -95,7 +95,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -148,7 +148,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.HexeNoBodyguard", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.HexeNoBodyguard", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 
@@ -161,7 +161,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Hyena", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Hyena", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -172,7 +172,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Serpent", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Serpent", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -183,7 +183,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SandGolem", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.SandGolem", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	}
 
@@ -191,13 +191,13 @@ local parties = [
 	{
 		ID = "SpiderBodyguards",
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SpiderBodyguard"}
+			{ BaseID = "UnitBlock.RF.SpiderBodyguard" }
 		]
 	},
 	{
 		ID = "DirewolfBodyguards",
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.DirewolfBodyguard"}
+			{ BaseID = "UnitBlock.RF.DirewolfBodyguard" }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
@@ -40,7 +40,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Unholds", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Unhold", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
@@ -1,0 +1,208 @@
+local parties = [
+	{
+		ID = "Direwolves",
+		HardMin = 3,
+		DefaultFigure = "figure_werewolf_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastDirewolves", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "Ghouls",
+		HardMin = 5,
+		DefaultFigure = "figure_ghoul_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastGhouls", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "Lindwurm",
+		HardMin = 1,
+		DefaultFigure = "figure_lindwurm_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastLindwurms", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "Unhold",
+		HardMin = 1,
+		DefaultFigure = "figure_unhold_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastUnholds", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "UnholdFrost",
+		HardMin = 1,
+		DefaultFigure = "figure_unhold_02",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastUnholdsFrost", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "UnholdBog",
+		HardMin = 1,
+		DefaultFigure = "figure_unhold_03",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastUnholdsBog", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "Spiders",
+		HardMin = 1,
+		DefaultFigure = "figure_spider_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastSpiders", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "Alps",
+		HardMin = 3,
+		DefaultFigure = "figure_alp_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastAlps", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "Schrats",
+		HardMin = 1,
+		DefaultFigure = "figure_schrat_01",
+		MovementSpeedMult = 0.5,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastSchrats", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "HexenAndMore",
+		HardMin = 1,
+		DefaultFigure = "figure_hexe_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.BeastHexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+		],
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastHexenWithBodyguards", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.BeastSpiders", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.BeastGhouls", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.BeastSchrats", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.BeastUnholds", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "UnitBlock.BeastUnholdsBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+			{ BaseID = "UnitBlock.BeastDirewolves", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.BeastHexenBandits", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "UnitBlock.BeastHexenBanditsRanged", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 200 }
+		]
+	},
+	{
+		ID = "HexenAndNoSpiders",
+		HardMin = 1,
+		DefaultFigure = "figure_hexe_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.BeastHexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+		],
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastHexenNoSpiders", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.BeastGhouls", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
+			{ BaseID = "UnitBlock.BeastSchrats", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.BeastUnholds", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "UnitBlock.BeastUnholdsBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+			{ BaseID = "UnitBlock.BeastDirewolves", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.BeastHexenBandits", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 }
+		]
+	},
+	{
+		ID = "Hexen",
+		HardMin = 1,
+		DefaultFigure = "figure_hexe_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastHexenNoBodyguards", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+
+	// Skipped Kraken
+	{
+		ID = "Hyenas",
+		HardMin = 3,
+		DefaultFigure = "figure_hyena_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastHyenas", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "Serpents",
+		HardMin = 3,
+		DefaultFigure = "figure_serpent_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastSerpents", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "SandGolems",
+		HardMin = 3,
+		DefaultFigure = "figure_golem_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastSandGolems", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	}
+
+	// SubParties
+	{
+		ID = "SpiderBodyguards",
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastSpiderBodyguards"}
+		]
+	},
+	{
+		ID = "DirewolfBodyguards",
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.BeastDirewolfBodyguards"}
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/beast_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Direwolf", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Ghoul", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -29,7 +29,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Lindwurm", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Lindwurm", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -40,7 +40,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Unhold", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -51,7 +51,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.UnholdFrost", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.UnholdFrost", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -62,7 +62,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.UnholdBog", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -73,7 +73,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Spider", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Spider", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -84,7 +84,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Alp", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Alp", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -95,7 +95,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Schrat", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -106,18 +106,18 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+			{ BaseID = "UnitBlock.RF.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HexeWithBodyguard", RatioMin = 0.00, RatioMax = 0.13 },
-			{ BaseID = "UnitBlock.Spider", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.Ghoul", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
-			{ BaseID = "UnitBlock.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ BaseID = "UnitBlock.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
-			{ BaseID = "UnitBlock.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.HexenBanditRanged", RatioMin = 0.00, RatioMax = 0.13 }
+			{ BaseID = "UnitBlock.RF.HexeWithBodyguard", RatioMin = 0.00, RatioMax = 0.13 },
+			{ BaseID = "UnitBlock.RF.Spider", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+			{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.HexenBanditRanged", RatioMin = 0.00, RatioMax = 0.13 }
 		]
 	},
 	{
@@ -128,16 +128,16 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+			{ BaseID = "UnitBlock.RF.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HexeNoSpider", RatioMin = 0.00, RatioMax = 0.13 },
-			{ BaseID = "UnitBlock.Ghoul", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
-			{ BaseID = "UnitBlock.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
-			{ BaseID = "UnitBlock.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ BaseID = "UnitBlock.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
-			{ BaseID = "UnitBlock.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "UnitBlock.RF.HexeNoSpider", RatioMin = 0.00, RatioMax = 0.13 },
+			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
+			{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+			{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+			{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -148,7 +148,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HexeNoBodyguard", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.HexeNoBodyguard", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 
@@ -161,7 +161,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Hyena", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Hyena", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -172,7 +172,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Serpent", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Serpent", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -183,7 +183,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.SandGolem", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.SandGolem", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	}
 
@@ -191,13 +191,13 @@ local parties = [
 	{
 		ID = "SpiderBodyguards",
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.SpiderBodyguard"}
+			{ BaseID = "UnitBlock.RF.SpiderBodyguard"}
 		]
 	},
 	{
 		ID = "DirewolfBodyguards",
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.DirewolfBodyguard"}
+			{ BaseID = "UnitBlock.RF.DirewolfBodyguard"}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/goblin_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/goblin_parties.nut
@@ -7,9 +7,9 @@ local parties = [
 		VisibilityMult = 1.0,		// Pure GoblinAmbusher groups have 0.75 here in vanilla
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true}		// Lategame GoblinRoamer only consist of Riders
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true}		// Lategame GoblinRoamer only consist of Riders
 		]
 	},
 	{	// Similar to GoblinRoamer except Scout sizes are capped in vanilla and they more mixed than Roamers. We have no cap in this implementation
@@ -20,9 +20,9 @@ local parties = [
 		VisibilityMult = 1.0,		// Parties that have no Rider have a value of 0.75 here in vanilla
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.GoblinFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinRanged", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinFlank", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinRanged", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinFlank", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 	{
@@ -33,10 +33,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
 	   ]
 	},
 	{
@@ -47,10 +47,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
 		]
 	},
 	{
@@ -61,10 +61,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50},
-			{ BaseID = "UnitBlock.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35},
-			{ BaseID = "UnitBlock.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true}	// One boss is always guaranteed
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50},
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true}	// One boss is always guaranteed
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/goblin_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/goblin_parties.nut
@@ -7,9 +7,9 @@ local parties = [
 		VisibilityMult = 1.0,		// Pure GoblinAmbusher groups have 0.75 here in vanilla
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true}		// Lategame GoblinRoamer only consist of Riders
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true }		// Lategame GoblinRoamer only consist of Riders
 		]
 	},
 	{	// Similar to GoblinRoamer except Scout sizes are capped in vanilla and they more mixed than Roamers. We have no cap in this implementation
@@ -20,9 +20,9 @@ local parties = [
 		VisibilityMult = 1.0,		// Parties that have no Rider have a value of 0.75 here in vanilla
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinRanged", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinFlank", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true }
 		]
 	},
 	{
@@ -33,10 +33,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true }	// One boss is guaranteed at 250+ resources
 	   ]
 	},
 	{
@@ -47,10 +47,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true }	// One boss is guaranteed at 250+ resources
 		]
 	},
 	{
@@ -61,10 +61,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50},
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35},
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true}	// One boss is always guaranteed
+			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true }	// One boss is always guaranteed
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/goblin_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/goblin_parties.nut
@@ -1,0 +1,75 @@
+local parties = [
+	{
+		ID = "GoblinRoamers",
+		HardMin = 4,
+		DefaultFigure = "figure_goblin_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,		// Pure GoblinAmbusher groups have 0.75 here in vanilla
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true}		// Lategame GoblinRoamer only consist of Riders
+		]
+	},
+	{	// Similar to GoblinRoamer except Scout sizes are capped in vanilla and they more mixed than Roamers. We have no cap in this implementation
+		ID = "GoblinScouts",
+		HardMin = 4,
+		DefaultFigure = "figure_goblin_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,		// Parties that have no Rider have a value of 0.75 here in vanilla
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.GoblinFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinRanged", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinFlank", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+		]
+	},
+	{
+		ID = "GoblinRaiders",
+		HardMin = 4,
+		DefaultFigure = "figure_goblin_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
+	   ]
+	},
+	{
+		ID = "GoblinDefenders",
+		HardMin = 4,
+		DefaultFigure = "figure_goblin_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
+		]
+	},
+	{
+		ID = "GoblinBoss",
+		HardMin = 12,
+		DefaultFigure = "figure_goblin_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50},
+			{ BaseID = "UnitBlock.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true}	// One boss is always guaranteed
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/greenskin_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/greenskin_parties.nut
@@ -1,0 +1,25 @@
+local parties = [
+	{
+		ID = "GreenskinHorde",
+		HardMin = 9,
+		DefaultFigure = "figure_orc_02",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.GreenskinGoblinsFoot", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinFlank", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinBoss", 			RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true},
+
+			{ BaseID = "UnitBlock.OrcYoung", 			RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.OrcWarrior", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.OrcBerserker", 		RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.OrcBoss", 				RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true}
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/greenskin_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/greenskin_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.GreenskinGoblinsFoot", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.GoblinRegular", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
 			{ BaseID = "UnitBlock.GoblinFlank", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
 			{ BaseID = "UnitBlock.GoblinBoss", 			RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true},
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/greenskin_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/greenskin_parties.nut
@@ -7,14 +7,14 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinRegular", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinFlank", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.GoblinBoss", 			RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinRegular", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true },
 
-			{ BaseID = "UnitBlock.RF.OrcYoung", 			RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.OrcWarrior", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.OrcBerserker", 		RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.OrcBoss", 				RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/greenskin_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/greenskin_parties.nut
@@ -7,14 +7,14 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.GoblinRegular", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinFlank", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.GoblinBoss", 			RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinRegular", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinFlank", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.GoblinBoss", 			RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true},
 
-			{ BaseID = "UnitBlock.OrcYoung", 			RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.OrcWarrior", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.OrcBerserker", 		RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.OrcBoss", 				RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.OrcYoung", 			RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.OrcWarrior", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.OrcBerserker", 		RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.OrcBoss", 				RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/human_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/human_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.CultistAmbush", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.CultistAmbush", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Peasant", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Peasant", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -29,7 +29,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.PeasantArmed", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.PeasantArmed", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -40,7 +40,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.SouthernPeasant", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.SouthernPeasant", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -51,9 +51,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.BountyHunter", RatioMin = 0.60, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30},
-			{ BaseID = "UnitBlock.Wardog", RatioMin = 0.05, RatioMax = 0.15}
+			{ BaseID = "UnitBlock.RF.BountyHunter", RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.RF.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30},
+			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.05, RatioMax = 0.15}
 		]
 	},
 	{
@@ -64,10 +64,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30},
-			{ BaseID = "UnitBlock.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, ReqPartySize = 10 },    // Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
-			{ BaseID = "UnitBlock.Wardog", RatioMin = 0.00, RatioMax = 0.12}
+			{ BaseID = "UnitBlock.RF.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.RF.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30},
+			{ BaseID = "UnitBlock.RF.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, ReqPartySize = 10 },    // Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
+			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.00, RatioMax = 0.12}
 		]
 	},
 	{
@@ -78,9 +78,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.MilitiaFrontline",    RatioMin = 0.60, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.MilitiaRanged",       RatioMin = 0.12, RatioMax = 0.35},
-			{ BaseID = "UnitBlock.MilitiaCaptain",      RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }   // Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
+			{ BaseID = "UnitBlock.RF.MilitiaFrontline",    RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.RF.MilitiaRanged",       RatioMin = 0.12, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.RF.MilitiaCaptain",      RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }   // Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
 		]
 	},
 	{
@@ -91,12 +91,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.CaravanDonkey" }
+			{ BaseID = "UnitBlock.RF.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.CaravanDonkey",  RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },      // Vanilla: Second Donkey starts spawning at 7+
-			{ BaseID = "UnitBlock.CaravanHand",    RatioMin = 0.35, RatioMax = 0.80},
-			{ BaseID = "UnitBlock.CaravanGuard",   RatioMin = 0.15, RatioMax = 0.55}
+			{ BaseID = "UnitBlock.RF.CaravanDonkey",  RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },      // Vanilla: Second Donkey starts spawning at 7+
+			{ BaseID = "UnitBlock.RF.CaravanHand",    RatioMin = 0.35, RatioMax = 0.80},
+			{ BaseID = "UnitBlock.RF.CaravanGuard",   RatioMin = 0.15, RatioMax = 0.55}
 		]
 	},
 	{
@@ -107,12 +107,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.CaravanDonkey" },      // In vanilla an escorted caravan can also have only a single Donkey. I chose to force 2 donkey every time instead
-			{ BaseID = "UnitBlock.CaravanDonkey" }
+			{ BaseID = "UnitBlock.RF.CaravanDonkey" },      // In vanilla an escorted caravan can also have only a single Donkey. I chose to force 2 donkey every time instead
+			{ BaseID = "UnitBlock.RF.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.CaravanDonkey",  RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },   // Vanilla: Third donkey spawns at 6+
-			{ BaseID = "UnitBlock.CaravanHand",    RatioMin = 0.50, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.CaravanDonkey",  RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },   // Vanilla: Third donkey spawns at 6+
+			{ BaseID = "UnitBlock.RF.CaravanHand",    RatioMin = 0.50, RatioMax = 1.00}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/human_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/human_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HumanCultistAmbush", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.CultistAmbush", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HumanPeasants", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.Peasant", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -29,7 +29,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HumanPeasantsArmed", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.PeasantArmed", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -40,7 +40,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HumanSouthernPeasants", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.SouthernPeasant", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -51,9 +51,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HumanBountyHunter", RatioMin = 0.60, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.HumanBountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30},
-			{ BaseID = "UnitBlock.HumanWardogs", RatioMin = 0.05, RatioMax = 0.15}
+			{ BaseID = "UnitBlock.BountyHunter", RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30},
+			{ BaseID = "UnitBlock.Wardog", RatioMin = 0.05, RatioMax = 0.15}
 		]
 	},
 	{
@@ -67,7 +67,7 @@ local parties = [
 			{ BaseID = "UnitBlock.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00},
 			{ BaseID = "UnitBlock.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30},
 			{ BaseID = "UnitBlock.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, ReqPartySize = 10 },    // Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
-			{ BaseID = "UnitBlock.HumanWardogs", RatioMin = 0.00, RatioMax = 0.12}
+			{ BaseID = "UnitBlock.Wardog", RatioMin = 0.00, RatioMax = 0.12}
 		]
 	},
 	{
@@ -78,9 +78,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HumanMilitiaFrontline",    RatioMin = 0.60, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.HumanMilitiaRanged",       RatioMin = 0.12, RatioMax = 0.35},
-			{ BaseID = "UnitBlock.HumanMilitiaCaptain",      RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }   // Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
+			{ BaseID = "UnitBlock.MilitiaFrontline",    RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.MilitiaRanged",       RatioMin = 0.12, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.MilitiaCaptain",      RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }   // Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
 		]
 	},
 	{
@@ -91,12 +91,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.HumanCaravanDonkey" }
+			{ BaseID = "UnitBlock.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HumanCaravanDonkeys",  RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },      // Vanilla: Second Donkey starts spawning at 7+
-			{ BaseID = "UnitBlock.HumanCaravanHands",    RatioMin = 0.35, RatioMax = 0.80},
-			{ BaseID = "UnitBlock.HumanCaravanGuards",   RatioMin = 0.15, RatioMax = 0.55}
+			{ BaseID = "UnitBlock.CaravanDonkey",  RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },      // Vanilla: Second Donkey starts spawning at 7+
+			{ BaseID = "UnitBlock.CaravanHand",    RatioMin = 0.35, RatioMax = 0.80},
+			{ BaseID = "UnitBlock.CaravanGuard",   RatioMin = 0.15, RatioMax = 0.55}
 		]
 	},
 	{
@@ -107,12 +107,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.HumanCaravanDonkey" },      // In vanilla an escorted caravan can also have only a single Donkey. I chose to force 2 donkey every time instead
-			{ BaseID = "UnitBlock.HumanCaravanDonkey" }
+			{ BaseID = "UnitBlock.CaravanDonkey" },      // In vanilla an escorted caravan can also have only a single Donkey. I chose to force 2 donkey every time instead
+			{ BaseID = "UnitBlock.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HumanCaravanDonkeys",  RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },   // Vanilla: Third donkey spawns at 6+
-			{ BaseID = "UnitBlock.HumanCaravanHands",    RatioMin = 0.50, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.CaravanDonkey",  RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },   // Vanilla: Third donkey spawns at 6+
+			{ BaseID = "UnitBlock.CaravanHand",    RatioMin = 0.50, RatioMax = 1.00}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/human_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/human_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.CultistAmbush", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.CultistAmbush", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Peasant", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.Peasant", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -29,7 +29,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.PeasantArmed", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.PeasantArmed", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -40,7 +40,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SouthernPeasant", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.SouthernPeasant", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -51,9 +51,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BountyHunter", RatioMin = 0.60, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30},
-			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.05, RatioMax = 0.15}
+			{ BaseID = "UnitBlock.RF.BountyHunter", RatioMin = 0.60, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30 },
+			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.05, RatioMax = 0.15 }
 		]
 	},
 	{
@@ -64,10 +64,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30},
+			{ BaseID = "UnitBlock.RF.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30 },
 			{ BaseID = "UnitBlock.RF.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, ReqPartySize = 10 },    // Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
-			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.00, RatioMax = 0.12}
+			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.00, RatioMax = 0.12 }
 		]
 	},
 	{
@@ -78,9 +78,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.MilitiaFrontline",    RatioMin = 0.60, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.MilitiaRanged",       RatioMin = 0.12, RatioMax = 0.35},
-			{ BaseID = "UnitBlock.RF.MilitiaCaptain",      RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }   // Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
+			{ BaseID = "UnitBlock.RF.MilitiaFrontline", RatioMin = 0.60, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.MilitiaRanged", RatioMin = 0.12, RatioMax = 0.35 },
+			{ BaseID = "UnitBlock.RF.MilitiaCaptain", RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }   // Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
 		]
 	},
 	{
@@ -94,9 +94,9 @@ local parties = [
 			{ BaseID = "UnitBlock.RF.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.CaravanDonkey",  RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },      // Vanilla: Second Donkey starts spawning at 7+
-			{ BaseID = "UnitBlock.RF.CaravanHand",    RatioMin = 0.35, RatioMax = 0.80},
-			{ BaseID = "UnitBlock.RF.CaravanGuard",   RatioMin = 0.15, RatioMax = 0.55}
+			{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },      // Vanilla: Second Donkey starts spawning at 7+
+			{ BaseID = "UnitBlock.RF.CaravanHand", RatioMin = 0.35, RatioMax = 0.80 },
+			{ BaseID = "UnitBlock.RF.CaravanGuard", RatioMin = 0.15, RatioMax = 0.55 }
 		]
 	},
 	{
@@ -111,8 +111,8 @@ local parties = [
 			{ BaseID = "UnitBlock.RF.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.CaravanDonkey",  RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },   // Vanilla: Third donkey spawns at 6+
-			{ BaseID = "UnitBlock.RF.CaravanHand",    RatioMin = 0.50, RatioMax = 1.00}
+			{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },   // Vanilla: Third donkey spawns at 6+
+			{ BaseID = "UnitBlock.RF.CaravanHand", RatioMin = 0.50, RatioMax = 1.00 }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/human_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/human_parties.nut
@@ -1,0 +1,123 @@
+local parties = [
+	{
+		ID = "Cultist",
+		HardMin = 4,
+		DefaultFigure = "figure_civilian_03",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.HumanCultistAmbush", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "Peasants",
+		HardMin = 3,
+		DefaultFigure = "figure_civilian_01",
+		MovementSpeedMult = 0.75,
+		VisibilityMult = 1.0,
+		VisionMult = 0.75,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.HumanPeasants", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "PeasantsArmed",
+		HardMin = 3,
+		DefaultFigure = "figure_civilian_01",
+		MovementSpeedMult = 0.75,
+		VisibilityMult = 1.0,
+		VisionMult = 0.75,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.HumanPeasantsArmed", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "PeasantsSouthern",
+		HardMin = 3,
+		DefaultFigure = "figure_civilian_06",
+		MovementSpeedMult = 0.75,
+		VisibilityMult = 1.0,
+		VisionMult = 0.75,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.HumanSouthernPeasants", RatioMin = 0.00, RatioMax = 1.00}
+		]
+	},
+	{
+		ID = "BountyHunters",
+		HardMin = 5,
+		DefaultFigure = "figure_bandit_03",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.HumanBountyHunter", RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.HumanBountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30},
+			{ BaseID = "UnitBlock.HumanWardogs", RatioMin = 0.05, RatioMax = 0.15}
+		]
+	},
+	{
+		ID = "Mercenaries",
+		HardMin = 5,
+		DefaultFigure = "figure_bandit_03",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30},
+			{ BaseID = "UnitBlock.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, ReqPartySize = 10 },    // Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
+			{ BaseID = "UnitBlock.HumanWardogs", RatioMin = 0.00, RatioMax = 0.12}
+		]
+	},
+	{
+		ID = "Militia",
+		HardMin = 6,
+		DefaultFigure = "figure_militia_01",	// In vanilla this is either ["figure_militia_01", "figure_militia_02"]
+		MovementSpeedMult = 0.9,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.HumanMilitiaFrontline",    RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.HumanMilitiaRanged",       RatioMin = 0.12, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.HumanMilitiaCaptain",      RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }   // Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
+		]
+	},
+	{
+		ID = "Caravan",
+		HardMin = 4,
+		DefaultFigure = "cart_02",
+		MovementSpeedMult = 0.5,
+		VisibilityMult = 1.0,
+		VisionMult = 0.25,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.HumanCaravanDonkey" }
+		],
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.HumanCaravanDonkeys",  RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },      // Vanilla: Second Donkey starts spawning at 7+
+			{ BaseID = "UnitBlock.HumanCaravanHands",    RatioMin = 0.35, RatioMax = 0.80},
+			{ BaseID = "UnitBlock.HumanCaravanGuards",   RatioMin = 0.15, RatioMax = 0.55}
+		]
+	},
+	{
+		ID = "CaravanEscort",   // Caravans spawned for player escort contract
+		HardMin = 4,
+		DefaultFigure = "cart_02",
+		MovementSpeedMult = 0.5,
+		VisibilityMult = 1.0,
+		VisionMult = 0.25,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.HumanCaravanDonkey" },      // In vanilla an escorted caravan can also have only a single Donkey. I chose to force 2 donkey every time instead
+			{ BaseID = "UnitBlock.HumanCaravanDonkey" }
+		],
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.HumanCaravanDonkeys",  RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },   // Vanilla: Third donkey spawns at 6+
+			{ BaseID = "UnitBlock.HumanCaravanHands",    RatioMin = 0.50, RatioMax = 1.00}
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/noble_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/noble_parties.nut
@@ -7,13 +7,13 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.NobleFrontline",   RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NobleBackline",    RatioMin = 0.01, RatioMax = 0.35 },
-			{ BaseID = "UnitBlock.RF.NobleRanged",      RatioMin = 0.01, RatioMax = 0.28 },
-			{ BaseID = "UnitBlock.RF.NobleFlank",       RatioMin = 0.00, RatioMax = 0.12 },
-			{ BaseID = "UnitBlock.RF.NobleSupport",     RatioMin = 0.01, RatioMax = 0.07, DeterminesFigure = true, ReqPartySize = 10 },    // Vanilla: Bannerman start spawning at 14
-			{ BaseID = "UnitBlock.RF.NobleOfficer",     RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, ReqPartySize = 8 },    // Vanilla: First sergeant spawns at 9, next one 12 and then 15+; Second one spawns at 27+
-			{ BaseID = "UnitBlock.RF.NobleElite",       RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.NobleFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NobleBackline", RatioMin = 0.01, RatioMax = 0.35 },
+			{ BaseID = "UnitBlock.RF.NobleRanged", RatioMin = 0.01, RatioMax = 0.28 },
+			{ BaseID = "UnitBlock.RF.NobleFlank", RatioMin = 0.00, RatioMax = 0.12 },
+			{ BaseID = "UnitBlock.RF.NobleSupport", RatioMin = 0.01, RatioMax = 0.07, DeterminesFigure = true, ReqPartySize = 10 },    // Vanilla: Bannerman start spawning at 14
+			{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, ReqPartySize = 8 },    // Vanilla: First sergeant spawns at 9, next one 12 and then 15+; Second one spawns at 27+
+			{ BaseID = "UnitBlock.RF.NobleElite", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
 		]
 	},
 	{
@@ -27,12 +27,12 @@ local parties = [
 			{ BaseID = "UnitBlock.RF.HumanCaravanDonkey" }      // Makes it much easier to get a good ratio
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.NobleFrontline",   RatioMin = 0.35, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.NobleBackline",    RatioMin = 0.08, RatioMax = 0.35},
-			{ BaseID = "UnitBlock.RF.NobleRanged",      RatioMin = 0.08, RatioMax = 0.28},
-			{ BaseID = "UnitBlock.RF.NobleOfficer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 10 },  // Vanilla: spawns at 12, at 15 and at 18 once respectively
-			{ BaseID = "UnitBlock.RF.NobleElite",       RatioMin = 0.00, RatioMax = 0.40 },
-			{ BaseID = "UnitBlock.RF.NobleDonkeys",     RatioMin = 0.01, RatioMax = 0.08, ReqPartySize = 13 }   // Vanilla: second donkey spawns at 14+
+			{ BaseID = "UnitBlock.RF.NobleFrontline", RatioMin = 0.35, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.NobleBackline", RatioMin = 0.08, RatioMax = 0.35 },
+			{ BaseID = "UnitBlock.RF.NobleRanged", RatioMin = 0.08, RatioMax = 0.28 },
+			{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 10 },  // Vanilla: spawns at 12, at 15 and at 18 once respectively
+			{ BaseID = "UnitBlock.RF.NobleElite", RatioMin = 0.00, RatioMax = 0.40 },
+			{ BaseID = "UnitBlock.RF.NobleDonkey", RatioMin = 0.01, RatioMax = 0.08, ReqPartySize = 13 }   // Vanilla: second donkey spawns at 14+
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/noble_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/noble_parties.nut
@@ -7,13 +7,13 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.NobleFrontline",   RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.NobleBackline",    RatioMin = 0.01, RatioMax = 0.35 },
-			{ BaseID = "UnitBlock.NobleRanged",      RatioMin = 0.01, RatioMax = 0.28 },
-			{ BaseID = "UnitBlock.NobleFlank",       RatioMin = 0.00, RatioMax = 0.12 },
-			{ BaseID = "UnitBlock.NobleSupport",     RatioMin = 0.01, RatioMax = 0.07, DeterminesFigure = true, ReqPartySize = 10 },    // Vanilla: Bannerman start spawning at 14
-			{ BaseID = "UnitBlock.NobleOfficer",     RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, ReqPartySize = 8 },    // Vanilla: First sergeant spawns at 9, next one 12 and then 15+; Second one spawns at 27+
-			{ BaseID = "UnitBlock.NobleElite",       RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.NobleFrontline",   RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NobleBackline",    RatioMin = 0.01, RatioMax = 0.35 },
+			{ BaseID = "UnitBlock.RF.NobleRanged",      RatioMin = 0.01, RatioMax = 0.28 },
+			{ BaseID = "UnitBlock.RF.NobleFlank",       RatioMin = 0.00, RatioMax = 0.12 },
+			{ BaseID = "UnitBlock.RF.NobleSupport",     RatioMin = 0.01, RatioMax = 0.07, DeterminesFigure = true, ReqPartySize = 10 },    // Vanilla: Bannerman start spawning at 14
+			{ BaseID = "UnitBlock.RF.NobleOfficer",     RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, ReqPartySize = 8 },    // Vanilla: First sergeant spawns at 9, next one 12 and then 15+; Second one spawns at 27+
+			{ BaseID = "UnitBlock.RF.NobleElite",       RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
 		]
 	},
 	{
@@ -24,15 +24,15 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.HumanCaravanDonkey" }      // Makes it much easier to get a good ratio
+			{ BaseID = "UnitBlock.RF.HumanCaravanDonkey" }      // Makes it much easier to get a good ratio
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.NobleFrontline",   RatioMin = 0.35, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.NobleBackline",    RatioMin = 0.08, RatioMax = 0.35},
-			{ BaseID = "UnitBlock.NobleRanged",      RatioMin = 0.08, RatioMax = 0.28},
-			{ BaseID = "UnitBlock.NobleOfficer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 10 },  // Vanilla: spawns at 12, at 15 and at 18 once respectively
-			{ BaseID = "UnitBlock.NobleElite",       RatioMin = 0.00, RatioMax = 0.40 },
-			{ BaseID = "UnitBlock.NobleDonkeys",     RatioMin = 0.01, RatioMax = 0.08, ReqPartySize = 13 }   // Vanilla: second donkey spawns at 14+
+			{ BaseID = "UnitBlock.RF.NobleFrontline",   RatioMin = 0.35, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.RF.NobleBackline",    RatioMin = 0.08, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.RF.NobleRanged",      RatioMin = 0.08, RatioMax = 0.28},
+			{ BaseID = "UnitBlock.RF.NobleOfficer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 10 },  // Vanilla: spawns at 12, at 15 and at 18 once respectively
+			{ BaseID = "UnitBlock.RF.NobleElite",       RatioMin = 0.00, RatioMax = 0.40 },
+			{ BaseID = "UnitBlock.RF.NobleDonkeys",     RatioMin = 0.01, RatioMax = 0.08, ReqPartySize = 13 }   // Vanilla: second donkey spawns at 14+
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/noble_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/noble_parties.nut
@@ -1,0 +1,43 @@
+local parties = [
+	{
+		ID = "Noble",
+		HardMin = 5,
+		DefaultFigure = "figure_noble_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.NobleFrontline",   RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.NobleBackline",    RatioMin = 0.01, RatioMax = 0.35 },
+			{ BaseID = "UnitBlock.NobleRanged",      RatioMin = 0.01, RatioMax = 0.28 },
+			{ BaseID = "UnitBlock.NobleFlank",       RatioMin = 0.00, RatioMax = 0.12 },
+			{ BaseID = "UnitBlock.NobleSupport",     RatioMin = 0.01, RatioMax = 0.07, DeterminesFigure = true, ReqPartySize = 10 },    // Vanilla: Bannerman start spawning at 14
+			{ BaseID = "UnitBlock.NobleOfficer",     RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, ReqPartySize = 8 },    // Vanilla: First sergeant spawns at 9, next one 12 and then 15+; Second one spawns at 27+
+			{ BaseID = "UnitBlock.NobleElite",       RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+		]
+	},
+	{
+		ID = "NobleCaravan",
+		HardMin = 7,
+		DefaultFigure = "cart_01",
+		MovementSpeedMult = 0.5,
+		VisibilityMult = 1.0,
+		VisionMult = 0.25,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.HumanCaravanDonkey" }      // Makes it much easier to get a good ratio
+		],
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.NobleFrontline",   RatioMin = 0.35, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.NobleBackline",    RatioMin = 0.08, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.NobleRanged",      RatioMin = 0.08, RatioMax = 0.28},
+			{ BaseID = "UnitBlock.NobleOfficer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 10 },  // Vanilla: spawns at 12, at 15 and at 18 once respectively
+			{ BaseID = "UnitBlock.NobleElite",       RatioMin = 0.00, RatioMax = 0.40 },
+			{ BaseID = "UnitBlock.NobleDonkeys",     RatioMin = 0.01, RatioMax = 0.08, ReqPartySize = 13 }   // Vanilla: second donkey spawns at 14+
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/nomad_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/nomad_parties.nut
@@ -7,8 +7,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.NomadFrontline",    RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadRanged",       RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true }
 		]
 	},
 	{
@@ -19,10 +19,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.NomadFrontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadRanged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadLeader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
-			{ BaseID = "UnitBlock.RF.NomadElite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
+			{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
 		]
 	},
 	{
@@ -33,10 +33,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.NomadFrontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadRanged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadLeader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },    // Vanilla: spawn at 7+
-			{ BaseID = "UnitBlock.RF.NomadElite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },    // Vanilla: spawn at 7+
+			{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/nomad_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/nomad_parties.nut
@@ -1,0 +1,48 @@
+local parties = [
+	{
+		ID = "NomadRoamers",
+		HardMin = 6,
+		DefaultFigure = "figure_nomad_01",  // Icon for Cutthroats
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.NomadFrontline",    RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.NomadRanged",       RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true }
+		]
+	},
+	{
+		ID = "NomadRaiders",
+		HardMin = 4,
+		DefaultFigure = "figure_nomad_01",  // Icon for Cutthroats
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.NomadFrontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.NomadRanged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.NomadLeader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
+			{ BaseID = "UnitBlock.NomadElite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+		]
+	},
+	{
+		ID = "NomadDefenders",
+		HardMin = 4,
+		DefaultFigure = "figure_nomad_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.NomadFrontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.NomadRanged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.NomadLeader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },    // Vanilla: spawn at 7+
+			{ BaseID = "UnitBlock.NomadElite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}
+

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/nomad_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/nomad_parties.nut
@@ -7,8 +7,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.NomadFrontline",    RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.NomadRanged",       RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.NomadFrontline",    RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadRanged",       RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true }
 		]
 	},
 	{
@@ -19,10 +19,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.NomadFrontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.NomadRanged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.NomadLeader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
-			{ BaseID = "UnitBlock.NomadElite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.NomadFrontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadRanged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadLeader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
+			{ BaseID = "UnitBlock.RF.NomadElite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
 		]
 	},
 	{
@@ -33,10 +33,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.NomadFrontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.NomadRanged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.NomadLeader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },    // Vanilla: spawn at 7+
-			{ BaseID = "UnitBlock.NomadElite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.NomadFrontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadRanged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.NomadLeader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },    // Vanilla: spawn at 7+
+			{ BaseID = "UnitBlock.RF.NomadElite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/orc_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/orc_parties.nut
@@ -32,7 +32,7 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true, StartingResourceMax = 250},
-			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.00, RatioMax = 0.65, DeterminesFigure = true, StartingResourceMin = 250},	// Lategame Parties will have less Young in them
+			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.00, RatioMax = 0.65, DeterminesFigure = true, StartingResourceMin = 250},	// Lategame Parties will have fewer Young in them
 			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, DeterminesFigure = true, StartingResourceMin = 125},
 			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true, StartingResourceMin = 150},
 			{ BaseID = "UnitBlock.RF.OrcBoss", 		RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/orc_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/orc_parties.nut
@@ -1,0 +1,109 @@
+local parties = [
+	{
+		ID = "OrcRoamers",
+		HardMin = 4,
+		DefaultFigure = "figure_orc_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
+		]
+	},
+	{	// This is currently the same as OrcRoamers. I couldn't spot differences in Vanilla
+		ID = "OrcScouts",
+		HardMin = 4,
+		DefaultFigure = "figure_orc_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
+		]
+	},
+	{
+		ID = "OrcRaiders",
+		HardMin = 5,
+		DefaultFigure = "figure_orc_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true, StartingResourceMax = 250},
+			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.00, RatioMax = 0.65, DeterminesFigure = true, StartingResourceMin = 250},	// Lategame Parties will have less Young in them
+			{ BaseID = "UnitBlock.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, DeterminesFigure = true, StartingResourceMin = 125},
+			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true, StartingResourceMin = 150},
+			{ BaseID = "UnitBlock.OrcBoss", 		RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
+		]
+	},
+	{
+		ID = "OrcDefenders",
+		HardMin = 4,
+		DefaultFigure = "figure_orc_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.15, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, StartingResourceMin = 125},
+			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80, StartingResourceMin = 150},
+			{ BaseID = "UnitBlock.OrcBoss", 		RatioMin = 0.00, RatioMax = 0.08, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
+		]
+	},
+	{
+		ID = "OrcBoss",
+		HardMin = 8,
+		DefaultFigure = "figure_orc_05",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.15, RatioMax = 0.80},
+			{ BaseID = "UnitBlock.OrcBerserker", RatioMin = 0.00, RatioMax = 0.50},
+			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80},
+			{ BaseID = "UnitBlock.OrcBoss", 		RatioMin = 0.01, RatioMax = 0.05}				// Vanilla never spawns more than one Boss here
+		]
+	},
+	{	// In Vanilla these never spawn OrcYoungLOW but here they do
+		ID = "YoungOrcsOnly",
+		HardMin = 4,		// In Vanilla this is 2 when spawning Berserker only
+		DefaultFigure = "figure_orc_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.OrcYoung", 		DeterminesFigure = true }
+		]
+	},
+	{	// In Vanilla these never spawn OrcYoungLOW but here they do
+		ID = "YoungOrcsAndBerserkers",
+		HardMin = 3,		// In Vanilla this is 2 when spawning Berserker only
+		DefaultFigure = "figure_orc_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.OrcYoung", 		DeterminesFigure = true },
+			{ BaseID = "UnitBlock.OrcBerserker", 	DeterminesFigure = true }
+		]
+	},
+	{
+		ID = "BerserkersOnly",
+		HardMin = 2,
+		DefaultFigure = "figure_orc_03",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.OrcBerserker" }
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}
+

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/orc_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/orc_parties.nut
@@ -7,8 +7,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
+			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
 		]
 	},
 	{	// This is currently the same as OrcRoamers. I couldn't spot differences in Vanilla
@@ -19,8 +19,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
+			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
 		]
 	},
 	{
@@ -31,11 +31,11 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true, StartingResourceMax = 250},
-			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.00, RatioMax = 0.65, DeterminesFigure = true, StartingResourceMin = 250},	// Lategame Parties will have less Young in them
-			{ BaseID = "UnitBlock.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, DeterminesFigure = true, StartingResourceMin = 125},
-			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true, StartingResourceMin = 150},
-			{ BaseID = "UnitBlock.OrcBoss", 		RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
+			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true, StartingResourceMax = 250},
+			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.00, RatioMax = 0.65, DeterminesFigure = true, StartingResourceMin = 250},	// Lategame Parties will have less Young in them
+			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, DeterminesFigure = true, StartingResourceMin = 125},
+			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true, StartingResourceMin = 150},
+			{ BaseID = "UnitBlock.RF.OrcBoss", 		RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
 		]
 	},
 	{
@@ -46,10 +46,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.15, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, StartingResourceMin = 125},
-			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80, StartingResourceMin = 150},
-			{ BaseID = "UnitBlock.OrcBoss", 		RatioMin = 0.00, RatioMax = 0.08, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
+			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.15, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, StartingResourceMin = 125},
+			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80, StartingResourceMin = 150},
+			{ BaseID = "UnitBlock.RF.OrcBoss", 		RatioMin = 0.00, RatioMax = 0.08, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
 		]
 	},
 	{
@@ -60,10 +60,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.OrcYoung", 	RatioMin = 0.15, RatioMax = 0.80},
-			{ BaseID = "UnitBlock.OrcBerserker", RatioMin = 0.00, RatioMax = 0.50},
-			{ BaseID = "UnitBlock.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80},
-			{ BaseID = "UnitBlock.OrcBoss", 		RatioMin = 0.01, RatioMax = 0.05}				// Vanilla never spawns more than one Boss here
+			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.15, RatioMax = 0.80},
+			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.50},
+			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80},
+			{ BaseID = "UnitBlock.RF.OrcBoss", 		RatioMin = 0.01, RatioMax = 0.05}				// Vanilla never spawns more than one Boss here
 		]
 	},
 	{	// In Vanilla these never spawn OrcYoungLOW but here they do
@@ -74,7 +74,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.OrcYoung", 		DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.OrcYoung", 		DeterminesFigure = true }
 		]
 	},
 	{	// In Vanilla these never spawn OrcYoungLOW but here they do
@@ -85,8 +85,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.OrcYoung", 		DeterminesFigure = true },
-			{ BaseID = "UnitBlock.OrcBerserker", 	DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.OrcYoung", 		DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.OrcBerserker", 	DeterminesFigure = true }
 		]
 	},
 	{
@@ -97,7 +97,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.OrcBerserker" }
+			{ BaseID = "UnitBlock.RF.OrcBerserker" }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/orc_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/orc_parties.nut
@@ -7,8 +7,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
+			{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150 }
 		]
 	},
 	{	// This is currently the same as OrcRoamers. I couldn't spot differences in Vanilla
@@ -19,8 +19,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
+			{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150 }
 		]
 	},
 	{
@@ -31,11 +31,11 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true, StartingResourceMax = 250},
-			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.00, RatioMax = 0.65, DeterminesFigure = true, StartingResourceMin = 250},	// Lategame Parties will have fewer Young in them
-			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, DeterminesFigure = true, StartingResourceMin = 125},
-			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true, StartingResourceMin = 150},
-			{ BaseID = "UnitBlock.RF.OrcBoss", 		RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
+			{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true, StartingResourceMax = 250 },
+			{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 0.65, DeterminesFigure = true, StartingResourceMin = 250 },	// Lategame Parties will have fewer Young in them
+			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, DeterminesFigure = true, StartingResourceMin = 125 },
+			{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true, StartingResourceMin = 150 },
+			{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, StartingResourceMin = 210 }		// Vanilla never spawns more than one Boss here
 		]
 	},
 	{
@@ -46,10 +46,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.15, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, StartingResourceMin = 125},
-			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80, StartingResourceMin = 150},
-			{ BaseID = "UnitBlock.RF.OrcBoss", 		RatioMin = 0.00, RatioMax = 0.08, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
+			{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.15, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, StartingResourceMin = 125 },
+			{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.80, StartingResourceMin = 150 },
+			{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.00, RatioMax = 0.08, StartingResourceMin = 210 }		// Vanilla never spawns more than one Boss here
 		]
 	},
 	{
@@ -60,10 +60,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.OrcYoung", 	RatioMin = 0.15, RatioMax = 0.80},
-			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.50},
-			{ BaseID = "UnitBlock.RF.OrcWarrior", 	RatioMin = 0.00, RatioMax = 0.80},
-			{ BaseID = "UnitBlock.RF.OrcBoss", 		RatioMin = 0.01, RatioMax = 0.05}				// Vanilla never spawns more than one Boss here
+			{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.15, RatioMax = 0.80 },
+			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.50 },
+			{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.80 },
+			{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.01, RatioMax = 0.05 }				// Vanilla never spawns more than one Boss here
 		]
 	},
 	{	// In Vanilla these never spawn OrcYoungLOW but here they do
@@ -74,7 +74,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.OrcYoung", 		DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.OrcYoung", DeterminesFigure = true }
 		]
 	},
 	{	// In Vanilla these never spawn OrcYoungLOW but here they do
@@ -85,8 +85,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.OrcYoung", 		DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.OrcBerserker", 	DeterminesFigure = true }
+			{ BaseID = "UnitBlock.RF.OrcYoung", DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.OrcBerserker", DeterminesFigure = true }
 		]
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
@@ -7,13 +7,13 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
-			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
-			{ BaseID = "UnitBlock.RF.UndeadFrontline", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.UndeadBackline", RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.ScourgeBoss", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17},
-			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18}
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18 },
+			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20 },	// Vanilla does not spawn T3 Ghouls. We allow it here
+			{ BaseID = "UnitBlock.RF.UndeadFrontline", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.UndeadBackline", RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.ScourgeBoss", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17 },
+			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18 }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
@@ -12,7 +12,7 @@ local parties = [
 			{ BaseID = "UnitBlock.Ghouls", 		RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
 			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
 			{ BaseID = "UnitBlock.UndeadBackline", 	RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.ScourgeBoss", 		RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17, StartingResourceMin = 350},
+			{ BaseID = "UnitBlock.ScourgeBoss", 		RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17},
 			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18},
 		]
 	}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
@@ -1,0 +1,24 @@
+local parties = [
+	{
+		ID = "UndeadScourge",
+		HardMin = 8,
+		DefaultFigure = "figure_skeleton_01",
+		MovementSpeedMult = 0.9,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.ZombieFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.ZombieGhost", 		RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
+			{ BaseID = "UnitBlock.BeastGhouls", 		RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
+			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.UndeadBackline", 	RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.ScourgeBoss", 		RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17, StartingResourceMin = 350},
+			{ BaseID = "UnitBlock.UndeadVampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18},
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
@@ -12,7 +12,7 @@ local parties = [
 			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20 },	// Vanilla does not spawn T3 Ghouls. We allow it here
 			{ BaseID = "UnitBlock.RF.UndeadFrontline", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true },
 			{ BaseID = "UnitBlock.RF.UndeadBackline", RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.ScourgeBoss", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17 },
+			{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17 },
 			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18 }
 		]
 	}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
@@ -8,12 +8,12 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.ZombieFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.ZombieGhost", 		RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
-			{ BaseID = "UnitBlock.BeastGhouls", 		RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
+			{ BaseID = "UnitBlock.Ghost", 		RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
+			{ BaseID = "UnitBlock.Ghouls", 		RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
 			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
 			{ BaseID = "UnitBlock.UndeadBackline", 	RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
 			{ BaseID = "UnitBlock.ScourgeBoss", 		RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17, StartingResourceMin = 350},
-			{ BaseID = "UnitBlock.UndeadVampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18},
+			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18},
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
@@ -7,13 +7,13 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.Ghost", 		RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
-			{ BaseID = "UnitBlock.RF.Ghouls", 		RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
-			{ BaseID = "UnitBlock.RF.UndeadFrontline", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.UndeadBackline", 	RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.ScourgeBoss", 		RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17},
-			{ BaseID = "UnitBlock.RF.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18},
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
+			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
+			{ BaseID = "UnitBlock.RF.UndeadFrontline", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.UndeadBackline", RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.ScourgeBoss", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17},
+			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/scourge_parties.nut
@@ -7,13 +7,13 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.ZombieFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.Ghost", 		RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
-			{ BaseID = "UnitBlock.Ghouls", 		RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
-			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.UndeadBackline", 	RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.ScourgeBoss", 		RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17},
-			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18},
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.Ghost", 		RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
+			{ BaseID = "UnitBlock.RF.Ghouls", 		RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
+			{ BaseID = "UnitBlock.RF.UndeadFrontline", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.UndeadBackline", 	RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.ScourgeBoss", 		RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17},
+			{ BaseID = "UnitBlock.RF.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18},
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
@@ -8,12 +8,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SouthernFrontline",    RatioMin = 0.50, RatioMax = 0.90, DeterminesFigure = true},			// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.SouthernBackline",     RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.SouthernRanged",       RatioMin = 0.00, RatioMax = 0.30 },		// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.Assassin",    RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
-			{ BaseID = "UnitBlock.RF.Officer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true},		// Vanilla: Start spawning at 15+
-			{ BaseID = "UnitBlock.RF.Siege",        RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
+			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.50, RatioMax = 0.90, DeterminesFigure = true },			// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.SouthernRanged", RatioMin = 0.00, RatioMax = 0.30 },		// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
+			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true },		// Vanilla: Start spawning at 15+
+			{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
 		]
 	},
 	{
@@ -27,11 +27,11 @@ local parties = [
 			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SouthernFrontline",        RatioMin = 0.15, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.Slave",           RatioMin = 0.00, RatioMax = 0.25 },
-			{ BaseID = "UnitBlock.RF.SouthernBackline",         RatioMin = 0.10, RatioMax = 0.40 },
-			{ BaseID = "UnitBlock.RF.Officer",         RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14 },
-			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey",   RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }   // Vanilla: Second starts spawning at 14, then 16+
+			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.15, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 0.25 },
+			{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40 },
+			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14 },
+			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }   // Vanilla: Second starts spawning at 14, then 16+
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
@@ -46,9 +46,9 @@ local parties = [
 			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SouthernFrontline",        RatioMin = 0.35, RatioMax = 1.00 },
-			// { BaseID = "UnitBlock.RF.Slave",           RatioMin = 0.00, RatioMax = 0.25 },     // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
-			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey",   RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
+			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.35, RatioMax = 1.00 },
+			// { BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 0.25 },     // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
+			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
@@ -60,7 +60,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Slave",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -71,7 +71,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.HumanSlaves",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -82,7 +82,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Assassin",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
@@ -8,12 +8,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.SouthernFrontline",    RatioMin = 0.50, RatioMax = 0.90, DeterminesFigure = true},			// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.SouthernBackline",     RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.SouthernRanged",       RatioMin = 0.00, RatioMax = 0.30 },		// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.Assassin",    RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
-			{ BaseID = "UnitBlock.Officer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true},		// Vanilla: Start spawning at 15+
-			{ BaseID = "UnitBlock.Siege",        RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
+			{ BaseID = "UnitBlock.RF.SouthernFrontline",    RatioMin = 0.50, RatioMax = 0.90, DeterminesFigure = true},			// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.SouthernBackline",     RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.SouthernRanged",       RatioMin = 0.00, RatioMax = 0.30 },		// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.Assassin",    RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
+			{ BaseID = "UnitBlock.RF.Officer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true},		// Vanilla: Start spawning at 15+
+			{ BaseID = "UnitBlock.RF.Siege",        RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
 		]
 	},
 	{
@@ -24,14 +24,14 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.SouthernCaravanDonkey" }
+			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.SouthernFrontline",        RatioMin = 0.15, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.Slave",           RatioMin = 0.00, RatioMax = 0.25 },
-			{ BaseID = "UnitBlock.SouthernBackline",         RatioMin = 0.10, RatioMax = 0.40 },
-			{ BaseID = "UnitBlock.Officer",         RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14 },
-			{ BaseID = "UnitBlock.SouthernCaravanDonkey",   RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }   // Vanilla: Second starts spawning at 14, then 16+
+			{ BaseID = "UnitBlock.RF.SouthernFrontline",        RatioMin = 0.15, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.Slave",           RatioMin = 0.00, RatioMax = 0.25 },
+			{ BaseID = "UnitBlock.RF.SouthernBackline",         RatioMin = 0.10, RatioMax = 0.40 },
+			{ BaseID = "UnitBlock.RF.Officer",         RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14 },
+			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey",   RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }   // Vanilla: Second starts spawning at 14, then 16+
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
@@ -43,12 +43,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.SouthernCaravanDonkey" }
+			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.SouthernFrontline",        RatioMin = 0.35, RatioMax = 1.00 },
-			// { BaseID = "UnitBlock.Slave",           RatioMin = 0.00, RatioMax = 0.25 },     // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
-			{ BaseID = "UnitBlock.SouthernCaravanDonkey",   RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
+			{ BaseID = "UnitBlock.RF.SouthernFrontline",        RatioMin = 0.35, RatioMax = 1.00 },
+			// { BaseID = "UnitBlock.RF.Slave",           RatioMin = 0.00, RatioMax = 0.25 },     // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
+			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey",   RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
@@ -60,7 +60,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Slave",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "UnitBlock.RF.Slave",           RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -71,7 +71,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.HumanSlaves",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "UnitBlock.RF.HumanSlaves",           RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -82,7 +82,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Assassin",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "UnitBlock.RF.Assassin",           RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 
@@ -92,7 +92,7 @@ local parties = [
 		HardMin = 2,
 		HardMax = 2,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Engineer"}
+			{ BaseID = "UnitBlock.RF.Engineer"}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
@@ -1,0 +1,104 @@
+local parties = [
+	{
+		ID = "Southern",
+		HardMin = 5,
+		// HardMax = 40,
+		DefaultFigure = "figure_southern_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.SouthernFrontline",    RatioMin = 0.50, RatioMax = 0.90, DeterminesFigure = true},			// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.SouthernBackline",     RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.SouthernRanged",       RatioMin = 0.00, RatioMax = 0.30 },		// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.SouthernAssassins",    RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
+			{ BaseID = "UnitBlock.SouthernOfficers",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true},		// Vanilla: Start spawning at 15+
+			{ BaseID = "UnitBlock.SouthernSiege",        RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
+		]
+	},
+	{
+		ID = "CaravanSouthern",
+		HardMin = 10,
+		DefaultFigure = "cart_03",
+		MovementSpeedMult = 0.5,
+		VisibilityMult = 1.0,
+		VisionMult = 0.25,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.SouthernCaravanDonkey" }
+		],
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.SouthernFrontline",        RatioMin = 0.15, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.SouthernSlaves",           RatioMin = 0.00, RatioMax = 0.25 },
+			{ BaseID = "UnitBlock.SouthernBackline",         RatioMin = 0.10, RatioMax = 0.40 },
+			{ BaseID = "UnitBlock.SouthernOfficers",         RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14 },
+			{ BaseID = "UnitBlock.SouthernCaravanDonkeys",   RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }   // Vanilla: Second starts spawning at 14, then 16+
+		]
+		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
+	},
+	{
+		ID = "CaravanSouthernEscort",   // For Contract Escort missions
+		HardMin = 2,
+		DefaultFigure = "cart_03",
+		MovementSpeedMult = 0.5,
+		VisibilityMult = 1.0,
+		VisionMult = 0.25,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.SouthernCaravanDonkey" }
+		],
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.SouthernFrontline",        RatioMin = 0.35, RatioMax = 1.00 },
+			// { BaseID = "UnitBlock.SouthernSlaves",           RatioMin = 0.00, RatioMax = 0.25 },     // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
+			{ BaseID = "UnitBlock.SouthernCaravanDonkeys",   RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
+		]
+		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
+	},
+	{
+		ID = "Slaves",
+		HardMin = 6,
+		DefaultFigure = "figure_slave_01",
+		MovementSpeedMult = 0.66,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.SouthernSlaves",           RatioMin = 0.00, RatioMax = 1.00 }
+		]
+	},
+	{
+		ID = "NorthernSlaves",
+		HardMin = 6,
+		DefaultFigure = "figure_slave_01",
+		MovementSpeedMult = 0.66,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.HumanSlaves",           RatioMin = 0.00, RatioMax = 1.00 }
+		]
+	},
+	{
+		ID = "Assassins",
+		HardMin = 3,
+		DefaultFigure = "figure_southern_01",
+		MovementSpeedMult = 1.00,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.SouthernAssassins",           RatioMin = 0.00, RatioMax = 1.00 }
+		]
+	},
+
+	// SubParties
+	{
+		ID = "MortarEngineers"
+		HardMin = 2,
+		HardMax = 2,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.SouthernEngineer"}
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}
+

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
@@ -11,9 +11,9 @@ local parties = [
 			{ BaseID = "UnitBlock.SouthernFrontline",    RatioMin = 0.50, RatioMax = 0.90, DeterminesFigure = true},			// Vanilla: doesn't care about size
 			{ BaseID = "UnitBlock.SouthernBackline",     RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
 			{ BaseID = "UnitBlock.SouthernRanged",       RatioMin = 0.00, RatioMax = 0.30 },		// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.SouthernAssassins",    RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
-			{ BaseID = "UnitBlock.SouthernOfficers",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true},		// Vanilla: Start spawning at 15+
-			{ BaseID = "UnitBlock.SouthernSiege",        RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
+			{ BaseID = "UnitBlock.Assassin",    RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
+			{ BaseID = "UnitBlock.Officer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true},		// Vanilla: Start spawning at 15+
+			{ BaseID = "UnitBlock.Siege",        RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
 		]
 	},
 	{
@@ -28,10 +28,10 @@ local parties = [
 		],
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.SouthernFrontline",        RatioMin = 0.15, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.SouthernSlaves",           RatioMin = 0.00, RatioMax = 0.25 },
+			{ BaseID = "UnitBlock.Slave",           RatioMin = 0.00, RatioMax = 0.25 },
 			{ BaseID = "UnitBlock.SouthernBackline",         RatioMin = 0.10, RatioMax = 0.40 },
-			{ BaseID = "UnitBlock.SouthernOfficers",         RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14 },
-			{ BaseID = "UnitBlock.SouthernCaravanDonkeys",   RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }   // Vanilla: Second starts spawning at 14, then 16+
+			{ BaseID = "UnitBlock.Officer",         RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14 },
+			{ BaseID = "UnitBlock.SouthernCaravanDonkey",   RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }   // Vanilla: Second starts spawning at 14, then 16+
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
@@ -47,8 +47,8 @@ local parties = [
 		],
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.SouthernFrontline",        RatioMin = 0.35, RatioMax = 1.00 },
-			// { BaseID = "UnitBlock.SouthernSlaves",           RatioMin = 0.00, RatioMax = 0.25 },     // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
-			{ BaseID = "UnitBlock.SouthernCaravanDonkeys",   RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
+			// { BaseID = "UnitBlock.Slave",           RatioMin = 0.00, RatioMax = 0.25 },     // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
+			{ BaseID = "UnitBlock.SouthernCaravanDonkey",   RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
@@ -60,7 +60,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.SouthernSlaves",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "UnitBlock.Slave",           RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -82,7 +82,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.SouthernAssassins",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "UnitBlock.Assassin",           RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 
@@ -92,7 +92,7 @@ local parties = [
 		HardMin = 2,
 		HardMax = 2,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.SouthernEngineer"}
+			{ BaseID = "UnitBlock.Engineer"}
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
@@ -10,7 +10,7 @@ local parties = [
 			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
 			{ BaseID = "UnitBlock.UndeadBackline", 	RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true, ReqPartySize = 8},
 			{ BaseID = "UnitBlock.UndeadBoss", 		RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15, StartingResourceMin = 225},
-			{ BaseID = "UnitBlock.UndeadVampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225},
+			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225},
 		]
 	},
 	{
@@ -21,7 +21,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.UndeadVampire", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 	{
@@ -33,7 +33,7 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.60, RatioMax = 1.00},		// In Vanilla only LightSkeletons spawn here
-			{ BaseID = "UnitBlock.UndeadVampire", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
@@ -7,10 +7,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.UndeadFrontline", 	RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.UndeadBackline", 	RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true, ReqPartySize = 8},
-			{ BaseID = "UnitBlock.RF.UndeadBoss", 		RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15},
-			{ BaseID = "UnitBlock.RF.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225},
+			{ BaseID = "UnitBlock.RF.UndeadFrontline", RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.UndeadBackline", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true, ReqPartySize = 8 },
+			{ BaseID = "UnitBlock.RF.UndeadBoss", RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15 },
+			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225 },
 		]
 	},
 	{
@@ -21,7 +21,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Vampire", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true }
 		]
 	},
 	{
@@ -32,8 +32,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.UndeadFrontline", 	RatioMin = 0.60, RatioMax = 1.00},		// In Vanilla only LightSkeletons spawn here
-			{ BaseID = "UnitBlock.RF.Vampire", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.UndeadFrontline", RatioMin = 0.60, RatioMax = 1.00 },		// In Vanilla only LightSkeletons spawn here
+			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true }
 		]
 	},
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
@@ -1,0 +1,54 @@
+local parties = [
+	{
+		ID = "UndeadArmy",
+		HardMin = 4,
+		DefaultFigure = "figure_skeleton_01",
+		MovementSpeedMult = 0.9,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.UndeadBackline", 	RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true, ReqPartySize = 8},
+			{ BaseID = "UnitBlock.UndeadBoss", 		RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15, StartingResourceMin = 225},
+			{ BaseID = "UnitBlock.UndeadVampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225},
+		]
+	},
+	{
+		ID = "Vampires",
+		HardMin = 2,	// In vanilla this is 1
+		DefaultFigure = "figure_vampire_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.UndeadVampire", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+		]
+	},
+	{
+		ID = "VampiresAndSkeletons",
+		HardMin = 7,
+		DefaultFigure = "figure_vampire_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.60, RatioMax = 1.00},		// In Vanilla only LightSkeletons spawn here
+			{ BaseID = "UnitBlock.UndeadVampire", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true}
+		]
+	},
+
+	// SubParties,
+	{	// The amount is set from outside
+		ID = "SubPartySkeletonHeavy",
+		UnitBlockDefs = [
+			{
+				ID = "Undead.SkeletonHeavyBodyguard"
+			}
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
@@ -9,7 +9,7 @@ local parties = [
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
 			{ BaseID = "UnitBlock.UndeadBackline", 	RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true, ReqPartySize = 8},
-			{ BaseID = "UnitBlock.UndeadBoss", 		RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15, StartingResourceMin = 225},
+			{ BaseID = "UnitBlock.UndeadBoss", 		RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15},
 			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225},
 		]
 	},

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/undead_parties.nut
@@ -7,10 +7,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.UndeadBackline", 	RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true, ReqPartySize = 8},
-			{ BaseID = "UnitBlock.UndeadBoss", 		RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15},
-			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225},
+			{ BaseID = "UnitBlock.RF.UndeadFrontline", 	RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.UndeadBackline", 	RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true, ReqPartySize = 8},
+			{ BaseID = "UnitBlock.RF.UndeadBoss", 		RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15},
+			{ BaseID = "UnitBlock.RF.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225},
 		]
 	},
 	{
@@ -21,7 +21,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.Vampire", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 	{
@@ -32,8 +32,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.UndeadFrontline", 	RatioMin = 0.60, RatioMax = 1.00},		// In Vanilla only LightSkeletons spawn here
-			{ BaseID = "UnitBlock.Vampire", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.UndeadFrontline", 	RatioMin = 0.60, RatioMax = 1.00},		// In Vanilla only LightSkeletons spawn here
+			{ BaseID = "UnitBlock.RF.Vampire", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 0.75,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.ZombieGhost" }
+			{ BaseID = "UnitBlock.Ghost" }
 		]
 	},
 	{
@@ -42,7 +42,7 @@ local parties = [
 		VisionMult = 0.8,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.ZombieFrontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.ZombieGhost", 			RatioMin = 0.12, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.Ghost", 			RatioMin = 0.12, RatioMax = 0.35},
 		]
 	},
 	{
@@ -54,8 +54,8 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.ZombieFrontline", 						RatioMin = 0.50, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.ZombieGhost", 							RatioMin = 0.00, RatioMax = 0.20},
-			{ BaseID = "UnitBlock.ZombieNecromancerWithBodyguards", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.Ghost", 							RatioMin = 0.00, RatioMax = 0.20},
+			{ BaseID = "UnitBlock.NecromancerWithBodyguard", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
 		]
 	},
 	{
@@ -67,7 +67,7 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.ZombieSouthern", 					RatioMin = 0.65, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.ZombieNecromancerWithNomads", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.NecromancerWithNomad", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
 			{ BaseID = "UnitBlock.ZombieElite", 						RatioMin = 0.00, RatioMax = 0.12, StartingResourceMin = 200},
 		]
 	},

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true }
 		]
 	},
 	{
@@ -29,8 +29,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.BeastGhoulLowOnly", 	RatioMin = 0.10, RatioMax = 0.30},
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.BeastGhoulLowOnly", RatioMin = 0.10, RatioMax = 0.30 }
 		]
 	},
 	{
@@ -41,8 +41,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.Ghost", 			RatioMin = 0.12, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.12, RatioMax = 0.35 }
 		]
 	},
 	{
@@ -53,9 +53,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", 						RatioMin = 0.50, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.Ghost", 							RatioMin = 0.00, RatioMax = 0.20},
-			{ BaseID = "UnitBlock.RF.NecromancerWithBodyguard", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.50, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.20 },
+			{ BaseID = "UnitBlock.RF.NecromancerWithBodyguard", RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true }
 		]
 	},
 	{
@@ -66,9 +66,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieSouthern", 					RatioMin = 0.65, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.NecromancerWithNomad", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.RF.ZombieElite", 						RatioMin = 0.00, RatioMax = 0.12, StartingResourceMin = 200},
+			{ BaseID = "UnitBlock.RF.ZombieSouthern", RatioMin = 0.65, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.NecromancerWithNomad", RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true },
+			{ BaseID = "UnitBlock.RF.ZombieElite", 	RatioMin = 0.00, RatioMax = 0.12, StartingResourceMin = 200 }
 		]
 	},
 	{	// Only un-armored zombies

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
@@ -1,0 +1,145 @@
+local parties = [
+	{
+		ID = "Zombies",
+		HardMin = 6,
+		DefaultFigure = "figure_zombie_01",
+		MovementSpeedMult = 0.8,
+		VisibilityMult = 1.0,
+		VisionMult = 0.8,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.ZombieFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+		]
+	},
+	{
+		ID = "Ghosts",
+		HardMin = 4,
+		DefaultFigure = "figure_ghost_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 0.75,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.ZombieGhost" }
+		]
+	},
+	{
+		ID = "ZombiesAndGhouls",
+		HardMin = 8,
+		DefaultFigure = "figure_zombie_01",
+		MovementSpeedMult = 0.8,
+		VisibilityMult = 1.0,
+		VisionMult = 0.8,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.ZombieFrontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.BeastGhoulLowOnly", 	RatioMin = 0.10, RatioMax = 0.30},
+		]
+	},
+	{
+		ID = "ZombiesAndGhosts",
+		HardMin = 8,
+		DefaultFigure = "figure_zombie_01",
+		MovementSpeedMult = 0.8,
+		VisibilityMult = 1.0,
+		VisionMult = 0.8,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.ZombieFrontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.ZombieGhost", 			RatioMin = 0.12, RatioMax = 0.35},
+		]
+	},
+	{
+		ID = "Necromancer",
+		HardMin = 10,
+		DefaultFigure = "figure_necromancer_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.ZombieFrontline", 						RatioMin = 0.50, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.ZombieGhost", 							RatioMin = 0.00, RatioMax = 0.20},
+			{ BaseID = "UnitBlock.ZombieNecromancerWithBodyguards", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
+		]
+	},
+	{
+		ID = "NecromancerSouthern",
+		HardMin = 4,
+		DefaultFigure = "figure_necromancer_01",
+		MovementSpeedMult = 1.0,
+		VisibilityMult = 1.0,
+		VisionMult = 1.0,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.ZombieSouthern", 					RatioMin = 0.65, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.ZombieNecromancerWithNomads", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.ZombieElite", 						RatioMin = 0.00, RatioMax = 0.12, StartingResourceMin = 200},
+		]
+	},
+	{	// Only un-armored zombies
+		ID = "ZombiesLight",
+		HardMin = 6,
+		DefaultFigure = "figure_zombie_01",
+		MovementSpeedMult = 0.8,
+		VisibilityMult = 1.0,
+		VisionMult = 0.8,
+		UnitBlockDefs = [
+			{ BaseID = "UnitBlock.ZombieLight" }
+		]
+	},
+
+	// SubParties
+	{
+		ID = "SubPartyYeoman",
+		HardMin = 1,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.UndeadYeomanBodyguard" }
+		]
+	},
+	{
+		ID = "SubPartyKnight",
+		HardMin = 1,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.UndeadFallenHeroBodyguard" }
+		]
+	},
+	{
+		ID = "SubPartyYeomanKnight",
+		HardMin = 2,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.UndeadYeomanBodyguard" },
+			{ BaseID = "UnitBlock.UndeadFallenHeroBodyguard" }
+		]
+	},
+	{
+		ID = "SubPartyKnightKnight",
+		HardMin = 2,
+		StaticUnitDefs = [
+			{ BaseID = "UnitBlock.UndeadFallenHeroBodyguard" },
+			{ BaseID = "UnitBlock.UndeadFallenHeroBodyguard" }
+		]
+	},
+	{	// The amount is set from outside
+		ID = "SubPartyNomad",
+		UnitBlockDefs = [
+			{
+				ID = "Zombie.ZombieNomadBodyguard"
+			}
+		]
+	}
+	{
+		ID = "SubPartyHonor",
+		HardMin = 1,
+		StaticUnitIDs = [
+			"Undead.SkeletonHeavyBodyguard"
+		]
+	},
+	{
+		ID = "SubPartyHonorHonor",
+		HardMin = 2,
+		StaticUnitIDs = [
+			"Undead.SkeletonHeavyBodyguard",
+			"Undead.SkeletonHeavyBodyguard"
+		]
+	}
+]
+
+foreach(partyDef in parties)
+{
+	::DynamicSpawns.Public.registerParty(partyDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
@@ -68,7 +68,7 @@ local parties = [
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.ZombieSouthern", RatioMin = 0.65, RatioMax = 1.00 },
 			{ BaseID = "UnitBlock.RF.NecromancerWithNomad", RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.ZombieElite", 	RatioMin = 0.00, RatioMax = 0.12, StartingResourceMin = 200 }
+			{ BaseID = "UnitBlock.RF.ZombieElite", 	RatioMin = 0.00, RatioMax = 0.12 }
 		]
 	},
 	{	// Only un-armored zombies

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/zombie_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.ZombieFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 0.75,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.Ghost" }
+			{ BaseID = "UnitBlock.RF.Ghost" }
 		]
 	},
 	{
@@ -29,8 +29,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.ZombieFrontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.BeastGhoulLowOnly", 	RatioMin = 0.10, RatioMax = 0.30},
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.BeastGhoulLowOnly", 	RatioMin = 0.10, RatioMax = 0.30},
 		]
 	},
 	{
@@ -41,8 +41,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.ZombieFrontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.Ghost", 			RatioMin = 0.12, RatioMax = 0.35},
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.Ghost", 			RatioMin = 0.12, RatioMax = 0.35},
 		]
 	},
 	{
@@ -53,9 +53,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.ZombieFrontline", 						RatioMin = 0.50, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.Ghost", 							RatioMin = 0.00, RatioMax = 0.20},
-			{ BaseID = "UnitBlock.NecromancerWithBodyguard", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.ZombieFrontline", 						RatioMin = 0.50, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.RF.Ghost", 							RatioMin = 0.00, RatioMax = 0.20},
+			{ BaseID = "UnitBlock.RF.NecromancerWithBodyguard", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
 		]
 	},
 	{
@@ -66,9 +66,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.ZombieSouthern", 					RatioMin = 0.65, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.NecromancerWithNomad", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
-			{ BaseID = "UnitBlock.ZombieElite", 						RatioMin = 0.00, RatioMax = 0.12, StartingResourceMin = 200},
+			{ BaseID = "UnitBlock.RF.ZombieSouthern", 					RatioMin = 0.65, RatioMax = 1.00},
+			{ BaseID = "UnitBlock.RF.NecromancerWithNomad", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
+			{ BaseID = "UnitBlock.RF.ZombieElite", 						RatioMin = 0.00, RatioMax = 0.12, StartingResourceMin = 200},
 		]
 	},
 	{	// Only un-armored zombies
@@ -79,7 +79,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.ZombieLight" }
+			{ BaseID = "UnitBlock.RF.ZombieLight" }
 		]
 	},
 
@@ -88,30 +88,30 @@ local parties = [
 		ID = "SubPartyYeoman",
 		HardMin = 1,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.UndeadYeomanBodyguard" }
+			{ BaseID = "UnitBlock.RF.UndeadYeomanBodyguard" }
 		]
 	},
 	{
 		ID = "SubPartyKnight",
 		HardMin = 1,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.UndeadFallenHeroBodyguard" }
+			{ BaseID = "UnitBlock.RF.UndeadFallenHeroBodyguard" }
 		]
 	},
 	{
 		ID = "SubPartyYeomanKnight",
 		HardMin = 2,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.UndeadYeomanBodyguard" },
-			{ BaseID = "UnitBlock.UndeadFallenHeroBodyguard" }
+			{ BaseID = "UnitBlock.RF.UndeadYeomanBodyguard" },
+			{ BaseID = "UnitBlock.RF.UndeadFallenHeroBodyguard" }
 		]
 	},
 	{
 		ID = "SubPartyKnightKnight",
 		HardMin = 2,
 		StaticUnitDefs = [
-			{ BaseID = "UnitBlock.UndeadFallenHeroBodyguard" },
-			{ BaseID = "UnitBlock.UndeadFallenHeroBodyguard" }
+			{ BaseID = "UnitBlock.RF.UndeadFallenHeroBodyguard" },
+			{ BaseID = "UnitBlock.RF.UndeadFallenHeroBodyguard" }
 		]
 	},
 	{	// The amount is set from outside

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/bandit_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/bandit_blocks.nut
@@ -1,84 +1,84 @@
 local unitBlocks = [
 	// {
-	// ID = "UnitBlock.BanditFrontline",
+	// ID = "UnitBlock.RF.BanditFrontline",
 	// 	UnitDefs = [
-	// 		{ID = "UnitBlock.BanditScoundrel" },
-	// 		{ID = "UnitBlock.BanditThug" },
-	// 		{ID = "UnitBlock.BanditRobber" },
-	// 		{ID = "UnitBlock.BanditRobberThrower" },
-	// 		{ID = "UnitBlock.BanditVandal" },
-	// 		{ID = "UnitBlock.BanditPillager" },
-	// 		{ID = "UnitBlock.BanditPillagerShield" },
-	// 		{ID = "UnitBlock.BanditRaider" },
-	// 		{ID = "UnitBlock.BanditOutlaw" },
-	// 		{ID = "UnitBlock.BanditBandit" },
-	// 		{ID = "UnitBlock.BanditBanditThrower" },
-	// 		{ID = "UnitBlock.BanditHighwayman" },
-	// 		{ID = "UnitBlock.BanditMarauder" },
-	// 		{ID = "UnitBlock.BanditKiller" },
-	// 		{ID = "UnitBlock.BanditKillerThrower" }
+	// 		{ID = "UnitBlock.RF.BanditScoundrel" },
+	// 		{ID = "UnitBlock.RF.BanditThug" },
+	// 		{ID = "UnitBlock.RF.BanditRobber" },
+	// 		{ID = "UnitBlock.RF.BanditRobberThrower" },
+	// 		{ID = "UnitBlock.RF.BanditVandal" },
+	// 		{ID = "UnitBlock.RF.BanditPillager" },
+	// 		{ID = "UnitBlock.RF.BanditPillagerShield" },
+	// 		{ID = "UnitBlock.RF.BanditRaider" },
+	// 		{ID = "UnitBlock.RF.BanditOutlaw" },
+	// 		{ID = "UnitBlock.RF.BanditBandit" },
+	// 		{ID = "UnitBlock.RF.BanditBanditThrower" },
+	// 		{ID = "UnitBlock.RF.BanditHighwayman" },
+	// 		{ID = "UnitBlock.RF.BanditMarauder" },
+	// 		{ID = "UnitBlock.RF.BanditKiller" },
+	// 		{ID = "UnitBlock.RF.BanditKillerThrower" }
 	// 	]
 	// },
 	{
-		ID = "UnitBlock.BanditBalanced",
+		ID = "UnitBlock.RF.BanditBalanced",
 		UnitDefs = [
-			{BaseID = "Unit.RF_BanditScoundrel",  StartingResourceMax = 250 },
-			{BaseID = "Unit.RF_BanditVandal", StartingResourceMin = 150 },
-			{BaseID = "Unit.BanditRaider", StartingResourceMin = 200 },
-			{BaseID = "Unit.RF_BanditHighwayman", StartingResourceMin = 300 }
+			{BaseID = "Unit.RF.RF_BanditScoundrel",  StartingResourceMax = 250 },
+			{BaseID = "Unit.RF.RF_BanditVandal", StartingResourceMin = 150 },
+			{BaseID = "Unit.RF.BanditRaider", StartingResourceMin = 200 },
+			{BaseID = "Unit.RF.RF_BanditHighwayman", StartingResourceMin = 300 }
 		]
 	},
 	{
-		ID = "UnitBlock.BanditFast",
+		ID = "UnitBlock.RF.BanditFast",
 		UnitDefs = [
-			{BaseID = "Unit.RF_BanditRobber", StartingResourceMin = 125 },
-			{BaseID = "Unit.RF_BanditBandit", StartingResourceMin = 200 },
-			{BaseID = "Unit.RF_BanditKiller", StartingResourceMin = 300 }
+			{BaseID = "Unit.RF.RF_BanditRobber", StartingResourceMin = 125 },
+			{BaseID = "Unit.RF.RF_BanditBandit", StartingResourceMin = 200 },
+			{BaseID = "Unit.RF.RF_BanditKiller", StartingResourceMin = 300 }
 		]
 	},
 	{
-		ID = "UnitBlock.BanditTough",
+		ID = "UnitBlock.RF.BanditTough",
 		UnitDefs = [
-			{BaseID = "Unit.BanditThug", StartingResourceMin = 63, StartingResourceMax = 275 },
-			{BaseID = "Unit.RF_BanditPillager", StartingResourceMin = 150 },
-			{BaseID = "Unit.RF_BanditOutlaw", StartingResourceMin = 200 },
-			{BaseID = "Unit.RF_BanditMarauder", StartingResourceMin = 300 }
+			{BaseID = "Unit.RF.BanditThug", StartingResourceMin = 63, StartingResourceMax = 275 },
+			{BaseID = "Unit.RF.RF_BanditPillager", StartingResourceMin = 150 },
+			{BaseID = "Unit.RF.RF_BanditOutlaw", StartingResourceMin = 200 },
+			{BaseID = "Unit.RF.RF_BanditMarauder", StartingResourceMin = 300 }
 		]
 	},
 	{
-		ID = "UnitBlock.BanditRanged",
+		ID = "UnitBlock.RF.BanditRanged",
 		UnitDefs = [
-			{BaseID = "Unit.BanditPoacher", StartingResourceMax = 250 },
-			{BaseID = "Unit.RF_BanditHunter", StartingResourceMin = 125 },
-			{BaseID = "Unit.BanditMarksman", StartingResourceMin = 200 },
-			{BaseID = "Unit.RF_BanditSharpshooter", StartingResourceMin = 300 }
+			{BaseID = "Unit.RF.BanditPoacher", StartingResourceMax = 250 },
+			{BaseID = "Unit.RF.RF_BanditHunter", StartingResourceMin = 125 },
+			{BaseID = "Unit.RF.BanditMarksman", StartingResourceMin = 200 },
+			{BaseID = "Unit.RF.RF_BanditSharpshooter", StartingResourceMin = 300 }
 		]
 	},
 	{
-		ID = "UnitBlock.BanditDog",
+		ID = "UnitBlock.RF.BanditDog",
 		UnitDefs = [
-			{BaseID = "Unit.BanditWardog", StartingResourceMax = 250 }
+			{BaseID = "Unit.RF.BanditWardog", StartingResourceMax = 250 }
 		]
 	},
 	{
-		ID = "UnitBlock.BanditElite",
+		ID = "UnitBlock.RF.BanditElite",
 		StartingResourceMin = 350,
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, {BaseID = "Unit.HumanMasterArcher" }],
-			[1, {BaseID = "Unit.HumanHedgeKnight" }],
-			[1, {BaseID = "Unit.HumanSwordmaster" }]
+			[1, {BaseID = "Unit.RF.HumanMasterArcher" }],
+			[1, {BaseID = "Unit.RF.HumanHedgeKnight" }],
+			[1, {BaseID = "Unit.RF.HumanSwordmaster" }]
 		])
 	},
 	{
-		ID = "UnitBlock.BanditBoss",
+		ID = "UnitBlock.RF.BanditBoss",
 		UnitDefs = [
-			{BaseID = "Unit.BanditLeader", StartingResourceMin = 250 },
-			{BaseID = "Unit.RF_BanditBaron" }
+			{BaseID = "Unit.RF.BanditLeader", StartingResourceMin = 250 },
+			{BaseID = "Unit.RF.RF_BanditBaron" }
 		]
 	},
 	{
-		ID = "UnitBlock.BanditDisguisedDirewolf",
-		UnitDefs = [{BaseID = "Unit.BanditRaiderWolf" }]
+		ID = "UnitBlock.RF.BanditDisguisedDirewolf",
+		UnitDefs = [{BaseID = "Unit.RF.BanditRaiderWolf" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/bandit_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/bandit_blocks.nut
@@ -1,84 +1,64 @@
 local unitBlocks = [
-	// {
-	// ID = "UnitBlock.RF.BanditFrontline",
-	// 	UnitDefs = [
-	// 		{ID = "UnitBlock.RF.BanditScoundrel" },
-	// 		{ID = "UnitBlock.RF.BanditThug" },
-	// 		{ID = "UnitBlock.RF.BanditRobber" },
-	// 		{ID = "UnitBlock.RF.BanditRobberThrower" },
-	// 		{ID = "UnitBlock.RF.BanditVandal" },
-	// 		{ID = "UnitBlock.RF.BanditPillager" },
-	// 		{ID = "UnitBlock.RF.BanditPillagerShield" },
-	// 		{ID = "UnitBlock.RF.BanditRaider" },
-	// 		{ID = "UnitBlock.RF.BanditOutlaw" },
-	// 		{ID = "UnitBlock.RF.BanditBandit" },
-	// 		{ID = "UnitBlock.RF.BanditBanditThrower" },
-	// 		{ID = "UnitBlock.RF.BanditHighwayman" },
-	// 		{ID = "UnitBlock.RF.BanditMarauder" },
-	// 		{ID = "UnitBlock.RF.BanditKiller" },
-	// 		{ID = "UnitBlock.RF.BanditKillerThrower" }
-	// 	]
-	// },
 	{
 		ID = "UnitBlock.RF.BanditBalanced",
 		UnitDefs = [
-			{BaseID = "Unit.RF.RF_BanditScoundrel",  StartingResourceMax = 250 },
-			{BaseID = "Unit.RF.RF_BanditVandal", StartingResourceMin = 150 },
-			{BaseID = "Unit.RF.BanditRaider", StartingResourceMin = 200 },
-			{BaseID = "Unit.RF.RF_BanditHighwayman", StartingResourceMin = 300 }
+			{ BaseID = "Unit.RF.RF_BanditScoundrel",  StartingResourceMax = 250 },
+			{ BaseID = "Unit.RF.RF_BanditVandal", StartingResourceMin = 150 },
+			{ BaseID = "Unit.RF.BanditRaider", StartingResourceMin = 200 },
+			{ BaseID = "Unit.RF.RF_BanditHighwayman", StartingResourceMin = 300 }
 		]
 	},
 	{
 		ID = "UnitBlock.RF.BanditFast",
 		UnitDefs = [
-			{BaseID = "Unit.RF.RF_BanditRobber", StartingResourceMin = 125 },
-			{BaseID = "Unit.RF.RF_BanditBandit", StartingResourceMin = 200 },
-			{BaseID = "Unit.RF.RF_BanditKiller", StartingResourceMin = 300 }
+			{ BaseID = "Unit.RF.RF_BanditRobber", StartingResourceMin = 125 },
+			{ BaseID = "Unit.RF.RF_BanditBandit", StartingResourceMin = 200 },
+			{ BaseID = "Unit.RF.RF_BanditKiller", StartingResourceMin = 300 }
 		]
 	},
 	{
 		ID = "UnitBlock.RF.BanditTough",
 		UnitDefs = [
-			{BaseID = "Unit.RF.BanditThug", StartingResourceMin = 63, StartingResourceMax = 275 },
-			{BaseID = "Unit.RF.RF_BanditPillager", StartingResourceMin = 150 },
-			{BaseID = "Unit.RF.RF_BanditOutlaw", StartingResourceMin = 200 },
-			{BaseID = "Unit.RF.RF_BanditMarauder", StartingResourceMin = 300 }
+			{ BaseID = "Unit.RF.BanditThug", StartingResourceMin = 63, StartingResourceMax = 275 },
+			{ BaseID = "Unit.RF.RF_BanditPillager", StartingResourceMin = 150 },
+			{ BaseID = "Unit.RF.RF_BanditOutlaw", StartingResourceMin = 200 },
+			{ BaseID = "Unit.RF.RF_BanditMarauder", StartingResourceMin = 300 }
 		]
 	},
 	{
 		ID = "UnitBlock.RF.BanditRanged",
 		UnitDefs = [
-			{BaseID = "Unit.RF.BanditPoacher", StartingResourceMax = 250 },
-			{BaseID = "Unit.RF.RF_BanditHunter", StartingResourceMin = 125 },
-			{BaseID = "Unit.RF.BanditMarksman", StartingResourceMin = 200 },
-			{BaseID = "Unit.RF.RF_BanditSharpshooter", StartingResourceMin = 300 }
+			{ BaseID = "Unit.RF.BanditPoacher", StartingResourceMax = 250 },
+			{ BaseID = "Unit.RF.RF_BanditHunter", StartingResourceMin = 125 },
+			{ BaseID = "Unit.RF.BanditMarksman", StartingResourceMin = 200 },
+			{ BaseID = "Unit.RF.RF_BanditSharpshooter", StartingResourceMin = 300 }
 		]
 	},
 	{
 		ID = "UnitBlock.RF.BanditDog",
 		UnitDefs = [
-			{BaseID = "Unit.RF.BanditWardog", StartingResourceMax = 250 }
+			{ BaseID = "Unit.RF.BanditWardog", StartingResourceMax = 250 }
 		]
 	},
 	{
 		ID = "UnitBlock.RF.BanditElite",
 		StartingResourceMin = 350,
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, {BaseID = "Unit.RF.HumanMasterArcher" }],
-			[1, {BaseID = "Unit.RF.HumanHedgeKnight" }],
-			[1, {BaseID = "Unit.RF.HumanSwordmaster" }]
+			[1, { BaseID = "Unit.RF.HumanMasterArcher" }],
+			[1, { BaseID = "Unit.RF.HumanHedgeKnight" }],
+			[1, { BaseID = "Unit.RF.HumanSwordmaster" }]
 		])
 	},
 	{
 		ID = "UnitBlock.RF.BanditBoss",
 		UnitDefs = [
-			{BaseID = "Unit.RF.BanditLeader", StartingResourceMin = 250 },
-			{BaseID = "Unit.RF.RF_BanditBaron" }
+			{ BaseID = "Unit.RF.BanditLeader", StartingResourceMin = 250 },
+			{ BaseID = "Unit.RF.RF_BanditBaron" }
 		]
 	},
 	{
 		ID = "UnitBlock.RF.BanditDisguisedDirewolf",
-		UnitDefs = [{BaseID = "Unit.RF.BanditRaiderWolf" }]
+		UnitDefs = [{ BaseID = "Unit.RF.BanditRaiderWolf" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/bandit_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/bandit_blocks.nut
@@ -1,85 +1,84 @@
 local unitBlocks = [
 	// {
-	// 	ID = "Bandit.Frontline",
+	// ID = "UnitBlock.BanditFrontline",
 	// 	UnitDefs = [
-	// 		{ ID = "Bandit.Scoundrel" },
-	// 		{ ID = "Bandit.Thug" },
-	// 		{ ID = "Bandit.Robber" },
-	// 		{ ID = "Bandit.RobberThrower" },
-	// 		{ ID = "Bandit.Vandal" },
-	// 		{ ID = "Bandit.Pillager" },
-	// 		{ ID = "Bandit.PillagerShield" },
-	// 		{ ID = "Bandit.Raider" },
-	// 		{ ID = "Bandit.Outlaw" },
-	// 		{ ID = "Bandit.Bandit" },
-	// 		{ ID = "Bandit.BanditThrower" },
-	// 		{ ID = "Bandit.Highwayman" },
-	// 		{ ID = "Bandit.Marauder" },
-	// 		{ ID = "Bandit.Killer" },
-	// 		{ ID = "Bandit.KillerThrower" }
+	// 		{ID = "UnitBlock.BanditScoundrel" },
+	// 		{ID = "UnitBlock.BanditThug" },
+	// 		{ID = "UnitBlock.BanditRobber" },
+	// 		{ID = "UnitBlock.BanditRobberThrower" },
+	// 		{ID = "UnitBlock.BanditVandal" },
+	// 		{ID = "UnitBlock.BanditPillager" },
+	// 		{ID = "UnitBlock.BanditPillagerShield" },
+	// 		{ID = "UnitBlock.BanditRaider" },
+	// 		{ID = "UnitBlock.BanditOutlaw" },
+	// 		{ID = "UnitBlock.BanditBandit" },
+	// 		{ID = "UnitBlock.BanditBanditThrower" },
+	// 		{ID = "UnitBlock.BanditHighwayman" },
+	// 		{ID = "UnitBlock.BanditMarauder" },
+	// 		{ID = "UnitBlock.BanditKiller" },
+	// 		{ID = "UnitBlock.BanditKillerThrower" }
 	// 	]
 	// },
 	{
-		ID = "Bandit.Balanced",
+		ID = "UnitBlock.BanditBalanced",
 		UnitDefs = [
-			{ ID = "Unit.RF_BanditScoundrel",  StartingResourceMax = 250 },
-			{ ID = "Unit.RF_BanditVandal", StartingResourceMin = 150 },
-			{ ID = "Bandit.Raider", StartingResourceMin = 200 },
-			{ ID = "Unit.RF_BanditHighwayman", StartingResourceMin = 300 }
+			{BaseID = "Unit.RF_BanditScoundrel",  StartingResourceMax = 250 },
+			{BaseID = "Unit.RF_BanditVandal", StartingResourceMin = 150 },
+			{BaseID = "Unit.BanditRaider", StartingResourceMin = 200 },
+			{BaseID = "Unit.RF_BanditHighwayman", StartingResourceMin = 300 }
 		]
 	},
 	{
-		ID = "Bandit.Fast",
+		ID = "UnitBlock.BanditFast",
 		UnitDefs = [
-			{ ID = "Unit.RF_BanditRobber", StartingResourceMin = 125 },
-			{ ID = "Unit.RF_BanditBandit", StartingResourceMin = 200 },
-			{ ID = "Unit.RF_BanditKiller", StartingResourceMin = 300 }
+			{BaseID = "Unit.RF_BanditRobber", StartingResourceMin = 125 },
+			{BaseID = "Unit.RF_BanditBandit", StartingResourceMin = 200 },
+			{BaseID = "Unit.RF_BanditKiller", StartingResourceMin = 300 }
 		]
 	},
 	{
-		ID = "Bandit.Tough",
+		ID = "UnitBlock.BanditTough",
 		UnitDefs = [
-			{ ID = "Bandit.Thug", StartingResourceMin = 63, StartingResourceMax = 275 },
-			{ ID = "Unit.RF_BanditPillager", StartingResourceMin = 150 },
-			{ ID = "Unit.RF_BanditOutlaw", StartingResourceMin = 200 },
-			{ ID = "Unit.RF_BanditMarauder", StartingResourceMin = 300 }
+			{BaseID = "Unit.BanditThug", StartingResourceMin = 63, StartingResourceMax = 275 },
+			{BaseID = "Unit.RF_BanditPillager", StartingResourceMin = 150 },
+			{BaseID = "Unit.RF_BanditOutlaw", StartingResourceMin = 200 },
+			{BaseID = "Unit.RF_BanditMarauder", StartingResourceMin = 300 }
 		]
 	},
 	{
-		ID = "Bandit.Ranged",
+		ID = "UnitBlock.BanditRanged",
 		UnitDefs = [
-			{ ID = "Bandit.Poacher", StartingResourceMax = 250 },
-			{ ID = "Unit.RF_BanditHunter", StartingResourceMin = 125 },
-			{ ID = "Bandit.Marksman", StartingResourceMin = 200 },
-			{ ID = "Unit.RF_BanditSharpshooter", StartingResourceMin = 300 }
+			{BaseID = "Unit.BanditPoacher", StartingResourceMax = 250 },
+			{BaseID = "Unit.RF_BanditHunter", StartingResourceMin = 125 },
+			{BaseID = "Unit.BanditMarksman", StartingResourceMin = 200 },
+			{BaseID = "Unit.RF_BanditSharpshooter", StartingResourceMin = 300 }
 		]
 	},
 	{
-		ID = "Bandit.Dogs",
+		ID = "UnitBlock.BanditDogs",
 		UnitDefs = [
-			{ ID = "Bandit.Wardog", StartingResourceMax = 250 }
+			{BaseID = "Unit.BanditWardog", StartingResourceMax = 250 }
 		]
 	},
 	{
-		ID = "Bandit.Elite",
+		ID = "UnitBlock.BanditElite",
 		StartingResourceMin = 350,
-		IsRandom = true,
+		UnitDefs = ::MSU.Class.WeightedContainer([
+			[1, {BaseID = "Unit.HumanMasterArcher" }],
+			[1, {BaseID = "Unit.HumanHedgeKnight" }],
+			[1, {BaseID = "Unit.HumanSwordmaster" }]
+		])
+	},
+	{
+		ID = "UnitBlock.BanditBoss",
 		UnitDefs = [
-			{ ID = "Human.MasterArcher" },
-			{ ID = "Human.HedgeKnight" },
-			{ ID = "Human.Swordmaster" }
+			{BaseID = "Unit.BanditLeader", StartingResourceMin = 250 },
+			{BaseID = "Unit.RF_BanditBaron" }
 		]
 	},
 	{
-		ID = "Bandit.Boss",
-		UnitDefs = [
-			{ ID = "Bandit.Leader", StartingResourceMin = 250 },
-			{ ID = "Unit.RF_BanditBaron" }
-		]
-	},
-	{
-		ID = "Bandit.DisguisedDirewolf",
-		UnitDefs = [{ ID = "Bandit.RaiderWolf" }]
+		ID = "UnitBlock.BanditDisguisedDirewolf",
+		UnitDefs = [{BaseID = "Unit.BanditRaiderWolf" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/bandit_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/bandit_blocks.nut
@@ -55,7 +55,7 @@ local unitBlocks = [
 		]
 	},
 	{
-		ID = "UnitBlock.BanditDogs",
+		ID = "UnitBlock.BanditDog",
 		UnitDefs = [
 			{BaseID = "Unit.BanditWardog", StartingResourceMax = 250 }
 		]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
@@ -1,7 +1,7 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.BarbarianFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianThrall" }, { BaseID = "Unit.RF.BarbarianMarauder", StartingResourceMin = 125 }, { BaseID = "Unit.RF.BarbarianChampion", StartingResourceMin = 200 }]
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianThrall" }, { BaseID = "Unit.RF.BarbarianMarauder" }, { BaseID = "Unit.RF.BarbarianChampion" }]
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianSupport",
@@ -14,8 +14,7 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianBeastmaster",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianBeastmasterU" }, { BaseID = "Unit.RF.BarbarianBeastmasterF" }, { BaseID = "Unit.RF.BarbarianBeastmasterUU" }, { BaseID = "Unit.RF.BarbarianBeastmasterFF" }],
-		StartingResourceMin = 200	// In Vanilla they appear in a group of 195 cost
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianBeastmasterU" }, { BaseID = "Unit.RF.BarbarianBeastmasterF" }, { BaseID = "Unit.RF.BarbarianBeastmasterUU" }, { BaseID = "Unit.RF.BarbarianBeastmasterFF" }]
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianHunterFrontline",

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
@@ -1,7 +1,7 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.BarbarianFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianThrall" }, { BaseID = "Unit.RF.BarbarianMarauder", StartingResourceMin = 125 }, { BaseID = "Unit.RF.BarbarianChosen", StartingResourceMin = 200 }]
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianThrall" }, { BaseID = "Unit.RF.BarbarianMarauder", StartingResourceMin = 125 }, { BaseID = "Unit.RF.BarbarianChampion", StartingResourceMin = 200 }]
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianSupport",
@@ -10,7 +10,7 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianDog",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianWarhound" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Warhound" }]
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianBeastmaster",

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
@@ -1,34 +1,34 @@
 local unitBlocks = [
 	{
-		ID = "UnitBlock.BarbarianFrontline",
-		UnitDefs = [{ BaseID = "Unit.BarbarianThrall" }, { BaseID = "Unit.BarbarianMarauder", StartingResourceMin = 125 }, { BaseID = "Unit.BarbarianChosen", StartingResourceMin = 200 }]
+		ID = "UnitBlock.RF.BarbarianFrontline",
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianThrall" }, { BaseID = "Unit.RF.BarbarianMarauder", StartingResourceMin = 125 }, { BaseID = "Unit.RF.BarbarianChosen", StartingResourceMin = 200 }]
 	},
 	{
-		ID = "UnitBlock.BarbarianSupport",
-		UnitDefs = [{ BaseID = "Unit.BarbarianDrummer" }]
+		ID = "UnitBlock.RF.BarbarianSupport",
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianDrummer" }]
 
 	},
 	{
-		ID = "UnitBlock.BarbarianDog",
-		UnitDefs = [{ BaseID = "Unit.BarbarianWarhound" }]
+		ID = "UnitBlock.RF.BarbarianDog",
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianWarhound" }]
 	},
 	{
-		ID = "UnitBlock.BarbarianBeastmaster",
-		UnitDefs = [{ BaseID = "Unit.BarbarianBeastmasterU" }, { BaseID = "Unit.BarbarianBeastmasterF" }, { BaseID = "Unit.BarbarianBeastmasterUU" }, { BaseID = "Unit.BarbarianBeastmasterFF" }],
+		ID = "UnitBlock.RF.BarbarianBeastmaster",
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianBeastmasterU" }, { BaseID = "Unit.RF.BarbarianBeastmasterF" }, { BaseID = "Unit.RF.BarbarianBeastmasterUU" }, { BaseID = "Unit.RF.BarbarianBeastmasterFF" }],
 		StartingResourceMin = 200	// In Vanilla they appear in a group of 195 cost
 	},
 	{
-		ID = "UnitBlock.BarbarianHunterFrontline",
-		UnitDefs = [{ BaseID = "Unit.BarbarianThrall" }]
+		ID = "UnitBlock.RF.BarbarianHunterFrontline",
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianThrall" }]
 	},
 
 	{
-		ID = "UnitBlock.BarbarianUnhold",
-		UnitDefs = [{ BaseID = "Unit.BarbarianUnhold" }]
+		ID = "UnitBlock.RF.BarbarianUnhold",
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianUnhold" }]
 	},
 	{
-		ID = "UnitBlock.BarbarianUnholdFrost",
-		UnitDefs = [{ BaseID = "Unit.BarbarianUnholdFrost" }]
+		ID = "UnitBlock.RF.BarbarianUnholdFrost",
+		UnitDefs = [{ BaseID = "Unit.RF.BarbarianUnholdFrost" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
@@ -10,7 +10,7 @@ local unitBlocks = [
 
 	},
 	{
-		ID = "UnitBlock.BarbarianDogs",
+		ID = "UnitBlock.BarbarianDog",
 		UnitDefs = [{ BaseID = "Unit.BarbarianWarhound" }]
 	},
 	{
@@ -24,11 +24,11 @@ local unitBlocks = [
 	},
 
 	{
-		ID = "UnitBlock.BarbarianUnholds",
+		ID = "UnitBlock.BarbarianUnhold",
 		UnitDefs = [{ BaseID = "Unit.BarbarianUnhold" }]
 	},
 	{
-		ID = "UnitBlock.BarbarianUnholdsFrost",
+		ID = "UnitBlock.BarbarianUnholdFrost",
 		UnitDefs = [{ BaseID = "Unit.BarbarianUnholdFrost" }]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
@@ -5,8 +5,7 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.BarbarianSupport",
-		UnitDefs = [{ BaseID = "Unit.BarbarianDrummer" }],
-		StartingResourceMin = 200	// In Vanilla they start appearing in a group of 210 cost alongside 15 thralls
+		UnitDefs = [{ BaseID = "Unit.BarbarianDrummer" }]
 
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/barbarian_blocks.nut
@@ -1,0 +1,39 @@
+local unitBlocks = [
+	{
+		ID = "UnitBlock.BarbarianFrontline",
+		UnitDefs = [{ BaseID = "Unit.BarbarianThrall" }, { BaseID = "Unit.BarbarianMarauder", StartingResourceMin = 125 }, { BaseID = "Unit.BarbarianChosen", StartingResourceMin = 200 }]
+	},
+	{
+		ID = "UnitBlock.BarbarianSupport",
+		UnitDefs = [{ BaseID = "Unit.BarbarianDrummer" }],
+		StartingResourceMin = 200	// In Vanilla they start appearing in a group of 210 cost alongside 15 thralls
+
+	},
+	{
+		ID = "UnitBlock.BarbarianDogs",
+		UnitDefs = [{ BaseID = "Unit.BarbarianWarhound" }]
+	},
+	{
+		ID = "UnitBlock.BarbarianBeastmaster",
+		UnitDefs = [{ BaseID = "Unit.BarbarianBeastmasterU" }, { BaseID = "Unit.BarbarianBeastmasterF" }, { BaseID = "Unit.BarbarianBeastmasterUU" }, { BaseID = "Unit.BarbarianBeastmasterFF" }],
+		StartingResourceMin = 200	// In Vanilla they appear in a group of 195 cost
+	},
+	{
+		ID = "UnitBlock.BarbarianHunterFrontline",
+		UnitDefs = [{ BaseID = "Unit.BarbarianThrall" }]
+	},
+
+	{
+		ID = "UnitBlock.BarbarianUnholds",
+		UnitDefs = [{ BaseID = "Unit.BarbarianUnhold" }]
+	},
+	{
+		ID = "UnitBlock.BarbarianUnholdsFrost",
+		UnitDefs = [{ BaseID = "Unit.BarbarianUnholdFrost" }]
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/beast_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/beast_blocks.nut
@@ -1,0 +1,93 @@
+local unitBlocks = [
+	// Purebred Beasts
+	{
+		ID = "UnitBlock.BeastDirewolves",
+		UnitDefs = [{ BaseID = "Unit.BeastDirewolf" }, { BaseID = "Unit.BeastDirewolfHIGH" }]
+	},
+	{
+		ID = "UnitBlock.BeastGhoulLowOnly",
+		UnitDefs = [{ BaseID = "Unit.BeastGhoulLOW" }]
+	},
+	{
+		ID = "UnitBlock.BeastGhouls",
+		UnitDefs = [{ BaseID = "Unit.BeastGhoulLOW" }, { BaseID = "Unit.BeastGhoul", StartingResourceMin = 125 }, { BaseID = "Unit.BeastGhoulHIGH", StartingResourceMin = 175 }]
+	},
+	{
+		ID = "UnitBlock.BeastLindwurms",
+		UnitDefs = [{ BaseID = "Unit.BeastLindwurm" }]
+	},
+	{
+		ID = "UnitBlock.BeastUnholds",
+		UnitDefs = [{ BaseID = "Unit.BeastUnhold" }]
+	},
+	{
+		ID = "UnitBlock.BeastUnholdsFrost",
+		UnitDefs = [{ BaseID = "Unit.BeastUnholdFrost" }]
+	},
+	{
+		ID = "UnitBlock.BeastUnholdsBog",
+		UnitDefs = [{ BaseID = "Unit.BeastUnholdBog" }]
+	},
+	{
+		ID = "UnitBlock.BeastSpiders",
+		UnitDefs = [{ BaseID = "Unit.BeastSpider" }]
+	},
+	{
+		ID = "UnitBlock.BeastAlps",
+		UnitDefs = [{ BaseID = "Unit.BeastAlp" }]
+	},
+	{
+		ID = "UnitBlock.BeastSchrats",
+		UnitDefs = [{ BaseID = "Unit.BeastSchrat" }]
+	},
+	// Vanilla Kraken skipped at this point
+	{
+		ID = "UnitBlock.BeastHyenas",
+		UnitDefs = [{ BaseID = "Unit.BeastHyena" }, { BaseID = "Unit.BeastHyenaHIGH" }]
+	},
+	{
+		ID = "UnitBlock.BeastSerpents",
+		UnitDefs = [{ BaseID = "Unit.BeastSerpent" }]
+	},
+	{
+		ID = "UnitBlock.BeastSandGolems",
+		UnitDefs = [{ BaseID = "Unit.BeastSandGolem" }, { BaseID = "Unit.BeastSandGolemMEDIUM" }, { BaseID = "Unit.BeastSandGolemHIGH" }]
+	},
+
+// Mixed Beasts
+	{
+		ID = "UnitBlock.BeastHexenNoBodyguards",
+		UnitDefs = [{ BaseID = "Unit.BeastHexe" }]
+	},
+	{
+		ID = "UnitBlock.BeastHexenWithBodyguards",
+		UnitDefs = [{ BaseID = "Unit.BeastHexe" }, { BaseID = "Unit.BeastHexeOneSpider" }, { BaseID = "Unit.BeastHexeTwoSpider" }, { BaseID = "Unit.BeastHexeOneDirewolf" }, { BaseID = "Unit.BeastHexeTwoDirewolf" }]
+	},
+	{
+		ID = "UnitBlock.BeastHexenNoSpiders",
+		UnitDefs = [{ BaseID = "Unit.BeastHexe" }, { BaseID = "Unit.BeastHexeOneDirewolf" }, { BaseID = "Unit.BeastHexeTwoDirewolf" }]
+	},
+	{
+		ID = "UnitBlock.BeastHexenBandits",    // Spawn in HexenFights
+		UnitDefs = [{ BaseID = "Unit.BanditRaider" }]
+	},
+	{
+		ID = "UnitBlock.BeastHexenBanditsRanged",    // Spawn in HexenFights. In Vanilla they only ever spawn a single marksman alongside several raiders. Never more
+		UnitDefs = [{ BaseID = "Unit.BanditMarksman" }]
+	},
+
+// Bodyguards
+	{
+		ID = "UnitBlock.BeastSpiderBodyguards",
+		UnitDefs = [{ BaseID = "Unit.BeastSpiderBodyguard" }]
+	},
+	{
+		ID = "UnitBlock.BeastDirewolfBodyguards",
+		UnitDefs = [{ BaseID = "Unit.BeastDirewolfBodyguard" }]
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/beast_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/beast_blocks.nut
@@ -1,93 +1,93 @@
 local unitBlocks = [
 	// Purebred Beasts
 	{
-		ID = "UnitBlock.Direwolf",
-		UnitDefs = [{ BaseID = "Unit.Direwolf" }, { BaseID = "Unit.DirewolfHIGH" }]
+		ID = "UnitBlock.RF.Direwolf",
+		UnitDefs = [{ BaseID = "Unit.RF.Direwolf" }, { BaseID = "Unit.RF.DirewolfHIGH" }]
 	},
 	{
-		ID = "UnitBlock.GhoulLowOnly",
-		UnitDefs = [{ BaseID = "Unit.GhoulLOW" }]
+		ID = "UnitBlock.RF.GhoulLowOnly",
+		UnitDefs = [{ BaseID = "Unit.RF.GhoulLOW" }]
 	},
 	{
-		ID = "UnitBlock.Ghoul",
-		UnitDefs = [{ BaseID = "Unit.GhoulLOW" }, { BaseID = "Unit.Ghoul", StartingResourceMin = 125 }, { BaseID = "Unit.GhoulHIGH", StartingResourceMin = 175 }]
+		ID = "UnitBlock.RF.Ghoul",
+		UnitDefs = [{ BaseID = "Unit.RF.GhoulLOW" }, { BaseID = "Unit.RF.Ghoul", StartingResourceMin = 125 }, { BaseID = "Unit.RF.GhoulHIGH", StartingResourceMin = 175 }]
 	},
 	{
-		ID = "UnitBlock.Lindwurm",
-		UnitDefs = [{ BaseID = "Unit.Lindwurm" }]
+		ID = "UnitBlock.RF.Lindwurm",
+		UnitDefs = [{ BaseID = "Unit.RF.Lindwurm" }]
 	},
 	{
-		ID = "UnitBlock.Unhold",
-		UnitDefs = [{ BaseID = "Unit.Unhold" }]
+		ID = "UnitBlock.RF.Unhold",
+		UnitDefs = [{ BaseID = "Unit.RF.Unhold" }]
 	},
 	{
-		ID = "UnitBlock.UnholdFrost",
-		UnitDefs = [{ BaseID = "Unit.UnholdFrost" }]
+		ID = "UnitBlock.RF.UnholdFrost",
+		UnitDefs = [{ BaseID = "Unit.RF.UnholdFrost" }]
 	},
 	{
-		ID = "UnitBlock.UnholdBog",
-		UnitDefs = [{ BaseID = "Unit.UnholdBog" }]
+		ID = "UnitBlock.RF.UnholdBog",
+		UnitDefs = [{ BaseID = "Unit.RF.UnholdBog" }]
 	},
 	{
-		ID = "UnitBlock.Spider",
-		UnitDefs = [{ BaseID = "Unit.Spider" }]
+		ID = "UnitBlock.RF.Spider",
+		UnitDefs = [{ BaseID = "Unit.RF.Spider" }]
 	},
 	{
-		ID = "UnitBlock.Alp",
-		UnitDefs = [{ BaseID = "Unit.Alp" }]
+		ID = "UnitBlock.RF.Alp",
+		UnitDefs = [{ BaseID = "Unit.RF.Alp" }]
 	},
 	{
-		ID = "UnitBlock.Schrat",
-		UnitDefs = [{ BaseID = "Unit.Schrat" }]
+		ID = "UnitBlock.RF.Schrat",
+		UnitDefs = [{ BaseID = "Unit.RF.Schrat" }]
 	},
 	// Vanilla Kraken skipped at this point
 	{
-		ID = "UnitBlock.Hyena",
-		UnitDefs = [{ BaseID = "Unit.Hyena" }, { BaseID = "Unit.HyenaHIGH" }]
+		ID = "UnitBlock.RF.Hyena",
+		UnitDefs = [{ BaseID = "Unit.RF.Hyena" }, { BaseID = "Unit.RF.HyenaHIGH" }]
 	},
 	{
-		ID = "UnitBlock.Serpent",
-		UnitDefs = [{ BaseID = "Unit.Serpent" }]
+		ID = "UnitBlock.RF.Serpent",
+		UnitDefs = [{ BaseID = "Unit.RF.Serpent" }]
 	},
 	{
-		ID = "UnitBlock.SandGolem",
-		UnitDefs = [{ BaseID = "Unit.SandGolem" }, { BaseID = "Unit.SandGolemMEDIUM" }, { BaseID = "Unit.SandGolemHIGH" }]
+		ID = "UnitBlock.RF.SandGolem",
+		UnitDefs = [{ BaseID = "Unit.RF.SandGolem" }, { BaseID = "Unit.RF.SandGolemMEDIUM" }, { BaseID = "Unit.RF.SandGolemHIGH" }]
 	},
 
 // Mixed Beasts
 	{
-		ID = "UnitBlock.HexeNoBodyguard",
-		UnitDefs = [{ BaseID = "Unit.Hexe" }]
+		ID = "UnitBlock.RF.HexeNoBodyguard",
+		UnitDefs = [{ BaseID = "Unit.RF.Hexe" }]
 	},
 	{
-		ID = "UnitBlock.HexeWithBodyguard",
+		ID = "UnitBlock.RF.HexeWithBodyguard",
 		StartingResourceMin = 300,
-		UnitDefs = [{ BaseID = "Unit.Hexe" }, { BaseID = "Unit.HexeOneSpider" }, { BaseID = "Unit.HexeTwoSpider" }, { BaseID = "Unit.HexeOneDirewolf" }, { BaseID = "Unit.HexeTwoDirewolf" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Hexe" }, { BaseID = "Unit.RF.HexeOneSpider" }, { BaseID = "Unit.RF.HexeTwoSpider" }, { BaseID = "Unit.RF.HexeOneDirewolf" }, { BaseID = "Unit.RF.HexeTwoDirewolf" }]
 	},
 	{
-		ID = "UnitBlock.HexeNoSpider",
+		ID = "UnitBlock.RF.HexeNoSpider",
 		StartingResourceMin = 300,
-		UnitDefs = [{ BaseID = "Unit.Hexe" }, { BaseID = "Unit.HexeOneDirewolf" }, { BaseID = "Unit.HexeTwoDirewolf" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Hexe" }, { BaseID = "Unit.RF.HexeOneDirewolf" }, { BaseID = "Unit.RF.HexeTwoDirewolf" }]
 	},
 	{
-		ID = "UnitBlock.HexeBandit",    // Spawn in HexenFights
+		ID = "UnitBlock.RF.HexeBandit",    // Spawn in HexenFights
 		StartingResourceMin = 200,
-		UnitDefs = [{ BaseID = "Unit.BanditRaider" }]
+		UnitDefs = [{ BaseID = "Unit.RF.BanditRaider" }]
 	},
 	{
-		ID = "UnitBlock.HexeBanditRanged",    // Spawn in HexenFights. In Vanilla they only ever spawn a single marksman alongside several raiders. Never more
+		ID = "UnitBlock.RF.HexeBanditRanged",    // Spawn in HexenFights. In Vanilla they only ever spawn a single marksman alongside several raiders. Never more
 		StartingResourceMin = 200,
-		UnitDefs = [{ BaseID = "Unit.BanditMarksman" }]
+		UnitDefs = [{ BaseID = "Unit.RF.BanditMarksman" }]
 	},
 
 // Bodyguards
 	{
-		ID = "UnitBlock.SpiderBodyguard",
-		UnitDefs = [{ BaseID = "Unit.SpiderBodyguard" }]
+		ID = "UnitBlock.RF.SpiderBodyguard",
+		UnitDefs = [{ BaseID = "Unit.RF.SpiderBodyguard" }]
 	},
 	{
-		ID = "UnitBlock.DirewolfBodyguard",
-		UnitDefs = [{ BaseID = "Unit.DirewolfBodyguard" }]
+		ID = "UnitBlock.RF.DirewolfBodyguard",
+		UnitDefs = [{ BaseID = "Unit.RF.DirewolfBodyguard" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/beast_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/beast_blocks.nut
@@ -1,89 +1,89 @@
 local unitBlocks = [
 	// Purebred Beasts
 	{
-		ID = "UnitBlock.BeastDirewolves",
-		UnitDefs = [{ BaseID = "Unit.BeastDirewolf" }, { BaseID = "Unit.BeastDirewolfHIGH" }]
+		ID = "UnitBlock.Direwolf",
+		UnitDefs = [{ BaseID = "Unit.Direwolf" }, { BaseID = "Unit.DirewolfHIGH" }]
 	},
 	{
-		ID = "UnitBlock.BeastGhoulLowOnly",
-		UnitDefs = [{ BaseID = "Unit.BeastGhoulLOW" }]
+		ID = "UnitBlock.GhoulLowOnly",
+		UnitDefs = [{ BaseID = "Unit.GhoulLOW" }]
 	},
 	{
-		ID = "UnitBlock.BeastGhouls",
-		UnitDefs = [{ BaseID = "Unit.BeastGhoulLOW" }, { BaseID = "Unit.BeastGhoul", StartingResourceMin = 125 }, { BaseID = "Unit.BeastGhoulHIGH", StartingResourceMin = 175 }]
+		ID = "UnitBlock.Ghoul",
+		UnitDefs = [{ BaseID = "Unit.GhoulLOW" }, { BaseID = "Unit.Ghoul", StartingResourceMin = 125 }, { BaseID = "Unit.GhoulHIGH", StartingResourceMin = 175 }]
 	},
 	{
-		ID = "UnitBlock.BeastLindwurms",
-		UnitDefs = [{ BaseID = "Unit.BeastLindwurm" }]
+		ID = "UnitBlock.Lindwurm",
+		UnitDefs = [{ BaseID = "Unit.Lindwurm" }]
 	},
 	{
-		ID = "UnitBlock.BeastUnholds",
-		UnitDefs = [{ BaseID = "Unit.BeastUnhold" }]
+		ID = "UnitBlock.Unhold",
+		UnitDefs = [{ BaseID = "Unit.Unhold" }]
 	},
 	{
-		ID = "UnitBlock.BeastUnholdsFrost",
-		UnitDefs = [{ BaseID = "Unit.BeastUnholdFrost" }]
+		ID = "UnitBlock.UnholdFrost",
+		UnitDefs = [{ BaseID = "Unit.UnholdFrost" }]
 	},
 	{
-		ID = "UnitBlock.BeastUnholdsBog",
-		UnitDefs = [{ BaseID = "Unit.BeastUnholdBog" }]
+		ID = "UnitBlock.UnholdBog",
+		UnitDefs = [{ BaseID = "Unit.UnholdBog" }]
 	},
 	{
-		ID = "UnitBlock.BeastSpiders",
-		UnitDefs = [{ BaseID = "Unit.BeastSpider" }]
+		ID = "UnitBlock.Spider",
+		UnitDefs = [{ BaseID = "Unit.Spider" }]
 	},
 	{
-		ID = "UnitBlock.BeastAlps",
-		UnitDefs = [{ BaseID = "Unit.BeastAlp" }]
+		ID = "UnitBlock.Alp",
+		UnitDefs = [{ BaseID = "Unit.Alp" }]
 	},
 	{
-		ID = "UnitBlock.BeastSchrats",
-		UnitDefs = [{ BaseID = "Unit.BeastSchrat" }]
+		ID = "UnitBlock.Schrat",
+		UnitDefs = [{ BaseID = "Unit.Schrat" }]
 	},
 	// Vanilla Kraken skipped at this point
 	{
-		ID = "UnitBlock.BeastHyenas",
-		UnitDefs = [{ BaseID = "Unit.BeastHyena" }, { BaseID = "Unit.BeastHyenaHIGH" }]
+		ID = "UnitBlock.Hyena",
+		UnitDefs = [{ BaseID = "Unit.Hyena" }, { BaseID = "Unit.HyenaHIGH" }]
 	},
 	{
-		ID = "UnitBlock.BeastSerpents",
-		UnitDefs = [{ BaseID = "Unit.BeastSerpent" }]
+		ID = "UnitBlock.Serpent",
+		UnitDefs = [{ BaseID = "Unit.Serpent" }]
 	},
 	{
-		ID = "UnitBlock.BeastSandGolems",
-		UnitDefs = [{ BaseID = "Unit.BeastSandGolem" }, { BaseID = "Unit.BeastSandGolemMEDIUM" }, { BaseID = "Unit.BeastSandGolemHIGH" }]
+		ID = "UnitBlock.SandGolem",
+		UnitDefs = [{ BaseID = "Unit.SandGolem" }, { BaseID = "Unit.SandGolemMEDIUM" }, { BaseID = "Unit.SandGolemHIGH" }]
 	},
 
 // Mixed Beasts
 	{
-		ID = "UnitBlock.BeastHexenNoBodyguards",
-		UnitDefs = [{ BaseID = "Unit.BeastHexe" }]
+		ID = "UnitBlock.HexeNoBodyguard",
+		UnitDefs = [{ BaseID = "Unit.Hexe" }]
 	},
 	{
-		ID = "UnitBlock.BeastHexenWithBodyguards",
-		UnitDefs = [{ BaseID = "Unit.BeastHexe" }, { BaseID = "Unit.BeastHexeOneSpider" }, { BaseID = "Unit.BeastHexeTwoSpider" }, { BaseID = "Unit.BeastHexeOneDirewolf" }, { BaseID = "Unit.BeastHexeTwoDirewolf" }]
+		ID = "UnitBlock.HexeWithBodyguard",
+		UnitDefs = [{ BaseID = "Unit.Hexe" }, { BaseID = "Unit.HexeOneSpider" }, { BaseID = "Unit.HexeTwoSpider" }, { BaseID = "Unit.HexeOneDirewolf" }, { BaseID = "Unit.HexeTwoDirewolf" }]
 	},
 	{
-		ID = "UnitBlock.BeastHexenNoSpiders",
-		UnitDefs = [{ BaseID = "Unit.BeastHexe" }, { BaseID = "Unit.BeastHexeOneDirewolf" }, { BaseID = "Unit.BeastHexeTwoDirewolf" }]
+		ID = "UnitBlock.HexeNoSpider",
+		UnitDefs = [{ BaseID = "Unit.Hexe" }, { BaseID = "Unit.HexeOneDirewolf" }, { BaseID = "Unit.HexeTwoDirewolf" }]
 	},
 	{
-		ID = "UnitBlock.BeastHexenBandits",    // Spawn in HexenFights
+		ID = "UnitBlock.HexeBandit",    // Spawn in HexenFights
 		UnitDefs = [{ BaseID = "Unit.BanditRaider" }]
 	},
 	{
-		ID = "UnitBlock.BeastHexenBanditsRanged",    // Spawn in HexenFights. In Vanilla they only ever spawn a single marksman alongside several raiders. Never more
+		ID = "UnitBlock.HexeBanditRanged",    // Spawn in HexenFights. In Vanilla they only ever spawn a single marksman alongside several raiders. Never more
 		UnitDefs = [{ BaseID = "Unit.BanditMarksman" }]
 	},
 
 // Bodyguards
 	{
-		ID = "UnitBlock.BeastSpiderBodyguards",
-		UnitDefs = [{ BaseID = "Unit.BeastSpiderBodyguard" }]
+		ID = "UnitBlock.SpiderBodyguard",
+		UnitDefs = [{ BaseID = "Unit.SpiderBodyguard" }]
 	},
 	{
-		ID = "UnitBlock.BeastDirewolfBodyguards",
-		UnitDefs = [{ BaseID = "Unit.BeastDirewolfBodyguard" }]
+		ID = "UnitBlock.DirewolfBodyguard",
+		UnitDefs = [{ BaseID = "Unit.DirewolfBodyguard" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/beast_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/beast_blocks.nut
@@ -61,18 +61,22 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.HexeWithBodyguard",
+		StartingResourceMin = 300,
 		UnitDefs = [{ BaseID = "Unit.Hexe" }, { BaseID = "Unit.HexeOneSpider" }, { BaseID = "Unit.HexeTwoSpider" }, { BaseID = "Unit.HexeOneDirewolf" }, { BaseID = "Unit.HexeTwoDirewolf" }]
 	},
 	{
 		ID = "UnitBlock.HexeNoSpider",
+		StartingResourceMin = 300,
 		UnitDefs = [{ BaseID = "Unit.Hexe" }, { BaseID = "Unit.HexeOneDirewolf" }, { BaseID = "Unit.HexeTwoDirewolf" }]
 	},
 	{
 		ID = "UnitBlock.HexeBandit",    // Spawn in HexenFights
+		StartingResourceMin = 200,
 		UnitDefs = [{ BaseID = "Unit.BanditRaider" }]
 	},
 	{
 		ID = "UnitBlock.HexeBanditRanged",    // Spawn in HexenFights. In Vanilla they only ever spawn a single marksman alongside several raiders. Never more
+		StartingResourceMin = 200,
 		UnitDefs = [{ BaseID = "Unit.BanditMarksman" }]
 	},
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/goblin_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/goblin_blocks.nut
@@ -3,14 +3,12 @@ local unitBlocks = [
 		ID = "UnitBlock.RF.GoblinFrontline",
 		UnitDefs =
 		[
-			{ BaseID = "Unit.RF.GoblinSkirmisherLOW" },
 			{ BaseID = "Unit.RF.GoblinSkirmisher" }
 		]
 	},
 	{
 		ID = "UnitBlock.RF.GoblinRanged",
 		UnitDefs = [
-			{ BaseID = "Unit.RF.GoblinAmbusherLOW" },
 			{ BaseID = "Unit.RF.GoblinAmbusher" }
 		]
 	},

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/goblin_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/goblin_blocks.nut
@@ -1,28 +1,28 @@
 local unitBlocks = [
 	{
-		ID = "UnitBlock.GoblinFrontline",
+		ID = "UnitBlock.RF.GoblinFrontline",
 		UnitDefs =
 		[
-			{ BaseID = "Unit.GoblinSkirmisherLOW" },
-			{ BaseID = "Unit.GoblinSkirmisher" }
+			{ BaseID = "Unit.RF.GoblinSkirmisherLOW" },
+			{ BaseID = "Unit.RF.GoblinSkirmisher" }
 		]
 	},
 	{
-		ID = "UnitBlock.GoblinRanged",
+		ID = "UnitBlock.RF.GoblinRanged",
 		UnitDefs = [
-			{ BaseID = "Unit.GoblinAmbusherLOW" },
-			{ BaseID = "Unit.GoblinAmbusher" }
+			{ BaseID = "Unit.RF.GoblinAmbusherLOW" },
+			{ BaseID = "Unit.RF.GoblinAmbusher" }
 		]
 	},
 	{
-		ID = "UnitBlock.GoblinFlank",
-		UnitDefs = [{ BaseID = "Unit.GoblinWolfrider" }]
+		ID = "UnitBlock.RF.GoblinFlank",
+		UnitDefs = [{ BaseID = "Unit.RF.GoblinWolfrider" }]
 	},
 	{
-		ID = "UnitBlock.GoblinBoss",
+		ID = "UnitBlock.RF.GoblinBoss",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.GoblinOverseer" }],
-			[1, { BaseID = "Unit.GoblinShaman" }]
+			[1, { BaseID = "Unit.RF.GoblinOverseer" }],
+			[1, { BaseID = "Unit.RF.GoblinShaman" }]
 		])
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/goblin_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/goblin_blocks.nut
@@ -1,0 +1,33 @@
+local unitBlocks = [
+	{
+		ID = "UnitBlock.GoblinFrontline",
+		UnitDefs =
+		[
+			{ BaseID = "Unit.GoblinSkirmisherLOW" },
+			{ BaseID = "Unit.GoblinSkirmisher" }
+		]
+	},
+	{
+		ID = "UnitBlock.GoblinRanged",
+		UnitDefs = [
+			{ BaseID = "Unit.GoblinAmbusherLOW" },
+			{ BaseID = "Unit.GoblinAmbusher" }
+		]
+	},
+	{
+		ID = "UnitBlock.GoblinFlank",
+		UnitDefs = [{ BaseID = "Unit.GoblinWolfrider" }]
+	},
+	{
+		ID = "UnitBlock.GoblinBoss",
+		UnitDefs = ::MSU.Class.WeightedContainer([
+			[1, { BaseID = "Unit.GoblinOverseer" }],
+			[1, { BaseID = "Unit.GoblinShaman" }]
+		])
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/greenskin_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/greenskin_blocks.nut
@@ -1,9 +1,9 @@
 local unitBlocks = [
 	{
-		ID = "UnitBlock.GoblinRegular",
+		ID = "UnitBlock.RF.GoblinRegular",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.GoblinSkirmisher" }],
-			[1, { BaseID = "Unit.GoblinAmbusher" }]
+			[1, { BaseID = "Unit.RF.GoblinSkirmisher" }],
+			[1, { BaseID = "Unit.RF.GoblinAmbusher" }]
 		])
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/greenskin_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/greenskin_blocks.nut
@@ -1,6 +1,6 @@
 local unitBlocks = [
 	{
-		ID = "UnitBlock.GreenskinGoblinsFoot",
+		ID = "UnitBlock.GoblinRegular",
 		UnitDefs = ::MSU.Class.WeightedContainer([
 			[1, { BaseID = "Unit.GoblinSkirmisher" }],
 			[1, { BaseID = "Unit.GoblinAmbusher" }]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/greenskin_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/greenskin_blocks.nut
@@ -1,0 +1,14 @@
+local unitBlocks = [
+	{
+		ID = "UnitBlock.GreenskinGoblinsFoot",
+		UnitDefs = ::MSU.Class.WeightedContainer([
+			[1, { BaseID = "Unit.GoblinSkirmisher" }],
+			[1, { BaseID = "Unit.GoblinAmbusher" }]
+		])
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
@@ -1,7 +1,7 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.MercenaryFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.MercenaryLOW" }, { BaseID = "Unit.RF.Mercenary" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Mercenary" }]
 	},
 	{
 		ID = "UnitBlock.RF.MercenaryRanged",

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
@@ -13,8 +13,7 @@ local unitBlocks = [
 			[1, { BaseID = "Unit.MasterArcher" }],
 			[1, { BaseID = "Unit.HedgeKnight" }],
 			[1, { BaseID = "Unit.Swordmaster" }]
-		]),
-		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
+		])
 	},
 	{
 		ID = "UnitBlock.BountyHunter",
@@ -76,8 +75,7 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.MilitiaCaptain",
-		UnitDefs = [{ BaseID = "Unit.MilitiaCaptain" }],
-		StartingResourceMin = 144	// In Vanilla they appear in a group of 144 cost
+		UnitDefs = [{ BaseID = "Unit.MilitiaCaptain" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
@@ -1,81 +1,81 @@
 local unitBlocks = [
 	{
-		ID = "UnitBlock.MercenaryFrontline",
-		UnitDefs = [{ BaseID = "Unit.MercenaryLOW" }, { BaseID = "Unit.Mercenary" }]
+		ID = "UnitBlock.RF.MercenaryFrontline",
+		UnitDefs = [{ BaseID = "Unit.RF.MercenaryLOW" }, { BaseID = "Unit.RF.Mercenary" }]
 	},
 	{
-		ID = "UnitBlock.MercenaryRanged",
-		UnitDefs = [{ BaseID = "Unit.MercenaryRanged" }]
+		ID = "UnitBlock.RF.MercenaryRanged",
+		UnitDefs = [{ BaseID = "Unit.RF.MercenaryRanged" }]
 	},
 	{
-		ID = "UnitBlock.MercenaryElite",
+		ID = "UnitBlock.RF.MercenaryElite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.MasterArcher" }],
-			[1, { BaseID = "Unit.HedgeKnight" }],
-			[1, { BaseID = "Unit.Swordmaster" }]
+			[1, { BaseID = "Unit.RF.MasterArcher" }],
+			[1, { BaseID = "Unit.RF.HedgeKnight" }],
+			[1, { BaseID = "Unit.RF.Swordmaster" }]
 		])
 	},
 	{
-		ID = "UnitBlock.BountyHunter",
-		UnitDefs = [{ BaseID = "Unit.BountyHunter" }]
+		ID = "UnitBlock.RF.BountyHunter",
+		UnitDefs = [{ BaseID = "Unit.RF.BountyHunter" }]
 	},
 	{
-		ID = "UnitBlock.BountyHunterRanged",
-		UnitDefs = [{ BaseID = "Unit.BountyHunterRanged" }]
+		ID = "UnitBlock.RF.BountyHunterRanged",
+		UnitDefs = [{ BaseID = "Unit.RF.BountyHunterRanged" }]
 	},
 	{
-		ID = "UnitBlock.Wardog",
-		UnitDefs = [{ BaseID = "Unit.Wardog" }]
+		ID = "UnitBlock.RF.Wardog",
+		UnitDefs = [{ BaseID = "Unit.RF.Wardog" }]
 	},
 	{
-		ID = "UnitBlock.Slave",
-		UnitDefs = [{ BaseID = "Unit.Slave" }]
+		ID = "UnitBlock.RF.Slave",
+		UnitDefs = [{ BaseID = "Unit.RF.Slave" }]
 	},
 
 // Civilians
 	{
-		ID = "UnitBlock.CultistAmbush",
-		UnitDefs = [{ BaseID = "Unit.CultistAmbush" }]
+		ID = "UnitBlock.RF.CultistAmbush",
+		UnitDefs = [{ BaseID = "Unit.RF.CultistAmbush" }]
 	},
 	{
-		ID = "UnitBlock.Peasant",
-		UnitDefs = [{ BaseID = "Unit.Peasant" }]
+		ID = "UnitBlock.RF.Peasant",
+		UnitDefs = [{ BaseID = "Unit.RF.Peasant" }]
 	},
 	{
-		ID = "UnitBlock.SouthernPeasant",
-		UnitDefs = [{ BaseID = "Unit.SouthernPeasant" }]
+		ID = "UnitBlock.RF.SouthernPeasant",
+		UnitDefs = [{ BaseID = "Unit.RF.SouthernPeasant" }]
 	},
 	{
-		ID = "UnitBlock.PeasantArmed",
-		UnitDefs = [{ BaseID = "Unit.PeasantArmed" }]
+		ID = "UnitBlock.RF.PeasantArmed",
+		UnitDefs = [{ BaseID = "Unit.RF.PeasantArmed" }]
 	},
 
 // Caravans
 	{
-		ID = "UnitBlock.CaravanDonkey",
-		UnitDefs = [{ BaseID = "Unit.CaravanDonkey" }]
+		ID = "UnitBlock.RF.CaravanDonkey",
+		UnitDefs = [{ BaseID = "Unit.RF.CaravanDonkey" }]
 	},
 	{
-		ID = "UnitBlock.CaravanHand",
-		UnitDefs = [{ BaseID = "Unit.CaravanHand" }]
+		ID = "UnitBlock.RF.CaravanHand",
+		UnitDefs = [{ BaseID = "Unit.RF.CaravanHand" }]
 	},
 	{
-		ID = "UnitBlock.CaravanGuard",
-		UnitDefs = [{ BaseID = "Unit.CaravanGuard" }, { BaseID = "Unit.Mercenary" }]		// In Vanilla they also allow ranged mercenaries here
+		ID = "UnitBlock.RF.CaravanGuard",
+		UnitDefs = [{ BaseID = "Unit.RF.CaravanGuard" }, { BaseID = "Unit.RF.Mercenary" }]		// In Vanilla they also allow ranged mercenaries here
 	},
 
 // Militia
 	{
-		ID = "UnitBlock.MilitiaFrontline",
-		UnitDefs = [{ BaseID = "Unit.Militia" }, { BaseID = "Unit.MilitiaVeteran" }]
+		ID = "UnitBlock.RF.MilitiaFrontline",
+		UnitDefs = [{ BaseID = "Unit.RF.Militia" }, { BaseID = "Unit.RF.MilitiaVeteran" }]
 	},
 	{
-		ID = "UnitBlock.MilitiaRanged",
-		UnitDefs = [{ BaseID = "Unit.MilitiaRanged" }]
+		ID = "UnitBlock.RF.MilitiaRanged",
+		UnitDefs = [{ BaseID = "Unit.RF.MilitiaRanged" }]
 	},
 	{
-		ID = "UnitBlock.MilitiaCaptain",
-		UnitDefs = [{ BaseID = "Unit.MilitiaCaptain" }]
+		ID = "UnitBlock.RF.MilitiaCaptain",
+		UnitDefs = [{ BaseID = "Unit.RF.MilitiaCaptain" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
@@ -1,82 +1,82 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.MercenaryFrontline",
-		UnitDefs = [{ BaseID = "Unit.HumanMercenaryLOW" }, { BaseID = "Unit.HumanMercenary" }]
+		UnitDefs = [{ BaseID = "Unit.MercenaryLOW" }, { BaseID = "Unit.Mercenary" }]
 	},
 	{
 		ID = "UnitBlock.MercenaryRanged",
-		UnitDefs = [{ BaseID = "Unit.HumanMercenaryRanged" }]
+		UnitDefs = [{ BaseID = "Unit.MercenaryRanged" }]
 	},
 	{
 		ID = "UnitBlock.MercenaryElite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.HumanMasterArcher" }],
-			[1, { BaseID = "Unit.HumanHedgeKnight" }],
-			[1, { BaseID = "Unit.HumanSwordmaster" }]
+			[1, { BaseID = "Unit.MasterArcher" }],
+			[1, { BaseID = "Unit.HedgeKnight" }],
+			[1, { BaseID = "Unit.Swordmaster" }]
 		]),
 		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
 	},
 	{
-		ID = "UnitBlock.HumanBountyHunter",
-		UnitDefs = [{ BaseID = "Unit.HumanBountyHunter" }]
+		ID = "UnitBlock.BountyHunter",
+		UnitDefs = [{ BaseID = "Unit.BountyHunter" }]
 	},
 	{
-		ID = "UnitBlock.HumanBountyHunterRanged",
-		UnitDefs = [{ BaseID = "Unit.HumanBountyHunterRanged" }]
+		ID = "UnitBlock.BountyHunterRanged",
+		UnitDefs = [{ BaseID = "Unit.BountyHunterRanged" }]
 	},
 	{
-		ID = "UnitBlock.HumanWardogs",
-		UnitDefs = [{ BaseID = "Unit.HumanWardog" }]
+		ID = "UnitBlock.Wardog",
+		UnitDefs = [{ BaseID = "Unit.Wardog" }]
 	},
 	{
-		ID = "UnitBlock.HumanSlaves",
-		UnitDefs = [{ BaseID = "Unit.HumanSlave" }]
+		ID = "UnitBlock.Slave",
+		UnitDefs = [{ BaseID = "Unit.Slave" }]
 	},
 
 // Civilians
 	{
-		ID = "UnitBlock.HumanCultistAmbush",
-		UnitDefs = [{ BaseID = "Unit.HumanCultistAmbush" }]
+		ID = "UnitBlock.CultistAmbush",
+		UnitDefs = [{ BaseID = "Unit.CultistAmbush" }]
 	},
 	{
-		ID = "UnitBlock.HumanPeasants",
-		UnitDefs = [{ BaseID = "Unit.HumanPeasant" }]
+		ID = "UnitBlock.Peasant",
+		UnitDefs = [{ BaseID = "Unit.Peasant" }]
 	},
 	{
-		ID = "UnitBlock.HumanSouthernPeasants",
-		UnitDefs = [{ BaseID = "Unit.HumanSouthernPeasant" }]
+		ID = "UnitBlock.SouthernPeasant",
+		UnitDefs = [{ BaseID = "Unit.SouthernPeasant" }]
 	},
 	{
-		ID = "UnitBlock.HumanPeasantsArmed",
-		UnitDefs = [{ BaseID = "Unit.HumanPeasantArmed" }]
+		ID = "UnitBlock.PeasantArmed",
+		UnitDefs = [{ BaseID = "Unit.PeasantArmed" }]
 	},
 
 // Caravans
 	{
-		ID = "UnitBlock.HumanCaravanDonkeys",
-		UnitDefs = [{ BaseID = "Unit.HumanCaravanDonkey" }]
+		ID = "UnitBlock.CaravanDonkey",
+		UnitDefs = [{ BaseID = "Unit.CaravanDonkey" }]
 	},
 	{
-		ID = "UnitBlock.HumanCaravanHands",
-		UnitDefs = [{ BaseID = "Unit.HumanCaravanHand" }]
+		ID = "UnitBlock.CaravanHand",
+		UnitDefs = [{ BaseID = "Unit.CaravanHand" }]
 	},
 	{
-		ID = "UnitBlock.HumanCaravanGuards",
-		UnitDefs = [{ BaseID = "Unit.HumanCaravanGuard" }, { BaseID = "Unit.HumanMercenary" }]		// In Vanilla they also allow ranged mercenaries here
+		ID = "UnitBlock.CaravanGuard",
+		UnitDefs = [{ BaseID = "Unit.CaravanGuard" }, { BaseID = "Unit.Mercenary" }]		// In Vanilla they also allow ranged mercenaries here
 	},
 
 // Militia
 	{
-		ID = "UnitBlock.HumanMilitiaFrontline",
-		UnitDefs = [{ BaseID = "Unit.HumanMilitia" }, { BaseID = "Unit.HumanMilitiaVeteran" }]
+		ID = "UnitBlock.MilitiaFrontline",
+		UnitDefs = [{ BaseID = "Unit.Militia" }, { BaseID = "Unit.MilitiaVeteran" }]
 	},
 	{
-		ID = "UnitBlock.HumanMilitiaRanged",
-		UnitDefs = [{ BaseID = "Unit.HumanMilitiaRanged" }]
+		ID = "UnitBlock.MilitiaRanged",
+		UnitDefs = [{ BaseID = "Unit.MilitiaRanged" }]
 	},
 	{
-		ID = "UnitBlock.HumanMilitiaCaptain",
-		UnitDefs = [{ BaseID = "Unit.HumanMilitiaCaptain" }],
+		ID = "UnitBlock.MilitiaCaptain",
+		UnitDefs = [{ BaseID = "Unit.MilitiaCaptain" }],
 		StartingResourceMin = 144	// In Vanilla they appear in a group of 144 cost
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/human_blocks.nut
@@ -1,0 +1,87 @@
+local unitBlocks = [
+	{
+		ID = "UnitBlock.MercenaryFrontline",
+		UnitDefs = [{ BaseID = "Unit.HumanMercenaryLOW" }, { BaseID = "Unit.HumanMercenary" }]
+	},
+	{
+		ID = "UnitBlock.MercenaryRanged",
+		UnitDefs = [{ BaseID = "Unit.HumanMercenaryRanged" }]
+	},
+	{
+		ID = "UnitBlock.MercenaryElite",
+		UnitDefs = ::MSU.Class.WeightedContainer([
+			[1, { BaseID = "Unit.HumanMasterArcher" }],
+			[1, { BaseID = "Unit.HumanHedgeKnight" }],
+			[1, { BaseID = "Unit.HumanSwordmaster" }]
+		]),
+		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
+	},
+	{
+		ID = "UnitBlock.HumanBountyHunter",
+		UnitDefs = [{ BaseID = "Unit.HumanBountyHunter" }]
+	},
+	{
+		ID = "UnitBlock.HumanBountyHunterRanged",
+		UnitDefs = [{ BaseID = "Unit.HumanBountyHunterRanged" }]
+	},
+	{
+		ID = "UnitBlock.HumanWardogs",
+		UnitDefs = [{ BaseID = "Unit.HumanWardog" }]
+	},
+	{
+		ID = "UnitBlock.HumanSlaves",
+		UnitDefs = [{ BaseID = "Unit.HumanSlave" }]
+	},
+
+// Civilians
+	{
+		ID = "UnitBlock.HumanCultistAmbush",
+		UnitDefs = [{ BaseID = "Unit.HumanCultistAmbush" }]
+	},
+	{
+		ID = "UnitBlock.HumanPeasants",
+		UnitDefs = [{ BaseID = "Unit.HumanPeasant" }]
+	},
+	{
+		ID = "UnitBlock.HumanSouthernPeasants",
+		UnitDefs = [{ BaseID = "Unit.HumanSouthernPeasant" }]
+	},
+	{
+		ID = "UnitBlock.HumanPeasantsArmed",
+		UnitDefs = [{ BaseID = "Unit.HumanPeasantArmed" }]
+	},
+
+// Caravans
+	{
+		ID = "UnitBlock.HumanCaravanDonkeys",
+		UnitDefs = [{ BaseID = "Unit.HumanCaravanDonkey" }]
+	},
+	{
+		ID = "UnitBlock.HumanCaravanHands",
+		UnitDefs = [{ BaseID = "Unit.HumanCaravanHand" }]
+	},
+	{
+		ID = "UnitBlock.HumanCaravanGuards",
+		UnitDefs = [{ BaseID = "Unit.HumanCaravanGuard" }, { BaseID = "Unit.HumanMercenary" }]		// In Vanilla they also allow ranged mercenaries here
+	},
+
+// Militia
+	{
+		ID = "UnitBlock.HumanMilitiaFrontline",
+		UnitDefs = [{ BaseID = "Unit.HumanMilitia" }, { BaseID = "Unit.HumanMilitiaVeteran" }]
+	},
+	{
+		ID = "UnitBlock.HumanMilitiaRanged",
+		UnitDefs = [{ BaseID = "Unit.HumanMilitiaRanged" }]
+	},
+	{
+		ID = "UnitBlock.HumanMilitiaCaptain",
+		UnitDefs = [{ BaseID = "Unit.HumanMilitiaCaptain" }],
+		StartingResourceMin = 144	// In Vanilla they appear in a group of 144 cost
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
@@ -1,33 +1,33 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.NobleFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.NobleFootman" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Footman" }]
 	},
 	{
 		ID = "UnitBlock.RF.NobleBackline",
-		UnitDefs = [{ BaseID = "Unit.RF.NobleBillman" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Billman" }]
 	},
 	{
 		ID = "UnitBlock.RF.NobleRanged",
-		UnitDefs = [{ BaseID = "Unit.RF.NobleArbalester" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Arbalester" }]
 	},
 	{
 		ID = "UnitBlock.RF.NobleFlank",
-		UnitDefs = [{ BaseID = "Unit.RF.NobleArmoredWardog" }]
+		UnitDefs = [{ BaseID = "Unit.RF.ArmoredWardog" }]
 	},
 	{
 		ID = "UnitBlock.RF.NobleSupport",
-		UnitDefs = [{ BaseID = "Unit.RF.NobleStandardBearer" }]
+		UnitDefs = [{ BaseID = "Unit.RF.StandardBearer" }]
 	},
 	{
 		ID = "UnitBlock.RF.NobleOfficer",
-		UnitDefs = [{ BaseID = "Unit.RF.NobleSergeant" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Sergeant" }]
 	},
 	{
 		ID = "UnitBlock.RF.NobleElite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.RF.NobleZweihander" }],
-			[1, { BaseID = "Unit.RF.NobleKnight" }]
+			[1, { BaseID = "Unit.RF.Greatsword" }],
+			[1, { BaseID = "Unit.RF.Knight" }]
 		])
 	},
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
@@ -1,40 +1,40 @@
 local unitBlocks = [
 	{
-		ID = "UnitBlock.NobleFrontline",
-		UnitDefs = [{ BaseID = "Unit.NobleFootman" }]
+		ID = "UnitBlock.RF.NobleFrontline",
+		UnitDefs = [{ BaseID = "Unit.RF.NobleFootman" }]
 	},
 	{
-		ID = "UnitBlock.NobleBackline",
-		UnitDefs = [{ BaseID = "Unit.NobleBillman" }]
+		ID = "UnitBlock.RF.NobleBackline",
+		UnitDefs = [{ BaseID = "Unit.RF.NobleBillman" }]
 	},
 	{
-		ID = "UnitBlock.NobleRanged",
-		UnitDefs = [{ BaseID = "Unit.NobleArbalester" }]
+		ID = "UnitBlock.RF.NobleRanged",
+		UnitDefs = [{ BaseID = "Unit.RF.NobleArbalester" }]
 	},
 	{
-		ID = "UnitBlock.NobleFlank",
-		UnitDefs = [{ BaseID = "Unit.NobleArmoredWardog" }]
+		ID = "UnitBlock.RF.NobleFlank",
+		UnitDefs = [{ BaseID = "Unit.RF.NobleArmoredWardog" }]
 	},
 	{
-		ID = "UnitBlock.NobleSupport",
-		UnitDefs = [{ BaseID = "Unit.NobleStandardBearer" }]
+		ID = "UnitBlock.RF.NobleSupport",
+		UnitDefs = [{ BaseID = "Unit.RF.NobleStandardBearer" }]
 	},
 	{
-		ID = "UnitBlock.NobleOfficer",
-		UnitDefs = [{ BaseID = "Unit.NobleSergeant" }]
+		ID = "UnitBlock.RF.NobleOfficer",
+		UnitDefs = [{ BaseID = "Unit.RF.NobleSergeant" }]
 	},
 	{
-		ID = "UnitBlock.NobleElite",
+		ID = "UnitBlock.RF.NobleElite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.NobleZweihander" }],
-			[1, { BaseID = "Unit.NobleKnight" }]
+			[1, { BaseID = "Unit.RF.NobleZweihander" }],
+			[1, { BaseID = "Unit.RF.NobleKnight" }]
 		])
 	},
 
 // Caravan
 	{
-	ID = "UnitBlock.NobleDonkeys",
-		UnitDefs = [{ BaseID = "Unit.NobleCaravanDonkey" }]
+	ID = "UnitBlock.RF.NobleDonkeys",
+		UnitDefs = [{ BaseID = "Unit.RF.NobleCaravanDonkey" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
@@ -17,21 +17,18 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.NobleSupport",
-		UnitDefs = [{ BaseID = "Unit.NobleStandardBearer" }],
-		StartingResourceMin = 200	// In Vanilla they appear in a group of 240 cost
+		UnitDefs = [{ BaseID = "Unit.NobleStandardBearer" }]
 	},
 	{
 		ID = "UnitBlock.NobleOfficer",
-		UnitDefs = [{ BaseID = "Unit.NobleSergeant" }],
-		StartingResourceMin = 200	// In Vanilla they appear in a group of 235 cost in noble caravans
+		UnitDefs = [{ BaseID = "Unit.NobleSergeant" }]
 	},
 	{
 		ID = "UnitBlock.NobleElite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
 			[1, { BaseID = "Unit.NobleZweihander" }],
 			[1, { BaseID = "Unit.NobleKnight" }]
-		]),
-		StartingResourceMin = 325	// In Vanilla they appear in a group of 235 cost in noble caravans
+		])
 	},
 
 // Caravan

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
@@ -1,0 +1,47 @@
+local unitBlocks = [
+	{
+		ID = "UnitBlock.NobleFrontline",
+		UnitDefs = [{ BaseID = "Unit.NobleFootman" }]
+	},
+	{
+		ID = "UnitBlock.NobleBackline",
+		UnitDefs = [{ BaseID = "Unit.NobleBillman" }]
+	},
+	{
+		ID = "UnitBlock.NobleRanged",
+		UnitDefs = [{ BaseID = "Unit.NobleArbalester" }]
+	},
+	{
+		ID = "UnitBlock.NobleFlank",
+		UnitDefs = [{ BaseID = "Unit.NobleArmoredWardog" }]
+	},
+	{
+		ID = "UnitBlock.NobleSupport",
+		UnitDefs = [{ BaseID = "Unit.NobleStandardBearer" }],
+		StartingResourceMin = 200	// In Vanilla they appear in a group of 240 cost
+	},
+	{
+		ID = "UnitBlock.NobleOfficer",
+		UnitDefs = [{ BaseID = "Unit.NobleSergeant" }],
+		StartingResourceMin = 200	// In Vanilla they appear in a group of 235 cost in noble caravans
+	},
+	{
+		ID = "UnitBlock.NobleElite",
+		UnitDefs = ::MSU.Class.WeightedContainer([
+			[1, { BaseID = "Unit.NobleZweihander" }],
+			[1, { BaseID = "Unit.NobleKnight" }]
+		]),
+		StartingResourceMin = 325	// In Vanilla they appear in a group of 235 cost in noble caravans
+	},
+
+// Caravan
+	{
+	ID = "UnitBlock.NobleDonkeys",
+		UnitDefs = [{ BaseID = "Unit.NobleCaravanDonkey" }]
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
@@ -33,7 +33,7 @@ local unitBlocks = [
 
 // Caravan
 	{
-	ID = "UnitBlock.RF.NobleDonkey",
+		ID = "UnitBlock.RF.NobleDonkey",
 		UnitDefs = [{ BaseID = "Unit.RF.NobleCaravanDonkey" }]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/noble_blocks.nut
@@ -33,7 +33,7 @@ local unitBlocks = [
 
 // Caravan
 	{
-	ID = "UnitBlock.RF.NobleDonkeys",
+	ID = "UnitBlock.RF.NobleDonkey",
 		UnitDefs = [{ BaseID = "Unit.RF.NobleCaravanDonkey" }]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/nomad_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/nomad_blocks.nut
@@ -14,9 +14,9 @@ local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.NomadElite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.RF.NomadExecutioner" }],
-			[1, { BaseID = "Unit.RF.NomadDesertStalker" }],
-			[1, { BaseID = "Unit.RF.NomadDesertDevil" }]
+			[1, { BaseID = "Unit.RF.Executioner" }],
+			[1, { BaseID = "Unit.RF.DesertStalker" }],
+			[1, { BaseID = "Unit.RF.DesertDevil" }]
 		])
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/nomad_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/nomad_blocks.nut
@@ -1,22 +1,22 @@
 local unitBlocks = [
 	{
-		ID = "UnitBlock.NomadFrontline",
-		UnitDefs = [{ BaseID = "Unit.NomadCutthroat" }, { BaseID = "Unit.NomadOutlaw" }]
+		ID = "UnitBlock.RF.NomadFrontline",
+		UnitDefs = [{ BaseID = "Unit.RF.NomadCutthroat" }, { BaseID = "Unit.RF.NomadOutlaw" }]
 	},
 	{
-		ID = "UnitBlock.NomadRanged",
-		UnitDefs = [{ BaseID = "Unit.NomadSlinger" }, { BaseID = "Unit.NomadArcher" }]
+		ID = "UnitBlock.RF.NomadRanged",
+		UnitDefs = [{ BaseID = "Unit.RF.NomadSlinger" }, { BaseID = "Unit.RF.NomadArcher" }]
 	},
 	{
-		ID = "UnitBlock.NomadLeader",
-		UnitDefs = [{ BaseID = "Unit.NomadLeader" }]
+		ID = "UnitBlock.RF.NomadLeader",
+		UnitDefs = [{ BaseID = "Unit.RF.NomadLeader" }]
 	},
 	{
-		ID = "UnitBlock.NomadElite",
+		ID = "UnitBlock.RF.NomadElite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.NomadExecutioner" }],
-			[1, { BaseID = "Unit.NomadDesertStalker" }],
-			[1, { BaseID = "Unit.NomadDesertDevil" }]
+			[1, { BaseID = "Unit.RF.NomadExecutioner" }],
+			[1, { BaseID = "Unit.RF.NomadDesertStalker" }],
+			[1, { BaseID = "Unit.RF.NomadDesertDevil" }]
 		])
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/nomad_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/nomad_blocks.nut
@@ -1,0 +1,29 @@
+local unitBlocks = [
+	{
+		ID = "UnitBlock.NomadFrontline",
+		UnitDefs = [{ BaseID = "Unit.NomadCutthroat" }, { BaseID = "Unit.NomadOutlaw" }]
+	},
+	{
+		ID = "UnitBlock.NomadRanged",
+		UnitDefs = [{ BaseID = "Unit.NomadSlinger" }, { BaseID = "Unit.NomadArcher" }]
+	},
+	{
+		ID = "UnitBlock.NomadLeader",
+		UnitDefs = [{ BaseID = "Unit.NomadLeader" }],
+		StartingResourceMin = 170	// In Vanilla they appear in a group of 170 cost
+	},
+	{
+		ID = "UnitBlock.NomadElite",
+		UnitDefs = ::MSU.Class.WeightedContainer([
+			[1, { BaseID = "Unit.NomadExecutioner" }],
+			[1, { BaseID = "Unit.NomadDesertStalker" }],
+			[1, { BaseID = "Unit.NomadDesertDevil" }]
+		]),
+		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/nomad_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/nomad_blocks.nut
@@ -9,8 +9,7 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.NomadLeader",
-		UnitDefs = [{ BaseID = "Unit.NomadLeader" }],
-		StartingResourceMin = 170	// In Vanilla they appear in a group of 170 cost
+		UnitDefs = [{ BaseID = "Unit.NomadLeader" }]
 	},
 	{
 		ID = "UnitBlock.NomadElite",
@@ -18,8 +17,7 @@ local unitBlocks = [
 			[1, { BaseID = "Unit.NomadExecutioner" }],
 			[1, { BaseID = "Unit.NomadDesertStalker" }],
 			[1, { BaseID = "Unit.NomadDesertDevil" }]
-		]),
-		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
+		])
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/orc_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/orc_blocks.nut
@@ -1,19 +1,19 @@
 local unitBlocks = [
 	{
-		ID = "UnitBlock.OrcYoung",
-		UnitDefs = [{ BaseID = "Unit.OrcYoungLOW" }, { BaseID = "Unit.OrcYoung" }]
+		ID = "UnitBlock.RF.OrcYoung",
+		UnitDefs = [{ BaseID = "Unit.RF.OrcYoungLOW" }, { BaseID = "Unit.RF.OrcYoung" }]
 	},
 	{
-		ID = "UnitBlock.OrcWarrior",
-		UnitDefs = [{ BaseID = "Unit.OrcWarriorLOW" }, { BaseID = "Unit.OrcWarrior" }]
+		ID = "UnitBlock.RF.OrcWarrior",
+		UnitDefs = [{ BaseID = "Unit.RF.OrcWarriorLOW" }, { BaseID = "Unit.RF.OrcWarrior" }]
 	},
 	{
-		ID = "UnitBlock.OrcBerserker",
-		UnitDefs = [{ BaseID = "Unit.OrcBerserker" }]
+		ID = "UnitBlock.RF.OrcBerserker",
+		UnitDefs = [{ BaseID = "Unit.RF.OrcBerserker" }]
 	},
 	{
-		ID = "UnitBlock.OrcBoss",
-		UnitDefs = [{ BaseID = "Unit.OrcWarlord" }],
+		ID = "UnitBlock.RF.OrcBoss",
+		UnitDefs = [{ BaseID = "Unit.RF.OrcWarlord" }],
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/orc_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/orc_blocks.nut
@@ -1,11 +1,11 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.OrcYoung",
-		UnitDefs = [{ BaseID = "Unit.RF.OrcYoungLOW" }, { BaseID = "Unit.RF.OrcYoung" }]
+		UnitDefs = [{ BaseID = "Unit.RF.OrcYoung" }]
 	},
 	{
 		ID = "UnitBlock.RF.OrcWarrior",
-		UnitDefs = [{ BaseID = "Unit.RF.OrcWarriorLOW" }, { BaseID = "Unit.RF.OrcWarrior" }]
+		UnitDefs = [{ BaseID = "Unit.RF.OrcWarrior" }]
 	},
 	{
 		ID = "UnitBlock.RF.OrcBerserker",
@@ -13,7 +13,7 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.OrcBoss",
-		UnitDefs = [{ BaseID = "Unit.RF.OrcWarlord" }],
+		UnitDefs = [{ BaseID = "Unit.RF.OrcWarlord" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/orc_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/orc_blocks.nut
@@ -1,0 +1,23 @@
+local unitBlocks = [
+	{
+		ID = "UnitBlock.OrcYoung",
+		UnitDefs = [{ BaseID = "Unit.OrcYoungLOW" }, { BaseID = "Unit.OrcYoung" }]
+	},
+	{
+		ID = "UnitBlock.OrcWarrior",
+		UnitDefs = [{ BaseID = "Unit.OrcWarriorLOW" }, { BaseID = "Unit.OrcWarrior" }]
+	},
+	{
+		ID = "UnitBlock.OrcBerserker",
+		UnitDefs = [{ BaseID = "Unit.OrcBerserker" }]
+	},
+	{
+		ID = "UnitBlock.OrcBoss",
+		UnitDefs = [{ BaseID = "Unit.OrcWarlord" }],
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
@@ -2,10 +2,10 @@ local unitBlocks = [
 	{
 			ID = "UnitBlock.ScourgeBoss",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.UndeadSkeletonPriestH" }],
-			[1, { BaseID = "Unit.UndeadSkeletonPriestHH" }],
-			[1, { BaseID = "Unit.UndeadNecromancerYK" }],
-			[1, { BaseID = "Unit.UndeadNecromancerKK" }]
+			[1, { BaseID = "Unit.SkeletonPriestH" }],
+			[1, { BaseID = "Unit.SkeletonPriestHH" }],
+			[1, { BaseID = "Unit.NecromancerYK" }],
+			[1, { BaseID = "Unit.NecromancerKK" }]
 		])
 	},
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
@@ -1,12 +1,12 @@
 local unitBlocks = [
 	{
-			ID = "UnitBlock.ScourgeBoss",
+			ID = "UnitBlock.RF.ScourgeBoss",
 			StartingResourceMin = 350,
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.SkeletonPriestH" }],
-			[1, { BaseID = "Unit.SkeletonPriestHH" }],
-			[1, { BaseID = "Unit.NecromancerYK" }],
-			[1, { BaseID = "Unit.NecromancerKK" }]
+			[1, { BaseID = "Unit.RF.SkeletonPriestH" }],
+			[1, { BaseID = "Unit.RF.SkeletonPriestHH" }],
+			[1, { BaseID = "Unit.RF.NecromancerYK" }],
+			[1, { BaseID = "Unit.RF.NecromancerKK" }]
 		])
 	},
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
@@ -1,6 +1,7 @@
 local unitBlocks = [
 	{
 			ID = "UnitBlock.ScourgeBoss",
+			StartingResourceMin = 350,
 		UnitDefs = ::MSU.Class.WeightedContainer([
 			[1, { BaseID = "Unit.SkeletonPriestH" }],
 			[1, { BaseID = "Unit.SkeletonPriestHH" }],

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
@@ -1,0 +1,16 @@
+local unitBlocks = [
+	{
+			ID = "UnitBlock.ScourgeBoss",
+		UnitDefs = ::MSU.Class.WeightedContainer([
+			[1, { BaseID = "Unit.UndeadSkeletonPriestH" }],
+			[1, { BaseID = "Unit.UndeadSkeletonPriestHH" }],
+			[1, { BaseID = "Unit.UndeadNecromancerYK" }],
+			[1, { BaseID = "Unit.UndeadNecromancerKK" }]
+		])
+	},
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
@@ -1,7 +1,7 @@
 local unitBlocks = [
 	{
-			ID = "UnitBlock.RF.ScourgeBoss",
-			StartingResourceMin = 350,
+		ID = "UnitBlock.RF.ScourgeBoss",
+		StartingResourceMin = 350,
 		UnitDefs = ::MSU.Class.WeightedContainer([
 			[1, { BaseID = "Unit.RF.SkeletonPriestH" }],
 			[1, { BaseID = "Unit.RF.SkeletonPriestHH" }],

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/scourge_blocks.nut
@@ -1,6 +1,6 @@
 local unitBlocks = [
 	{
-		ID = "UnitBlock.RF.ScourgeBoss",
+		ID = "UnitBlock.RF.ScourgeSupport",
 		StartingResourceMin = 350,
 		UnitDefs = ::MSU.Class.WeightedContainer([
 			[1, { BaseID = "Unit.RF.SkeletonPriestH" }],

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
@@ -40,7 +40,7 @@ local unitBlocks = [
 // Caravan
 	{
 	ID = "UnitBlock.RF.SouthernCaravanDonkeys",
-		UnitDefs = [{ BaseID = "Unit.RF.SouthernCaravanDonkey" }]
+		UnitDefs = [{ BaseID = "Unit.RF.SouthernDonkey" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
@@ -1,45 +1,45 @@
 local unitBlocks = [
 	{
-			ID = "UnitBlock.RF.SouthernFrontline",
+		ID = "UnitBlock.RF.SouthernFrontline",
 		//UnitDefs = [{ BaseID = "Conscript" }, { BaseID = "Conscript++" }]
 		UnitDefs = [{ BaseID = "Unit.RF.Conscript" }]
 	},
 	{
-			ID = "UnitBlock.RF.SouthernBackline",
+		ID = "UnitBlock.RF.SouthernBackline",
 		//UnitDefs = [{ BaseID = "Conscript_Polearm" }, { BaseID = "Conscript_Polearm++" }]
 		UnitDefs = [{ BaseID = "Unit.RF.Conscript_Polearm" }]
 	},
 	{
-			ID = "UnitBlock.RF.Assassin",
+		ID = "UnitBlock.RF.Assassin",
 		// UnitDefs = [{ BaseID = "Assassin" }, { BaseID = "Assassin++" }]
 		UnitDefs = [{ BaseID = "Unit.RF.Assassin" }]
 	},
 	{
-			ID = "UnitBlock.RF.Officer",
+		ID = "UnitBlock.RF.Officer",
 		//UnitDefs = [{ BaseID = "Officer" }, { BaseID = "Officer++" }]
 		UnitDefs = [{ BaseID = "Unit.RF.Officer" }]
 	},
 	{
-			ID = "UnitBlock.RF.SouthernRanged",
+		ID = "UnitBlock.RF.SouthernRanged",
 		//UnitDefs = [{ BaseID = "Gunner" }, { BaseID = "Gunner++" }]
 		UnitDefs = [{ BaseID = "Unit.RF.Gunner" }]
 	},
 	{
-			ID = "UnitBlock.RF.Siege",
+		ID = "UnitBlock.RF.Siege",
 		UnitDefs = [{ BaseID = "Unit.RF.Mortar" }]
 	},
 	{
-			ID = "UnitBlock.RF.Engineer",
+		ID = "UnitBlock.RF.Engineer",
 		UnitDefs = [{ BaseID = "Unit.RF.Engineer" }]
 	},
 	{
-			ID = "UnitBlock.RF.Slave",
+		ID = "UnitBlock.RF.Slave",
 		UnitDefs = [{ BaseID = "Unit.RF.Slave" }]
 	},
 
 // Caravan
 	{
-	ID = "UnitBlock.RF.SouthernCaravanDonkey",
+		ID = "UnitBlock.RF.SouthernCaravanDonkey",
 		UnitDefs = [{ BaseID = "Unit.RF.SouthernDonkey" }]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
@@ -39,7 +39,7 @@ local unitBlocks = [
 
 // Caravan
 	{
-	ID = "UnitBlock.RF.SouthernCaravanDonkeys",
+	ID = "UnitBlock.RF.SouthernCaravanDonkey",
 		UnitDefs = [{ BaseID = "Unit.RF.SouthernDonkey" }]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
@@ -2,41 +2,41 @@ local unitBlocks = [
 	{
 			ID = "UnitBlock.SouthernFrontline",
 		//UnitDefs = [{ BaseID = "Conscript" }, { BaseID = "Conscript++" }]
-		UnitDefs = [{ BaseID = "Unit.SouthernConscript" }]
+		UnitDefs = [{ BaseID = "Unit.Conscript" }]
 	},
 	{
 			ID = "UnitBlock.SouthernBackline",
 		//UnitDefs = [{ BaseID = "Conscript_Polearm" }, { BaseID = "Conscript_Polearm++" }]
-		UnitDefs = [{ BaseID = "Unit.SouthernConscript_Polearm" }]
+		UnitDefs = [{ BaseID = "Unit.Conscript_Polearm" }]
 	},
 	{
-			ID = "UnitBlock.SouthernAssassins",
+			ID = "UnitBlock.Assassin",
 		// UnitDefs = [{ BaseID = "Assassin" }, { BaseID = "Assassin++" }]
-		UnitDefs = [{ BaseID = "Unit.SouthernAssassin" }]
+		UnitDefs = [{ BaseID = "Unit.Assassin" }]
 	},
 	{
-			ID = "UnitBlock.SouthernOfficers",
+			ID = "UnitBlock.Officer",
 		//UnitDefs = [{ BaseID = "Officer" }, { BaseID = "Officer++" }]
-		UnitDefs = [{ BaseID = "Unit.SouthernOfficer" }],
+		UnitDefs = [{ BaseID = "Unit.Officer" }],
 		StartingResourceMin = 250	// In Vanilla they appear in a group of 250 cost
 	},
 	{
 			ID = "UnitBlock.SouthernRanged",
 		//UnitDefs = [{ BaseID = "Gunner" }, { BaseID = "Gunner++" }]
-		UnitDefs = [{ BaseID = "Unit.SouthernGunner" }]
+		UnitDefs = [{ BaseID = "Unit.Gunner" }]
 	},
 	{
-			ID = "UnitBlock.SouthernSiege",
-		UnitDefs = [{ BaseID = "Unit.SouthernMortar" }],
+			ID = "UnitBlock.Siege",
+		UnitDefs = [{ BaseID = "Unit.Mortar" }],
 		StartingResourceMin = 340	// In Vanilla they appear in a group of 340 cost
 	},
 	{
-			ID = "UnitBlock.SouthernEngineer",
-		UnitDefs = [{ BaseID = "Unit.SouthernEngineer" }]
+			ID = "UnitBlock.Engineer",
+		UnitDefs = [{ BaseID = "Unit.Engineer" }]
 	},
 	{
-			ID = "UnitBlock.SouthernSlaves",
-		UnitDefs = [{ BaseID = "Unit.SouthernSlave" }]
+			ID = "UnitBlock.Slave",
+		UnitDefs = [{ BaseID = "Unit.Slave" }]
 	},
 
 // Caravan

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
@@ -1,0 +1,52 @@
+local unitBlocks = [
+	{
+			ID = "UnitBlock.SouthernFrontline",
+		//UnitDefs = [{ BaseID = "Conscript" }, { BaseID = "Conscript++" }]
+		UnitDefs = [{ BaseID = "Unit.SouthernConscript" }]
+	},
+	{
+			ID = "UnitBlock.SouthernBackline",
+		//UnitDefs = [{ BaseID = "Conscript_Polearm" }, { BaseID = "Conscript_Polearm++" }]
+		UnitDefs = [{ BaseID = "Unit.SouthernConscript_Polearm" }]
+	},
+	{
+			ID = "UnitBlock.SouthernAssassins",
+		// UnitDefs = [{ BaseID = "Assassin" }, { BaseID = "Assassin++" }]
+		UnitDefs = [{ BaseID = "Unit.SouthernAssassin" }]
+	},
+	{
+			ID = "UnitBlock.SouthernOfficers",
+		//UnitDefs = [{ BaseID = "Officer" }, { BaseID = "Officer++" }]
+		UnitDefs = [{ BaseID = "Unit.SouthernOfficer" }],
+		StartingResourceMin = 250	// In Vanilla they appear in a group of 250 cost
+	},
+	{
+			ID = "UnitBlock.SouthernRanged",
+		//UnitDefs = [{ BaseID = "Gunner" }, { BaseID = "Gunner++" }]
+		UnitDefs = [{ BaseID = "Unit.SouthernGunner" }]
+	},
+	{
+			ID = "UnitBlock.SouthernSiege",
+		UnitDefs = [{ BaseID = "Unit.SouthernMortar" }],
+		StartingResourceMin = 340	// In Vanilla they appear in a group of 340 cost
+	},
+	{
+			ID = "UnitBlock.SouthernEngineer",
+		UnitDefs = [{ BaseID = "Unit.SouthernEngineer" }]
+	},
+	{
+			ID = "UnitBlock.SouthernSlaves",
+		UnitDefs = [{ BaseID = "Unit.SouthernSlave" }]
+	},
+
+// Caravan
+	{
+	ID = "UnitBlock.SouthernCaravanDonkeys",
+		UnitDefs = [{ BaseID = "Unit.SouthernCaravanDonkey" }]
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
@@ -1,46 +1,46 @@
 local unitBlocks = [
 	{
-			ID = "UnitBlock.SouthernFrontline",
+			ID = "UnitBlock.RF.SouthernFrontline",
 		//UnitDefs = [{ BaseID = "Conscript" }, { BaseID = "Conscript++" }]
-		UnitDefs = [{ BaseID = "Unit.Conscript" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Conscript" }]
 	},
 	{
-			ID = "UnitBlock.SouthernBackline",
+			ID = "UnitBlock.RF.SouthernBackline",
 		//UnitDefs = [{ BaseID = "Conscript_Polearm" }, { BaseID = "Conscript_Polearm++" }]
-		UnitDefs = [{ BaseID = "Unit.Conscript_Polearm" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Conscript_Polearm" }]
 	},
 	{
-			ID = "UnitBlock.Assassin",
+			ID = "UnitBlock.RF.Assassin",
 		// UnitDefs = [{ BaseID = "Assassin" }, { BaseID = "Assassin++" }]
-		UnitDefs = [{ BaseID = "Unit.Assassin" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Assassin" }]
 	},
 	{
-			ID = "UnitBlock.Officer",
+			ID = "UnitBlock.RF.Officer",
 		//UnitDefs = [{ BaseID = "Officer" }, { BaseID = "Officer++" }]
-		UnitDefs = [{ BaseID = "Unit.Officer" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Officer" }]
 	},
 	{
-			ID = "UnitBlock.SouthernRanged",
+			ID = "UnitBlock.RF.SouthernRanged",
 		//UnitDefs = [{ BaseID = "Gunner" }, { BaseID = "Gunner++" }]
-		UnitDefs = [{ BaseID = "Unit.Gunner" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Gunner" }]
 	},
 	{
-			ID = "UnitBlock.Siege",
-		UnitDefs = [{ BaseID = "Unit.Mortar" }]
+			ID = "UnitBlock.RF.Siege",
+		UnitDefs = [{ BaseID = "Unit.RF.Mortar" }]
 	},
 	{
-			ID = "UnitBlock.Engineer",
-		UnitDefs = [{ BaseID = "Unit.Engineer" }]
+			ID = "UnitBlock.RF.Engineer",
+		UnitDefs = [{ BaseID = "Unit.RF.Engineer" }]
 	},
 	{
-			ID = "UnitBlock.Slave",
-		UnitDefs = [{ BaseID = "Unit.Slave" }]
+			ID = "UnitBlock.RF.Slave",
+		UnitDefs = [{ BaseID = "Unit.RF.Slave" }]
 	},
 
 // Caravan
 	{
-	ID = "UnitBlock.SouthernCaravanDonkeys",
-		UnitDefs = [{ BaseID = "Unit.SouthernCaravanDonkey" }]
+	ID = "UnitBlock.RF.SouthernCaravanDonkeys",
+		UnitDefs = [{ BaseID = "Unit.RF.SouthernCaravanDonkey" }]
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/southern_blocks.nut
@@ -17,8 +17,7 @@ local unitBlocks = [
 	{
 			ID = "UnitBlock.Officer",
 		//UnitDefs = [{ BaseID = "Officer" }, { BaseID = "Officer++" }]
-		UnitDefs = [{ BaseID = "Unit.Officer" }],
-		StartingResourceMin = 250	// In Vanilla they appear in a group of 250 cost
+		UnitDefs = [{ BaseID = "Unit.Officer" }]
 	},
 	{
 			ID = "UnitBlock.SouthernRanged",
@@ -27,8 +26,7 @@ local unitBlocks = [
 	},
 	{
 			ID = "UnitBlock.Siege",
-		UnitDefs = [{ BaseID = "Unit.Mortar" }],
-		StartingResourceMin = 340	// In Vanilla they appear in a group of 340 cost
+		UnitDefs = [{ BaseID = "Unit.Mortar" }]
 	},
 	{
 			ID = "UnitBlock.Engineer",

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
@@ -2,36 +2,36 @@ local unitBlocks = [
 	{
 			ID = "UnitBlock.UndeadFrontline",
 		UnitDefs = [
-			{ BaseID = "Unit.UndeadSkeletonLight" },
-			{ BaseID = "Unit.UndeadSkeletonMedium", StartingResourceMin = 125 },
-			{ BaseID = "Unit.UndeadSkeletonHeavy", StartingResourceMin = 175 }
+			{ BaseID = "unit.SkeletonLight" },
+			{ BaseID = "unit.SkeletonMedium", StartingResourceMin = 125 },
+			{ BaseID = "unit.SkeletonHeavy", StartingResourceMin = 175 }
 		]
 	},
 	{
 			ID = "UnitBlock.UndeadBackline",
 		UnitDefs = [
-			{ BaseID = "Unit.UndeadSkeletonMediumPolearm", StartingResourceMin = 125 },
-			{ BaseID = "Unit.UndeadSkeletonHeavyPolearm", StartingResourceMin = 175 }
+			{ BaseID = "unit.SkeletonMediumPolearm", StartingResourceMin = 125 },
+			{ BaseID = "unit.SkeletonHeavyPolearm", StartingResourceMin = 175 }
 		]
 	},
 	{
 			ID = "UnitBlock.UndeadBoss",
 		UnitDefs = [
-			{ BaseID = "Unit.UndeadSkeletonPriestH" },
-			{ BaseID = "Unit.UndeadSkeletonPriestHH" }
+			{ BaseID = "unit.SkeletonPriestH" },
+			{ BaseID = "unit.SkeletonPriestHH" }
 		]
 	},
 	{
-			ID = "UnitBlock.UndeadSkeletonHeavyBodyguard",
+			ID = "UnitBlock.SkeletonHeavyBodyguard",
 		UnitDefs = [
-			{ BaseID = "Unit.UndeadSkeletonHeavyBodyguard" }
+			{ BaseID = "unit.SkeletonHeavyBodyguard" }
 		]
 	},
 	{
-			ID = "UnitBlock.UndeadVampire",
+			ID = "UnitBlock.Vampire",
 		UnitDefs = [
-			{ BaseID = "Unit.UndeadVampireLOW" },
-			{ BaseID = "Unit.UndeadVampire" }
+			{ BaseID = "unit.VampireLOW" },
+			{ BaseID = "unit.Vampire" }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
@@ -1,38 +1,38 @@
 local unitBlocks = [
 	{
-			ID = "UnitBlock.UndeadFrontline",
+			ID = "UnitBlock.RF.UndeadFrontline",
 		UnitDefs = [
-			{ BaseID = "unit.SkeletonLight" },
-			{ BaseID = "unit.SkeletonMedium" },
-			{ BaseID = "unit.SkeletonHeavy" }
+			{ BaseID = "Unit.RF.SkeletonLight" },
+			{ BaseID = "Unit.RF.SkeletonMedium" },
+			{ BaseID = "Unit.RF.SkeletonHeavy" }
 		]
 	},
 	{
-			ID = "UnitBlock.UndeadBackline",
+			ID = "UnitBlock.RF.UndeadBackline",
 		UnitDefs = [
-			{ BaseID = "unit.SkeletonMediumPolearm" },
-			{ BaseID = "unit.SkeletonHeavyPolearm" }
+			{ BaseID = "Unit.RF.SkeletonMediumPolearm" },
+			{ BaseID = "Unit.RF.SkeletonHeavyPolearm" }
 		]
 	},
 	{
-			ID = "UnitBlock.UndeadBoss",
+			ID = "UnitBlock.RF.UndeadBoss",
 			StartingResourceMin = 225
 		UnitDefs = [
-			{ BaseID = "unit.SkeletonPriestH" },
-			{ BaseID = "unit.SkeletonPriestHH" }
+			{ BaseID = "Unit.RF.SkeletonPriestH" },
+			{ BaseID = "Unit.RF.SkeletonPriestHH" }
 		]
 	},
 	{
-			ID = "UnitBlock.SkeletonHeavyBodyguard",
+			ID = "UnitBlock.RF.SkeletonHeavyBodyguard",
 		UnitDefs = [
-			{ BaseID = "unit.SkeletonHeavyBodyguard" }
+			{ BaseID = "Unit.RF.SkeletonHeavyBodyguard" }
 		]
 	},
 	{
-			ID = "UnitBlock.Vampire",
+			ID = "UnitBlock.RF.Vampire",
 		UnitDefs = [
-			{ BaseID = "unit.VampireLOW" },
-			{ BaseID = "unit.Vampire" }
+			{ BaseID = "Unit.RF.VampireLOW" },
+			{ BaseID = "Unit.RF.Vampire" }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
@@ -3,19 +3,20 @@ local unitBlocks = [
 			ID = "UnitBlock.UndeadFrontline",
 		UnitDefs = [
 			{ BaseID = "unit.SkeletonLight" },
-			{ BaseID = "unit.SkeletonMedium", StartingResourceMin = 125 },
-			{ BaseID = "unit.SkeletonHeavy", StartingResourceMin = 175 }
+			{ BaseID = "unit.SkeletonMedium" },
+			{ BaseID = "unit.SkeletonHeavy" }
 		]
 	},
 	{
 			ID = "UnitBlock.UndeadBackline",
 		UnitDefs = [
-			{ BaseID = "unit.SkeletonMediumPolearm", StartingResourceMin = 125 },
-			{ BaseID = "unit.SkeletonHeavyPolearm", StartingResourceMin = 175 }
+			{ BaseID = "unit.SkeletonMediumPolearm" },
+			{ BaseID = "unit.SkeletonHeavyPolearm" }
 		]
 	},
 	{
 			ID = "UnitBlock.UndeadBoss",
+			StartingResourceMin = 225
 		UnitDefs = [
 			{ BaseID = "unit.SkeletonPriestH" },
 			{ BaseID = "unit.SkeletonPriestHH" }

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
@@ -1,0 +1,42 @@
+local unitBlocks = [
+	{
+			ID = "UnitBlock.UndeadFrontline",
+		UnitDefs = [
+			{ BaseID = "Unit.UndeadSkeletonLight" },
+			{ BaseID = "Unit.UndeadSkeletonMedium", StartingResourceMin = 125 },
+			{ BaseID = "Unit.UndeadSkeletonHeavy", StartingResourceMin = 175 }
+		]
+	},
+	{
+			ID = "UnitBlock.UndeadBackline",
+		UnitDefs = [
+			{ BaseID = "Unit.UndeadSkeletonMediumPolearm", StartingResourceMin = 125 },
+			{ BaseID = "Unit.UndeadSkeletonHeavyPolearm", StartingResourceMin = 175 }
+		]
+	},
+	{
+			ID = "UnitBlock.UndeadBoss",
+		UnitDefs = [
+			{ BaseID = "Unit.UndeadSkeletonPriestH" },
+			{ BaseID = "Unit.UndeadSkeletonPriestHH" }
+		]
+	},
+	{
+			ID = "UnitBlock.UndeadSkeletonHeavyBodyguard",
+		UnitDefs = [
+			{ BaseID = "Unit.UndeadSkeletonHeavyBodyguard" }
+		]
+	},
+	{
+			ID = "UnitBlock.UndeadVampire",
+		UnitDefs = [
+			{ BaseID = "Unit.UndeadVampireLOW" },
+			{ BaseID = "Unit.UndeadVampire" }
+		]
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/undead_blocks.nut
@@ -1,6 +1,6 @@
 local unitBlocks = [
 	{
-			ID = "UnitBlock.RF.UndeadFrontline",
+		ID = "UnitBlock.RF.UndeadFrontline",
 		UnitDefs = [
 			{ BaseID = "Unit.RF.SkeletonLight" },
 			{ BaseID = "Unit.RF.SkeletonMedium" },
@@ -8,28 +8,28 @@ local unitBlocks = [
 		]
 	},
 	{
-			ID = "UnitBlock.RF.UndeadBackline",
+		ID = "UnitBlock.RF.UndeadBackline",
 		UnitDefs = [
 			{ BaseID = "Unit.RF.SkeletonMediumPolearm" },
 			{ BaseID = "Unit.RF.SkeletonHeavyPolearm" }
 		]
 	},
 	{
-			ID = "UnitBlock.RF.UndeadBoss",
-			StartingResourceMin = 225
+		ID = "UnitBlock.RF.UndeadBoss",
+		StartingResourceMin = 225
 		UnitDefs = [
 			{ BaseID = "Unit.RF.SkeletonPriestH" },
 			{ BaseID = "Unit.RF.SkeletonPriestHH" }
 		]
 	},
 	{
-			ID = "UnitBlock.RF.SkeletonHeavyBodyguard",
+		ID = "UnitBlock.RF.SkeletonHeavyBodyguard",
 		UnitDefs = [
 			{ BaseID = "Unit.RF.SkeletonHeavyBodyguard" }
 		]
 	},
 	{
-			ID = "UnitBlock.RF.Vampire",
+		ID = "UnitBlock.RF.Vampire",
 		UnitDefs = [
 			{ BaseID = "Unit.RF.VampireLOW" },
 			{ BaseID = "Unit.RF.Vampire" }

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
@@ -1,49 +1,49 @@
 local unitBlocks = [
 	{
-			ID = "UnitBlock.ZombieFrontline",
-		UnitDefs = [{ BaseID = "Unit.Zombie" }, { BaseID = "Unit.ZombieYeoman" }, { BaseID = "Unit.FallenHero" }]
+			ID = "UnitBlock.RF.ZombieFrontline",
+		UnitDefs = [{ BaseID = "Unit.RF.Zombie" }, { BaseID = "Unit.RF.ZombieYeoman" }, { BaseID = "Unit.RF.FallenHero" }]
 	},
 	{
-			ID = "UnitBlock.ZombieLight",
-		UnitDefs = [{ BaseID = "Unit.Zombie" }]
+			ID = "UnitBlock.RF.ZombieLight",
+		UnitDefs = [{ BaseID = "Unit.RF.Zombie" }]
 	},
 	{
-			ID = "UnitBlock.ZombieElite",
-		UnitDefs = [{ BaseID = "Unit.FallenHero" }]
+			ID = "UnitBlock.RF.ZombieElite",
+		UnitDefs = [{ BaseID = "Unit.RF.FallenHero" }]
 	},
 	{
-			ID = "UnitBlock.ZombieSouthern",
-		UnitDefs = [{ BaseID = "Unit.ZombieNomad" }]
+			ID = "UnitBlock.RF.ZombieSouthern",
+		UnitDefs = [{ BaseID = "Unit.RF.ZombieNomad" }]
 	},
 	{
-			ID = "UnitBlock.Necromancer",
-		UnitDefs = [{ BaseID = "Unit.Necromancer" }]
+			ID = "UnitBlock.RF.Necromancer",
+		UnitDefs = [{ BaseID = "Unit.RF.Necromancer" }]
 	},
 	{
-			ID = "UnitBlock.NecromancerWithBodyguards",
+			ID = "UnitBlock.RF.NecromancerWithBodyguards",
 		UnitDefs = [
-			{ BaseID = "Unit.NecromancerY" },
-			{ BaseID = "Unit.NecromancerK" },
-			{ BaseID = "Unit.NecromancerYK" },
-			{ BaseID = "Unit.NecromancerKK" }
+			{ BaseID = "Unit.RF.NecromancerY" },
+			{ BaseID = "Unit.RF.NecromancerK" },
+			{ BaseID = "Unit.RF.NecromancerYK" },
+			{ BaseID = "Unit.RF.NecromancerKK" }
 		]
 	},
 	{
-			ID = "UnitBlock.NecromancerWithNomads",
+			ID = "UnitBlock.RF.NecromancerWithNomads",
 		UnitDefs = [
-			{ BaseID = "Unit.NecromancerN" },
-			{ BaseID = "Unit.NecromancerNN" },
-			{ BaseID = "Unit.NecromancerNNN" }
+			{ BaseID = "Unit.RF.NecromancerN" },
+			{ BaseID = "Unit.RF.NecromancerNN" },
+			{ BaseID = "Unit.RF.NecromancerNNN" }
 		]
 	},
 	{
-			ID = "UnitBlock.Ghost",
-		UnitDefs = [{ BaseID = "Unit.Ghost" }]
+			ID = "UnitBlock.RF.Ghost",
+		UnitDefs = [{ BaseID = "Unit.RF.Ghost" }]
 	},
 	{
-			ID = "UnitBlock.ZombieNomadBodyguard",
+			ID = "UnitBlock.RF.ZombieNomadBodyguard",
 		UnitDefs = [
-			{ BaseID = "Unit.ZombieNomadBodyguard" }
+			{ BaseID = "Unit.RF.ZombieNomadBodyguard" }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
@@ -1,26 +1,26 @@
 local unitBlocks = [
 	{
-			ID = "UnitBlock.RF.ZombieFrontline",
+		ID = "UnitBlock.RF.ZombieFrontline",
 		UnitDefs = [{ BaseID = "Unit.RF.Zombie" }, { BaseID = "Unit.RF.ZombieYeoman" }, { BaseID = "Unit.RF.ZombieKnight" }]
 	},
 	{
-			ID = "UnitBlock.RF.ZombieLight",
+		ID = "UnitBlock.RF.ZombieLight",
 		UnitDefs = [{ BaseID = "Unit.RF.Zombie" }]
 	},
 	{
-			ID = "UnitBlock.RF.ZombieElite",
+		ID = "UnitBlock.RF.ZombieElite",
 		UnitDefs = [{ BaseID = "Unit.RF.ZombieKnight" }]
 	},
 	{
-			ID = "UnitBlock.RF.ZombieSouthern",
+		ID = "UnitBlock.RF.ZombieSouthern",
 		UnitDefs = [{ BaseID = "Unit.RF.ZombieNomad" }]
 	},
 	{
-			ID = "UnitBlock.RF.Necromancer",
+		ID = "UnitBlock.RF.Necromancer",
 		UnitDefs = [{ BaseID = "Unit.RF.Necromancer" }]
 	},
 	{
-			ID = "UnitBlock.RF.NecromancerWithBodyguards",
+		ID = "UnitBlock.RF.NecromancerWithBodyguards",
 		UnitDefs = [
 			{ BaseID = "Unit.RF.NecromancerY" },
 			{ BaseID = "Unit.RF.NecromancerK" },
@@ -29,7 +29,7 @@ local unitBlocks = [
 		]
 	},
 	{
-			ID = "UnitBlock.RF.NecromancerWithNomads",
+		ID = "UnitBlock.RF.NecromancerWithNomads",
 		UnitDefs = [
 			{ BaseID = "Unit.RF.NecromancerN" },
 			{ BaseID = "Unit.RF.NecromancerNN" },
@@ -37,11 +37,11 @@ local unitBlocks = [
 		]
 	},
 	{
-			ID = "UnitBlock.RF.Ghost",
+		ID = "UnitBlock.RF.Ghost",
 		UnitDefs = [{ BaseID = "Unit.RF.Ghost" }]
 	},
 	{
-			ID = "UnitBlock.RF.ZombieNomadBodyguard",
+		ID = "UnitBlock.RF.ZombieNomadBodyguard",
 		UnitDefs = [
 			{ BaseID = "Unit.RF.ZombieNomadBodyguard" }
 		]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
@@ -1,49 +1,49 @@
 local unitBlocks = [
 	{
 			ID = "UnitBlock.ZombieFrontline",
-		UnitDefs = [{ BaseID = "Unit.UndeadZombie" }, { BaseID = "Unit.UndeadZombieYeoman" }, { BaseID = "Unit.UndeadFallenHero" }]
+		UnitDefs = [{ BaseID = "Unit.Zombie" }, { BaseID = "Unit.ZombieYeoman" }, { BaseID = "Unit.FallenHero" }]
 	},
 	{
 			ID = "UnitBlock.ZombieLight",
-		UnitDefs = [{ BaseID = "Unit.UndeadZombie" }]
+		UnitDefs = [{ BaseID = "Unit.Zombie" }]
 	},
 	{
 			ID = "UnitBlock.ZombieElite",
-		UnitDefs = [{ BaseID = "Unit.UndeadFallenHero" }]
+		UnitDefs = [{ BaseID = "Unit.FallenHero" }]
 	},
 	{
 			ID = "UnitBlock.ZombieSouthern",
-		UnitDefs = [{ BaseID = "Unit.UndeadZombieNomad" }]
+		UnitDefs = [{ BaseID = "Unit.ZombieNomad" }]
 	},
 	{
-			ID = "UnitBlock.ZombieNecromancer",
-		UnitDefs = [{ BaseID = "Unit.UndeadNecromancer" }]
+			ID = "UnitBlock.Necromancer",
+		UnitDefs = [{ BaseID = "Unit.Necromancer" }]
 	},
 	{
-			ID = "UnitBlock.ZombieNecromancerWithBodyguards",
+			ID = "UnitBlock.NecromancerWithBodyguards",
 		UnitDefs = [
-			{ BaseID = "Unit.UndeadNecromancerY" },
-			{ BaseID = "Unit.UndeadNecromancerK" },
-			{ BaseID = "Unit.UndeadNecromancerYK" },
-			{ BaseID = "Unit.UndeadNecromancerKK" }
+			{ BaseID = "Unit.NecromancerY" },
+			{ BaseID = "Unit.NecromancerK" },
+			{ BaseID = "Unit.NecromancerYK" },
+			{ BaseID = "Unit.NecromancerKK" }
 		]
 	},
 	{
-			ID = "UnitBlock.ZombieNecromancerWithNomads",
+			ID = "UnitBlock.NecromancerWithNomads",
 		UnitDefs = [
-			{ BaseID = "Unit.UndeadNecromancerN" },
-			{ BaseID = "Unit.UndeadNecromancerNN" },
-			{ BaseID = "Unit.UndeadNecromancerNNN" }
+			{ BaseID = "Unit.NecromancerN" },
+			{ BaseID = "Unit.NecromancerNN" },
+			{ BaseID = "Unit.NecromancerNNN" }
 		]
 	},
 	{
-			ID = "UnitBlock.ZombieGhost",
-		UnitDefs = [{ BaseID = "Unit.UndeadGhost" }]
+			ID = "UnitBlock.Ghost",
+		UnitDefs = [{ BaseID = "Unit.Ghost" }]
 	},
 	{
-			ID = "UnitBlock.ZombieZombieNomadBodyguard",
+			ID = "UnitBlock.ZombieNomadBodyguard",
 		UnitDefs = [
-			{ BaseID = "Unit.UndeadZombieNomadBodyguard" }
+			{ BaseID = "Unit.ZombieNomadBodyguard" }
 		]
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
@@ -1,0 +1,54 @@
+local unitBlocks = [
+	{
+			ID = "UnitBlock.ZombieFrontline",
+		UnitDefs = [{ BaseID = "Unit.UndeadZombie" }, { BaseID = "Unit.UndeadZombieYeoman" }, { BaseID = "Unit.UndeadFallenHero" }]
+	},
+	{
+			ID = "UnitBlock.ZombieLight",
+		UnitDefs = [{ BaseID = "Unit.UndeadZombie" }]
+	},
+	{
+			ID = "UnitBlock.ZombieElite",
+		UnitDefs = [{ BaseID = "Unit.UndeadFallenHero" }]
+	},
+	{
+			ID = "UnitBlock.ZombieSouthern",
+		UnitDefs = [{ BaseID = "Unit.UndeadZombieNomad" }]
+	},
+	{
+			ID = "UnitBlock.ZombieNecromancer",
+		UnitDefs = [{ BaseID = "Unit.UndeadNecromancer" }]
+	},
+	{
+			ID = "UnitBlock.ZombieNecromancerWithBodyguards",
+		UnitDefs = [
+			{ BaseID = "Unit.UndeadNecromancerY" },
+			{ BaseID = "Unit.UndeadNecromancerK" },
+			{ BaseID = "Unit.UndeadNecromancerYK" },
+			{ BaseID = "Unit.UndeadNecromancerKK" }
+		]
+	},
+	{
+			ID = "UnitBlock.ZombieNecromancerWithNomads",
+		UnitDefs = [
+			{ BaseID = "Unit.UndeadNecromancerN" },
+			{ BaseID = "Unit.UndeadNecromancerNN" },
+			{ BaseID = "Unit.UndeadNecromancerNNN" }
+		]
+	},
+	{
+			ID = "UnitBlock.ZombieGhost",
+		UnitDefs = [{ BaseID = "Unit.UndeadGhost" }]
+	},
+	{
+			ID = "UnitBlock.ZombieZombieNomadBodyguard",
+		UnitDefs = [
+			{ BaseID = "Unit.UndeadZombieNomadBodyguard" }
+		]
+	}
+]
+
+foreach (blockDef in unitBlocks)
+{
+	::DynamicSpawns.Public.registerUnitBlock(blockDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/unit_blocks/zombie_blocks.nut
@@ -1,7 +1,7 @@
 local unitBlocks = [
 	{
 			ID = "UnitBlock.RF.ZombieFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.Zombie" }, { BaseID = "Unit.RF.ZombieYeoman" }, { BaseID = "Unit.RF.FallenHero" }]
+		UnitDefs = [{ BaseID = "Unit.RF.Zombie" }, { BaseID = "Unit.RF.ZombieYeoman" }, { BaseID = "Unit.RF.ZombieKnight" }]
 	},
 	{
 			ID = "UnitBlock.RF.ZombieLight",
@@ -9,7 +9,7 @@ local unitBlocks = [
 	},
 	{
 			ID = "UnitBlock.RF.ZombieElite",
-		UnitDefs = [{ BaseID = "Unit.RF.FallenHero" }]
+		UnitDefs = [{ BaseID = "Unit.RF.ZombieKnight" }]
 	},
 	{
 			ID = "UnitBlock.RF.ZombieSouthern",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/bandit_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/bandit_units.nut
@@ -3,40 +3,33 @@ local units = [
 		ID = "Unit.RF.BanditThug",
 		Troop = "BanditThug",
 		Figure = "figure_bandit_02",
-		Cost = 9
 	},
 	{
 		ID = "Unit.RF.Wardog",
 		Troop = "Wardog",
-		Cost = 10
 	},
 	{
 		ID = "Unit.RF.BanditPoacher",
 		Troop = "BanditMarksmanLOW",
 		Figure = "figure_bandit_01",
-		Cost = 12
 	},
 	{
 		ID = "Unit.RF.BanditMarksman",
 		Troop = "BanditMarksman",
-		Cost = 15
 	},
 	{
 		ID = "Unit.RF.BanditRaider",
 		Troop = "BanditRaider",
 		Figure = "figure_bandit_03",
-		Cost = 20
 	},
 	{
 		ID = "Unit.RF.BanditLeader",
 		Troop = "BanditLeader",
 		Figure = "figure_bandit_04",
-		Cost = 25
 	},
 	{
 		ID = "Unit.RF.BanditRaiderWolf",
 		Troop = "BanditRaiderWolf",
-		Cost = 25
 	}
 	{
 		ID = "Unit.RF.RF_BanditScoundrel",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/bandit_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/bandit_units.nut
@@ -1,61 +1,100 @@
 local units = [
 	{
-		ID = "Unit.RF_BanditScoundrel",
+		ID = "Unit.RF.BanditThug",
+		Troop = "BanditThug",
+		Figure = "figure_bandit_02",
+		Cost = 9
+	},
+	{
+		ID = "Unit.RF.Wardog",
+		Troop = "Wardog",
+		Cost = 10
+	},
+	{
+		ID = "Unit.RF.BanditPoacher",
+		Troop = "BanditMarksmanLOW",
+		Figure = "figure_bandit_01",
+		Cost = 12
+	},
+	{
+		ID = "Unit.RF.BanditMarksman",
+		Troop = "BanditMarksman",
+		Cost = 15
+	},
+	{
+		ID = "Unit.RF.BanditRaider",
+		Troop = "BanditRaider",
+		Figure = "figure_bandit_03",
+		Cost = 20
+	},
+	{
+		ID = "Unit.RF.BanditLeader",
+		Troop = "BanditLeader",
+		Figure = "figure_bandit_04",
+		Cost = 25
+	},
+	{
+		ID = "Unit.RF.BanditRaiderWolf",
+		Troop = "BanditRaiderWolf",
+		Cost = 25
+	}
+	{
+		ID = "Unit.RF.RF_BanditScoundrel",
 		Troop = "RF_BanditScoundrel",
 		Figure = "figure_bandit_02"
 	},
 	{
-		ID = "Unit.RF_BanditRobber",
+		ID = "Unit.RF.RF_BanditRobber",
 		Troop = "RF_BanditRobber",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditHunter",
+		ID = "Unit.RF.RF_BanditHunter",
 		Troop = "RF_BanditHunter",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditVandal",
+		ID = "Unit.RF.RF_BanditVandal",
 		Troop = "RF_BanditVandal",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditPillager",
+		ID = "Unit.RF.RF_BanditPillager",
 		Troop = "RF_BanditPillager",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditOutlaw",
+		ID = "Unit.RF.RF_BanditOutlaw",
 		Troop = "RF_BanditOutlaw",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditBandit",
+		ID = "Unit.RF.RF_BanditBandit",
 		Troop = "RF_BanditBandit",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditHighwayman",
+		ID = "Unit.RF.RF_BanditHighwayman",
 		Troop = "RF_BanditHighwayman",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditMarauder",
+		ID = "Unit.RF.RF_BanditMarauder",
 		Troop = "RF_BanditMarauder",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditSharpshooter",
+		ID = "Unit.RF.RF_BanditSharpshooter",
 		Troop = "RF_BanditSharpshooter",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditKiller",
+		ID = "Unit.RF.RF_BanditKiller",
 		Troop = "RF_BanditKiller",
 		Figure = "figure_bandit_03"
 	},
 	{
-		ID = "Unit.RF_BanditBaron",
+		ID = "Unit.RF.RF_BanditBaron",
 		Troop = "RF_BanditBaron",
 		Figure = "figure_bandit_04",
 		StartingResourceMin = 400

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/bandit_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/bandit_units.nut
@@ -1,11 +1,3 @@
-/*	Figures Explanation
-figure_bandit_01 - Bandit Poacher
-figure_bandit_02 - Bandit Thug
-figure_bandit_03 - Bandit Raider
-figure_bandit_04 - Bandit Leader
-*/
-
-// We add our new bandit units
 local units = [
 	{
 		ID = "Unit.RF_BanditScoundrel",
@@ -72,6 +64,7 @@ local units = [
 
 foreach (unitDef in units)
 {
-	unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
 	::DynamicSpawns.Public.registerUnit(unitDef);
 }

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
@@ -10,7 +10,7 @@ local units = [
 		Figure = "figure_wildman_02"
 	},
 	{
-		ID = "Unit.RF.BarbarianChosen",
+		ID = "Unit.RF.BarbarianChampion",
 		Troop = "BarbarianChampion",
 		Figure = "figure_wildman_03",
 		StartingResourceMin = 170
@@ -21,12 +21,12 @@ local units = [
 		StartingResourceMin = 200 // In Vanilla they start appearing in a group of 210 cost alongside 15 thralls
 	},
 	{
-		ID = "Unit.RF.BarbarianKing",
-		Troop = "BarbarianChosen",		// Weird Vanilla Naming Scheme
+		ID = "Unit.RF.BarbarianChosen",
+		Troop = "BarbarianChosen",		// This is the Barbarian King. Weird Vanilla Naming Scheme
 		Figure = "figure_wildman_06"
 	},
 	{
-		ID = "Unit.RF.BarbarianWarhound",
+		ID = "Unit.RF.Warhound",
 		Troop = "Warhound"
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
@@ -17,7 +17,8 @@ local units = [
 	},
 	{
 		ID = "Unit.BarbarianDrummer",
-		Troop = "BarbarianDrummer"
+		Troop = "BarbarianDrummer",
+		StartingResourceMin = 200 // In Vanilla they start appearing in a group of 210 cost alongside 15 thralls
 	},
 	{
 		ID = "Unit.BarbarianKing",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
@@ -1,0 +1,80 @@
+local units = [
+	{
+		ID = "Unit.BarbarianThrall",
+		Troop = "BarbarianThrall",
+		Figure = "figure_wildman_01",
+		Cost = 12
+	},
+	{
+		ID = "Unit.BarbarianMarauder",
+		Troop = "BarbarianMarauder",
+		Figure = "figure_wildman_02",
+		Cost = 25
+	},
+	{
+		ID = "Unit.BarbarianChosen",
+		Troop = "BarbarianChampion",
+		Figure = "figure_wildman_03",
+		Cost = 35,
+		StartingResourceMin = 170
+	},
+	{
+		ID = "Unit.BarbarianDrummer",
+		Troop = "BarbarianDrummer",
+		Cost = 20
+	},
+	{
+		ID = "Unit.BarbarianKing",
+		Troop = "BarbarianChosen",		// Weird Vanilla Naming Scheme
+		Figure = "figure_wildman_06",
+		Cost = 45
+	},
+	{
+		ID = "Unit.BarbarianWarhound",
+		Troop = "Warhound",
+		Cost = 10
+	},
+	{
+		ID = "Unit.BarbarianUnhold",
+		Troop = "BarbarianUnhold",
+		Cost = 55,
+		Figure = "figure_unhold_01"     // Not really needed as barbarian unholds never determine their Figure in Vanilla
+	},
+	{
+		ID = "Unit.BarbarianUnholdFrost",
+		Troop = "BarbarianUnholdFrost",
+		Cost = 75,
+		Figure = "figure_unhold_02"     // Not really needed as barbarian unholds never determine their Figure in Vanilla
+	},
+	{
+		ID = "Unit.BarbarianBeastmasterU",
+		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
+		Cost = 15 + 55,
+		SubPartyDef = {ID = "OneUnhold"}
+	},
+	{
+		ID = "Unit.BarbarianBeastmasterUU",
+		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
+		Cost = 15 + 55 + 55,
+		SubPartyDef = {ID = "TwoUnhold"}
+	},
+	{
+		ID = "Unit.BarbarianBeastmasterF",
+		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
+		Cost = 15 + 75,
+		SubPartyDef = {ID = "OneFrostUnhold"}
+	},
+	{
+		ID = "Unit.BarbarianBeastmasterFF",
+		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
+		Cost = 15 + 75 + 75,
+		SubPartyDef = {ID = "TwoFrostUnhold"}
+	}
+]
+
+foreach (unitDef in units)
+{
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	::DynamicSpawns.Public.registerUnit(unitDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
@@ -2,48 +2,40 @@ local units = [
 	{
 		ID = "Unit.BarbarianThrall",
 		Troop = "BarbarianThrall",
-		Figure = "figure_wildman_01",
-		Cost = 12
+		Figure = "figure_wildman_01"
 	},
 	{
 		ID = "Unit.BarbarianMarauder",
 		Troop = "BarbarianMarauder",
-		Figure = "figure_wildman_02",
-		Cost = 25
+		Figure = "figure_wildman_02"
 	},
 	{
 		ID = "Unit.BarbarianChosen",
 		Troop = "BarbarianChampion",
 		Figure = "figure_wildman_03",
-		Cost = 35,
 		StartingResourceMin = 170
 	},
 	{
 		ID = "Unit.BarbarianDrummer",
-		Troop = "BarbarianDrummer",
-		Cost = 20
+		Troop = "BarbarianDrummer"
 	},
 	{
 		ID = "Unit.BarbarianKing",
 		Troop = "BarbarianChosen",		// Weird Vanilla Naming Scheme
-		Figure = "figure_wildman_06",
-		Cost = 45
+		Figure = "figure_wildman_06"
 	},
 	{
 		ID = "Unit.BarbarianWarhound",
-		Troop = "Warhound",
-		Cost = 10
+		Troop = "Warhound"
 	},
 	{
 		ID = "Unit.BarbarianUnhold",
 		Troop = "BarbarianUnhold",
-		Cost = 55,
 		Figure = "figure_unhold_01"     // Not really needed as barbarian unholds never determine their Figure in Vanilla
 	},
 	{
 		ID = "Unit.BarbarianUnholdFrost",
 		Troop = "BarbarianUnholdFrost",
-		Cost = 75,
 		Figure = "figure_unhold_02"     // Not really needed as barbarian unholds never determine their Figure in Vanilla
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
@@ -7,13 +7,14 @@ local units = [
 	{
 		ID = "Unit.RF.BarbarianMarauder",
 		Troop = "BarbarianMarauder",
-		Figure = "figure_wildman_02"
+		Figure = "figure_wildman_02",
+		StartingResourceMin = 125
 	},
 	{
 		ID = "Unit.RF.BarbarianChampion",
 		Troop = "BarbarianChampion",
 		Figure = "figure_wildman_03",
-		StartingResourceMin = 170
+		StartingResourceMin = 200
 	},
 	{
 		ID = "Unit.RF.BarbarianDrummer",
@@ -43,24 +44,28 @@ local units = [
 		ID = "Unit.RF.BarbarianBeastmasterU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 15 + 55,
+		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
 		SubPartyDef = {ID = "OneUnhold"}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterUU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 15 + 55 + 55,
+		StartingResourceMin = 400, // In Vanilla they appear in a group of 400 cost
 		SubPartyDef = {ID = "TwoUnhold"}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 15 + 75,
+		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
 		SubPartyDef = {ID = "OneFrostUnhold"}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterFF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 15 + 75 + 75,
+		StartingResourceMin = 430, // In Vanilla they appear in a group of 430 cost
 		SubPartyDef = {ID = "TwoFrostUnhold"}
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
@@ -1,64 +1,64 @@
 local units = [
 	{
-		ID = "Unit.BarbarianThrall",
+		ID = "Unit.RF.BarbarianThrall",
 		Troop = "BarbarianThrall",
 		Figure = "figure_wildman_01"
 	},
 	{
-		ID = "Unit.BarbarianMarauder",
+		ID = "Unit.RF.BarbarianMarauder",
 		Troop = "BarbarianMarauder",
 		Figure = "figure_wildman_02"
 	},
 	{
-		ID = "Unit.BarbarianChosen",
+		ID = "Unit.RF.BarbarianChosen",
 		Troop = "BarbarianChampion",
 		Figure = "figure_wildman_03",
 		StartingResourceMin = 170
 	},
 	{
-		ID = "Unit.BarbarianDrummer",
+		ID = "Unit.RF.BarbarianDrummer",
 		Troop = "BarbarianDrummer",
 		StartingResourceMin = 200 // In Vanilla they start appearing in a group of 210 cost alongside 15 thralls
 	},
 	{
-		ID = "Unit.BarbarianKing",
+		ID = "Unit.RF.BarbarianKing",
 		Troop = "BarbarianChosen",		// Weird Vanilla Naming Scheme
 		Figure = "figure_wildman_06"
 	},
 	{
-		ID = "Unit.BarbarianWarhound",
+		ID = "Unit.RF.BarbarianWarhound",
 		Troop = "Warhound"
 	},
 	{
-		ID = "Unit.BarbarianUnhold",
+		ID = "Unit.RF.BarbarianUnhold",
 		Troop = "BarbarianUnhold",
 		Figure = "figure_unhold_01"     // Not really needed as barbarian unholds never determine their Figure in Vanilla
 	},
 	{
-		ID = "Unit.BarbarianUnholdFrost",
+		ID = "Unit.RF.BarbarianUnholdFrost",
 		Troop = "BarbarianUnholdFrost",
 		Figure = "figure_unhold_02"     // Not really needed as barbarian unholds never determine their Figure in Vanilla
 	},
 	{
-		ID = "Unit.BarbarianBeastmasterU",
+		ID = "Unit.RF.BarbarianBeastmasterU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 15 + 55,
 		SubPartyDef = {ID = "OneUnhold"}
 	},
 	{
-		ID = "Unit.BarbarianBeastmasterUU",
+		ID = "Unit.RF.BarbarianBeastmasterUU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 15 + 55 + 55,
 		SubPartyDef = {ID = "TwoUnhold"}
 	},
 	{
-		ID = "Unit.BarbarianBeastmasterF",
+		ID = "Unit.RF.BarbarianBeastmasterF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 15 + 75,
 		SubPartyDef = {ID = "OneFrostUnhold"}
 	},
 	{
-		ID = "Unit.BarbarianBeastmasterFF",
+		ID = "Unit.RF.BarbarianBeastmasterFF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 15 + 75 + 75,
 		SubPartyDef = {ID = "TwoFrostUnhold"}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
@@ -1,0 +1,174 @@
+local units = [
+	{
+		ID = "Unit.BeastDirewolf",
+		Troop = "Direwolf",
+		Figure = "figure_werewolf_01",
+		Cost = 20
+	},
+	{
+		ID = "Unit.BeastDirewolfHIGH",
+		Troop = "DirewolfHIGH",
+		Figure = "figure_werewolf_01",
+		Cost = 25,
+		StartingResourceMin = 95		// In Vanilla this is 95
+	},
+	{
+		ID = "Unit.BeastGhoulLOW",
+		Troop = "GhoulLOW",
+		Figure = "figure_ghoul_01",
+		Cost = 9
+	},
+	{
+		ID = "Unit.BeastGhoul",
+		Troop = "Ghoul",
+		Figure = "figure_ghoul_01",
+		Cost = 19,
+		StartingResourceMin = 120	// In vanilla this is 120
+	},
+	{
+		ID = "Unit.BeastGhoulHIGH",
+		Troop = "GhoulHIGH",
+		Figure = "figure_ghoul_02",     // I don't know if a 'figure_ghoul_03' exists
+		Cost = 30,
+		StartingResourceMin = 150	// In vanilla this is 120
+	},
+	{
+		ID = "Unit.BeastLindwurm",
+		Troop = "Lindwurm",
+		Figure = "figure_lindwurm_01",
+		Cost = 90
+	},
+	{
+		ID = "Unit.BeastUnhold",
+		Troop = "Unhold",
+		Figure = "figure_unhold_01",
+		Cost = 50
+	},
+	{
+		ID = "Unit.BeastUnholdFrost",
+		Troop = "UnholdFrost",
+		Figure = "figure_unhold_02",
+		Cost = 60
+	},
+	{
+		ID = "Unit.BeastUnholdBog",
+		Troop = "UnholdBog",
+		Figure = "figure_unhold_03",
+		Cost = 50
+	},
+	{
+		ID = "Unit.BeastSpider",
+		Troop = "Spider",
+		Figure = "figure_spider_01",
+		Cost = 12
+	},
+	{
+		ID = "Unit.BeastAlp",
+		Troop = "Alp",
+		Figure = "figure_alp_01",
+		Cost = 30
+	},
+	{
+		ID = "Unit.BeastSchrat",
+		Troop = "Schrat",
+		Figure = "figure_schrat_01",
+		Cost = 70
+	},
+	{
+		ID = "Unit.BeastKraken",
+		Troop = "Kraken",
+		Cost = 200
+	},
+	{
+		ID = "Unit.BeastHyena",
+		Troop = "Hyena",
+		Figure = "figure_hyena_01",
+		Cost = 20
+	},
+	{
+		ID = "Unit.BeastHyenaHIGH",
+		Troop = "HyenaHIGH",
+		Figure = "figure_hyena_01",
+		Cost = 25,
+		StartingResourceMin = 125		// In Vanilla this is 125
+	},
+	{
+		ID = "Unit.BeastSerpent",
+		Troop = "Serpent",
+		Figure = "figure_serpent_01",
+		Cost = 20
+	},
+	{
+		ID = "Unit.BeastSandGolem",
+		Troop = "SandGolem",
+		Figure = "figure_golem_01",
+		Cost = 13
+	},
+	{
+		ID = "Unit.BeastSandGolemMEDIUM",
+		Troop = "SandGolemMEDIUM",
+		Figure = "figure_golem_01",
+		Cost = 42   // 35 in Vanilla, 3 Small Golems should cost slightly less than 1 Medium Golem because they always spend their first turn action morphing
+	},
+	{	// In Vanilla these never spawn naturally as part of the line-up
+		ID = "Unit.BeastSandGolemHIGH",
+		Troop = "SandGolemHIGH",
+		Figure = "figure_golem_02",    // I don't know if a 'figure_golem_03' exists
+		Cost = 129   // 70 in Vanilla, -!!-
+	}
+
+	// Possible Hexen
+	{
+		ID = "Unit.BeastHexe",      // Without Bodyguards
+		Troop = "Hexe",
+		Figure = "figure_hexe_01",
+		Cost = 50
+	},
+	{
+		ID = "Unit.BeastHexeOneSpider",
+		Troop = "Hexe",
+		Figure = "figure_hexe_01",
+		Cost = 50 + 12,
+		SubPartyDef = {ID = "SpiderBodyguards", HardMin = 1, HardMax = 1}
+	},
+	{
+		ID = "Unit.BeastHexeTwoSpider",
+		Troop = "Hexe",
+		Figure = "figure_hexe_01",
+		Cost = 50 + 12 + 12,
+		SubPartyDef = {ID = "SpiderBodyguards", HardMin = 2, HardMax = 2}
+	},
+	{
+		ID = "Unit.BeastHexeOneDirewolf",
+		Troop = "Hexe",
+		Figure = "figure_hexe_01",
+		Cost = 50 + 25,
+		SubPartyDef = {ID = "DirewolfBodyguards", HardMin = 1, HardMax = 1}
+	},
+	{
+		ID = "Unit.BeastHexeTwoDirewolf",
+		Troop = "Hexe",
+		Figure = "figure_hexe_01",
+		Cost = 50 + 25 + 25,
+		SubPartyDef = {ID = "DirewolfBodyguards", HardMin = 2, HardMax = 2}
+	},
+
+	// Bodyguards
+	{
+		ID = "Unit.BeastSpiderBodyguard",
+		Troop = "SpiderBodyguard",
+		Cost = 12
+	},
+	{
+		ID = "Unit.BeastDirewolfBodyguard",
+		Troop = "DirewolfBodyguard",
+		Cost = 25
+	}
+]
+
+foreach (unitDef in units)
+{
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	::DynamicSpawns.Public.registerUnit(unitDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
@@ -1,117 +1,117 @@
 local units = [
 	{
-		ID = "Unit.BeastDirewolf",
+		ID = "Unit.Direwolf",
 		Troop = "Direwolf",
 		Figure = "figure_werewolf_01",
 		Cost = 20
 	},
 	{
-		ID = "Unit.BeastDirewolfHIGH",
+		ID = "Unit.DirewolfHIGH",
 		Troop = "DirewolfHIGH",
 		Figure = "figure_werewolf_01",
 		Cost = 25,
 		StartingResourceMin = 95		// In Vanilla this is 95
 	},
 	{
-		ID = "Unit.BeastGhoulLOW",
+		ID = "Unit.GhoulLOW",
 		Troop = "GhoulLOW",
 		Figure = "figure_ghoul_01",
 		Cost = 9
 	},
 	{
-		ID = "Unit.BeastGhoul",
+		ID = "Unit.Ghoul",
 		Troop = "Ghoul",
 		Figure = "figure_ghoul_01",
 		Cost = 19,
 		StartingResourceMin = 120	// In vanilla this is 120
 	},
 	{
-		ID = "Unit.BeastGhoulHIGH",
+		ID = "Unit.GhoulHIGH",
 		Troop = "GhoulHIGH",
 		Figure = "figure_ghoul_02",     // I don't know if a 'figure_ghoul_03' exists
 		Cost = 30,
 		StartingResourceMin = 150	// In vanilla this is 120
 	},
 	{
-		ID = "Unit.BeastLindwurm",
+		ID = "Unit.Lindwurm",
 		Troop = "Lindwurm",
 		Figure = "figure_lindwurm_01",
 		Cost = 90
 	},
 	{
-		ID = "Unit.BeastUnhold",
+		ID = "Unit.Unhold",
 		Troop = "Unhold",
 		Figure = "figure_unhold_01",
 		Cost = 50
 	},
 	{
-		ID = "Unit.BeastUnholdFrost",
+		ID = "Unit.UnholdFrost",
 		Troop = "UnholdFrost",
 		Figure = "figure_unhold_02",
 		Cost = 60
 	},
 	{
-		ID = "Unit.BeastUnholdBog",
+		ID = "Unit.UnholdBog",
 		Troop = "UnholdBog",
 		Figure = "figure_unhold_03",
 		Cost = 50
 	},
 	{
-		ID = "Unit.BeastSpider",
+		ID = "Unit.Spider",
 		Troop = "Spider",
 		Figure = "figure_spider_01",
 		Cost = 12
 	},
 	{
-		ID = "Unit.BeastAlp",
+		ID = "Unit.Alp",
 		Troop = "Alp",
 		Figure = "figure_alp_01",
 		Cost = 30
 	},
 	{
-		ID = "Unit.BeastSchrat",
+		ID = "Unit.Schrat",
 		Troop = "Schrat",
 		Figure = "figure_schrat_01",
 		Cost = 70
 	},
 	{
-		ID = "Unit.BeastKraken",
+		ID = "Unit.Kraken",
 		Troop = "Kraken",
 		Cost = 200
 	},
 	{
-		ID = "Unit.BeastHyena",
+		ID = "Unit.Hyena",
 		Troop = "Hyena",
 		Figure = "figure_hyena_01",
 		Cost = 20
 	},
 	{
-		ID = "Unit.BeastHyenaHIGH",
+		ID = "Unit.HyenaHIGH",
 		Troop = "HyenaHIGH",
 		Figure = "figure_hyena_01",
 		Cost = 25,
 		StartingResourceMin = 125		// In Vanilla this is 125
 	},
 	{
-		ID = "Unit.BeastSerpent",
+		ID = "Unit.Serpent",
 		Troop = "Serpent",
 		Figure = "figure_serpent_01",
 		Cost = 20
 	},
 	{
-		ID = "Unit.BeastSandGolem",
+		ID = "Unit.SandGolem",
 		Troop = "SandGolem",
 		Figure = "figure_golem_01",
 		Cost = 13
 	},
 	{
-		ID = "Unit.BeastSandGolemMEDIUM",
+		ID = "Unit.SandGolemMEDIUM",
 		Troop = "SandGolemMEDIUM",
 		Figure = "figure_golem_01",
 		Cost = 42   // 35 in Vanilla, 3 Small Golems should cost slightly less than 1 Medium Golem because they always spend their first turn action morphing
 	},
 	{	// In Vanilla these never spawn naturally as part of the line-up
-		ID = "Unit.BeastSandGolemHIGH",
+		ID = "Unit.SandGolemHIGH",
 		Troop = "SandGolemHIGH",
 		Figure = "figure_golem_02",    // I don't know if a 'figure_golem_03' exists
 		Cost = 129   // 70 in Vanilla, -!!-
@@ -119,34 +119,34 @@ local units = [
 
 	// Possible Hexen
 	{
-		ID = "Unit.BeastHexe",      // Without Bodyguards
+		ID = "Unit.Hexe",      // Without Bodyguards
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50
 	},
 	{
-		ID = "Unit.BeastHexeOneSpider",
+		ID = "Unit.HexeOneSpider",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50 + 12,
 		SubPartyDef = {ID = "SpiderBodyguards", HardMin = 1, HardMax = 1}
 	},
 	{
-		ID = "Unit.BeastHexeTwoSpider",
+		ID = "Unit.HexeTwoSpider",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50 + 12 + 12,
 		SubPartyDef = {ID = "SpiderBodyguards", HardMin = 2, HardMax = 2}
 	},
 	{
-		ID = "Unit.BeastHexeOneDirewolf",
+		ID = "Unit.HexeOneDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50 + 25,
 		SubPartyDef = {ID = "DirewolfBodyguards", HardMin = 1, HardMax = 1}
 	},
 	{
-		ID = "Unit.BeastHexeTwoDirewolf",
+		ID = "Unit.HexeTwoDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50 + 25 + 25,
@@ -155,12 +155,12 @@ local units = [
 
 	// Bodyguards
 	{
-		ID = "Unit.BeastSpiderBodyguard",
+		ID = "Unit.SpiderBodyguard",
 		Troop = "SpiderBodyguard",
 		Cost = 12
 	},
 	{
-		ID = "Unit.BeastDirewolfBodyguard",
+		ID = "Unit.DirewolfBodyguard",
 		Troop = "DirewolfBodyguard",
 		Cost = 25
 	}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
@@ -2,107 +2,90 @@ local units = [
 	{
 		ID = "Unit.Direwolf",
 		Troop = "Direwolf",
-		Figure = "figure_werewolf_01",
-		Cost = 20
+		Figure = "figure_werewolf_01"
 	},
 	{
 		ID = "Unit.DirewolfHIGH",
 		Troop = "DirewolfHIGH",
 		Figure = "figure_werewolf_01",
-		Cost = 25,
 		StartingResourceMin = 95		// In Vanilla this is 95
 	},
 	{
 		ID = "Unit.GhoulLOW",
 		Troop = "GhoulLOW",
-		Figure = "figure_ghoul_01",
-		Cost = 9
+		Figure = "figure_ghoul_01"
 	},
 	{
 		ID = "Unit.Ghoul",
 		Troop = "Ghoul",
 		Figure = "figure_ghoul_01",
-		Cost = 19,
 		StartingResourceMin = 120	// In vanilla this is 120
 	},
 	{
 		ID = "Unit.GhoulHIGH",
 		Troop = "GhoulHIGH",
 		Figure = "figure_ghoul_02",     // I don't know if a 'figure_ghoul_03' exists
-		Cost = 30,
 		StartingResourceMin = 150	// In vanilla this is 120
 	},
 	{
 		ID = "Unit.Lindwurm",
 		Troop = "Lindwurm",
-		Figure = "figure_lindwurm_01",
-		Cost = 90
+		Figure = "figure_lindwurm_01"
 	},
 	{
 		ID = "Unit.Unhold",
 		Troop = "Unhold",
-		Figure = "figure_unhold_01",
-		Cost = 50
+		Figure = "figure_unhold_01"
 	},
 	{
 		ID = "Unit.UnholdFrost",
 		Troop = "UnholdFrost",
-		Figure = "figure_unhold_02",
-		Cost = 60
+		Figure = "figure_unhold_02"
 	},
 	{
 		ID = "Unit.UnholdBog",
 		Troop = "UnholdBog",
-		Figure = "figure_unhold_03",
-		Cost = 50
+		Figure = "figure_unhold_03"
 	},
 	{
 		ID = "Unit.Spider",
 		Troop = "Spider",
-		Figure = "figure_spider_01",
-		Cost = 12
+		Figure = "figure_spider_01"
 	},
 	{
 		ID = "Unit.Alp",
 		Troop = "Alp",
-		Figure = "figure_alp_01",
-		Cost = 30
+		Figure = "figure_alp_01"
 	},
 	{
 		ID = "Unit.Schrat",
 		Troop = "Schrat",
-		Figure = "figure_schrat_01",
-		Cost = 70
+		Figure = "figure_schrat_01"
 	},
 	{
 		ID = "Unit.Kraken",
-		Troop = "Kraken",
-		Cost = 200
+		Troop = "Kraken"
 	},
 	{
 		ID = "Unit.Hyena",
 		Troop = "Hyena",
-		Figure = "figure_hyena_01",
-		Cost = 20
+		Figure = "figure_hyena_01"
 	},
 	{
 		ID = "Unit.HyenaHIGH",
 		Troop = "HyenaHIGH",
 		Figure = "figure_hyena_01",
-		Cost = 25,
 		StartingResourceMin = 125		// In Vanilla this is 125
 	},
 	{
 		ID = "Unit.Serpent",
 		Troop = "Serpent",
-		Figure = "figure_serpent_01",
-		Cost = 20
+		Figure = "figure_serpent_01"
 	},
 	{
 		ID = "Unit.SandGolem",
 		Troop = "SandGolem",
-		Figure = "figure_golem_01",
-		Cost = 13
+		Figure = "figure_golem_01"
 	},
 	{
 		ID = "Unit.SandGolemMEDIUM",
@@ -121,8 +104,7 @@ local units = [
 	{
 		ID = "Unit.Hexe",      // Without Bodyguards
 		Troop = "Hexe",
-		Figure = "figure_hexe_01",
-		Cost = 50
+		Figure = "figure_hexe_01"
 	},
 	{
 		ID = "Unit.HexeOneSpider",
@@ -156,13 +138,11 @@ local units = [
 	// Bodyguards
 	{
 		ID = "Unit.SpiderBodyguard",
-		Troop = "SpiderBodyguard",
-		Cost = 12
+		Troop = "SpiderBodyguard"
 	},
 	{
 		ID = "Unit.DirewolfBodyguard",
-		Troop = "DirewolfBodyguard",
-		Cost = 25
+		Troop = "DirewolfBodyguard"
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
@@ -1,100 +1,100 @@
 local units = [
 	{
-		ID = "Unit.Direwolf",
+		ID = "Unit.RF.Direwolf",
 		Troop = "Direwolf",
 		Figure = "figure_werewolf_01"
 	},
 	{
-		ID = "Unit.DirewolfHIGH",
+		ID = "Unit.RF.DirewolfHIGH",
 		Troop = "DirewolfHIGH",
 		Figure = "figure_werewolf_01",
 		StartingResourceMin = 95		// In Vanilla this is 95
 	},
 	{
-		ID = "Unit.GhoulLOW",
+		ID = "Unit.RF.GhoulLOW",
 		Troop = "GhoulLOW",
 		Figure = "figure_ghoul_01"
 	},
 	{
-		ID = "Unit.Ghoul",
+		ID = "Unit.RF.Ghoul",
 		Troop = "Ghoul",
 		Figure = "figure_ghoul_01",
 		StartingResourceMin = 120	// In vanilla this is 120
 	},
 	{
-		ID = "Unit.GhoulHIGH",
+		ID = "Unit.RF.GhoulHIGH",
 		Troop = "GhoulHIGH",
 		Figure = "figure_ghoul_02",     // I don't know if a 'figure_ghoul_03' exists
 		StartingResourceMin = 150	// In vanilla this is 120
 	},
 	{
-		ID = "Unit.Lindwurm",
+		ID = "Unit.RF.Lindwurm",
 		Troop = "Lindwurm",
 		Figure = "figure_lindwurm_01"
 	},
 	{
-		ID = "Unit.Unhold",
+		ID = "Unit.RF.Unhold",
 		Troop = "Unhold",
 		Figure = "figure_unhold_01"
 	},
 	{
-		ID = "Unit.UnholdFrost",
+		ID = "Unit.RF.UnholdFrost",
 		Troop = "UnholdFrost",
 		Figure = "figure_unhold_02"
 	},
 	{
-		ID = "Unit.UnholdBog",
+		ID = "Unit.RF.UnholdBog",
 		Troop = "UnholdBog",
 		Figure = "figure_unhold_03"
 	},
 	{
-		ID = "Unit.Spider",
+		ID = "Unit.RF.Spider",
 		Troop = "Spider",
 		Figure = "figure_spider_01"
 	},
 	{
-		ID = "Unit.Alp",
+		ID = "Unit.RF.Alp",
 		Troop = "Alp",
 		Figure = "figure_alp_01"
 	},
 	{
-		ID = "Unit.Schrat",
+		ID = "Unit.RF.Schrat",
 		Troop = "Schrat",
 		Figure = "figure_schrat_01"
 	},
 	{
-		ID = "Unit.Kraken",
+		ID = "Unit.RF.Kraken",
 		Troop = "Kraken"
 	},
 	{
-		ID = "Unit.Hyena",
+		ID = "Unit.RF.Hyena",
 		Troop = "Hyena",
 		Figure = "figure_hyena_01"
 	},
 	{
-		ID = "Unit.HyenaHIGH",
+		ID = "Unit.RF.HyenaHIGH",
 		Troop = "HyenaHIGH",
 		Figure = "figure_hyena_01",
 		StartingResourceMin = 125		// In Vanilla this is 125
 	},
 	{
-		ID = "Unit.Serpent",
+		ID = "Unit.RF.Serpent",
 		Troop = "Serpent",
 		Figure = "figure_serpent_01"
 	},
 	{
-		ID = "Unit.SandGolem",
+		ID = "Unit.RF.SandGolem",
 		Troop = "SandGolem",
 		Figure = "figure_golem_01"
 	},
 	{
-		ID = "Unit.SandGolemMEDIUM",
+		ID = "Unit.RF.SandGolemMEDIUM",
 		Troop = "SandGolemMEDIUM",
 		Figure = "figure_golem_01",
 		Cost = 42   // 35 in Vanilla, 3 Small Golems should cost slightly less than 1 Medium Golem because they always spend their first turn action morphing
 	},
 	{	// In Vanilla these never spawn naturally as part of the line-up
-		ID = "Unit.SandGolemHIGH",
+		ID = "Unit.RF.SandGolemHIGH",
 		Troop = "SandGolemHIGH",
 		Figure = "figure_golem_02",    // I don't know if a 'figure_golem_03' exists
 		Cost = 129   // 70 in Vanilla, -!!-
@@ -102,33 +102,33 @@ local units = [
 
 	// Possible Hexen
 	{
-		ID = "Unit.Hexe",      // Without Bodyguards
+		ID = "Unit.RF.Hexe",      // Without Bodyguards
 		Troop = "Hexe",
 		Figure = "figure_hexe_01"
 	},
 	{
-		ID = "Unit.HexeOneSpider",
+		ID = "Unit.RF.HexeOneSpider",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50 + 12,
 		SubPartyDef = {ID = "SpiderBodyguards", HardMin = 1, HardMax = 1}
 	},
 	{
-		ID = "Unit.HexeTwoSpider",
+		ID = "Unit.RF.HexeTwoSpider",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50 + 12 + 12,
 		SubPartyDef = {ID = "SpiderBodyguards", HardMin = 2, HardMax = 2}
 	},
 	{
-		ID = "Unit.HexeOneDirewolf",
+		ID = "Unit.RF.HexeOneDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50 + 25,
 		SubPartyDef = {ID = "DirewolfBodyguards", HardMin = 1, HardMax = 1}
 	},
 	{
-		ID = "Unit.HexeTwoDirewolf",
+		ID = "Unit.RF.HexeTwoDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50 + 25 + 25,
@@ -137,11 +137,11 @@ local units = [
 
 	// Bodyguards
 	{
-		ID = "Unit.SpiderBodyguard",
+		ID = "Unit.RF.SpiderBodyguard",
 		Troop = "SpiderBodyguard"
 	},
 	{
-		ID = "Unit.DirewolfBodyguard",
+		ID = "Unit.RF.DirewolfBodyguard",
 		Troop = "DirewolfBodyguard"
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/goblin_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/goblin_units.nut
@@ -2,44 +2,37 @@ local units = [
 	{
 		ID = "Unit.GoblinSkirmisherLOW",
 		Troop = "GoblinSkirmisherLOW",
-		Figure = "figure_goblin_01",
-		Cost = 10
+		Figure = "figure_goblin_01"
 	},
 	{
 		ID = "Unit.GoblinSkirmisher",
 		Troop = "GoblinSkirmisher",
-		Figure = "figure_goblin_01",
-		Cost = 15
+		Figure = "figure_goblin_01"
 	},
 	{
 		ID = "Unit.GoblinAmbusherLOW",
 		Troop = "GoblinAmbusherLOW",
-		Figure = "figure_goblin_02",
-		Cost = 15
+		Figure = "figure_goblin_02"
 	},
 	{
 		ID = "Unit.GoblinAmbusher",
 		Troop = "GoblinAmbusher",
-		Figure = "figure_goblin_02",
-		Cost = 20
+		Figure = "figure_goblin_02"
 	},
 	{
 		ID = "Unit.GoblinWolfrider",
 		Troop = "GoblinWolfrider",
-		Figure = "figure_goblin_05",
-		Cost = 20
+		Figure = "figure_goblin_05"
 	},
 	{
 		ID = "Unit.GoblinOverseer",
 		Troop = "GoblinOverseer",
-		Figure = "figure_goblin_04",
-		Cost = 35
+		Figure = "figure_goblin_04"
 	},
 	{
 		ID = "Unit.GoblinShaman",
 		Troop = "GoblinShaman",
-		Figure = "figure_goblin_03",
-		Cost = 35
+		Figure = "figure_goblin_03"
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/goblin_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/goblin_units.nut
@@ -1,36 +1,36 @@
 local units = [
 	{
-		ID = "Unit.GoblinSkirmisherLOW",
+		ID = "Unit.RF.GoblinSkirmisherLOW",
 		Troop = "GoblinSkirmisherLOW",
 		Figure = "figure_goblin_01"
 	},
 	{
-		ID = "Unit.GoblinSkirmisher",
+		ID = "Unit.RF.GoblinSkirmisher",
 		Troop = "GoblinSkirmisher",
 		Figure = "figure_goblin_01"
 	},
 	{
-		ID = "Unit.GoblinAmbusherLOW",
+		ID = "Unit.RF.GoblinAmbusherLOW",
 		Troop = "GoblinAmbusherLOW",
 		Figure = "figure_goblin_02"
 	},
 	{
-		ID = "Unit.GoblinAmbusher",
+		ID = "Unit.RF.GoblinAmbusher",
 		Troop = "GoblinAmbusher",
 		Figure = "figure_goblin_02"
 	},
 	{
-		ID = "Unit.GoblinWolfrider",
+		ID = "Unit.RF.GoblinWolfrider",
 		Troop = "GoblinWolfrider",
 		Figure = "figure_goblin_05"
 	},
 	{
-		ID = "Unit.GoblinOverseer",
+		ID = "Unit.RF.GoblinOverseer",
 		Troop = "GoblinOverseer",
 		Figure = "figure_goblin_04"
 	},
 	{
-		ID = "Unit.GoblinShaman",
+		ID = "Unit.RF.GoblinShaman",
 		Troop = "GoblinShaman",
 		Figure = "figure_goblin_03"
 	}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/goblin_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/goblin_units.nut
@@ -1,0 +1,51 @@
+local units = [
+	{
+		ID = "Unit.GoblinSkirmisherLOW",
+		Troop = "GoblinSkirmisherLOW",
+		Figure = "figure_goblin_01",
+		Cost = 10
+	},
+	{
+		ID = "Unit.GoblinSkirmisher",
+		Troop = "GoblinSkirmisher",
+		Figure = "figure_goblin_01",
+		Cost = 15
+	},
+	{
+		ID = "Unit.GoblinAmbusherLOW",
+		Troop = "GoblinAmbusherLOW",
+		Figure = "figure_goblin_02",
+		Cost = 15
+	},
+	{
+		ID = "Unit.GoblinAmbusher",
+		Troop = "GoblinAmbusher",
+		Figure = "figure_goblin_02",
+		Cost = 20
+	},
+	{
+		ID = "Unit.GoblinWolfrider",
+		Troop = "GoblinWolfrider",
+		Figure = "figure_goblin_05",
+		Cost = 20
+	},
+	{
+		ID = "Unit.GoblinOverseer",
+		Troop = "GoblinOverseer",
+		Figure = "figure_goblin_04",
+		Cost = 35
+	},
+	{
+		ID = "Unit.GoblinShaman",
+		Troop = "GoblinShaman",
+		Figure = "figure_goblin_03",
+		Cost = 35
+	}
+]
+
+foreach (unitDef in units)
+{
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	::DynamicSpawns.Public.registerUnit(unitDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/goblin_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/goblin_units.nut
@@ -1,18 +1,8 @@
 local units = [
 	{
-		ID = "Unit.RF.GoblinSkirmisherLOW",
-		Troop = "GoblinSkirmisherLOW",
-		Figure = "figure_goblin_01"
-	},
-	{
 		ID = "Unit.RF.GoblinSkirmisher",
 		Troop = "GoblinSkirmisher",
 		Figure = "figure_goblin_01"
-	},
-	{
-		ID = "Unit.RF.GoblinAmbusherLOW",
-		Troop = "GoblinAmbusherLOW",
-		Figure = "figure_goblin_02"
 	},
 	{
 		ID = "Unit.RF.GoblinAmbusher",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
@@ -57,7 +57,8 @@ local units = [
 	{
 		ID = "Unit.MilitiaCaptain",
 		Troop = "MilitiaCaptain",
-		Cost = 20
+		Cost = 20,
+		StartingResourceMin = 144	// In Vanilla they appear in a group of 144 cost
 	},
 
 // Mercenaries
@@ -89,14 +90,17 @@ local units = [
 	{
 		ID = "Unit.MasterArcher",
 		Troop = "MasterArcher",
+		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
 	},
 	{
 		ID = "Unit.HedgeKnight",
 		Troop = "HedgeKnight",
+		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
 	},
 	{
 		ID = "Unit.Swordmaster",
 		Troop = "Swordmaster",
+		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
@@ -1,116 +1,117 @@
 local units = [
 // Civilians
-	// {
-	// 	ID = "Human.Peasant",
-	// 	Troop = "Peasant",
-	// 	Cost = 10,
-	// 	Figure = "figure_civilian_01"
-	// },
-	// {
-	// 	ID = "Human.PeasantArmed",
-	// 	Troop = "PeasantArmed",
-	// 	Cost = 10,
-	// 	Figure = "figure_civilian_01"
-	// },
-	// {
-	// 	ID = "Human.SouthernPeasant",
-	// 	Troop = "SouthernPeasant",
-	// 	Cost = 10
-	// },
-	// {
-	// 	ID = "Human.CultistAmbush",
-	// 	Troop = "CultistAmbush",
-	// 	Cost = 15,
-	// 	Figure = "figure_civilian_03"
-	// },
-	// {
-	// 	ID = "Human.Slave",
-	// 	Troop = "NorthernSlave",
-	// 	Cost = 7
-	// },
+	{
+		ID = "Unit.HumanPeasant",
+		Troop = "Peasant",
+		Cost = 10,
+		Figure = "figure_civilian_01"
+	},
+	{
+		ID = "Unit.HumanPeasantArmed",
+		Troop = "PeasantArmed",
+		Cost = 10,
+		Figure = "figure_civilian_01"
+	},
+	{
+		ID = "Unit.HumanSouthernPeasant",
+		Troop = "SouthernPeasant",
+		Cost = 10
+	},
+	{
+		ID = "Unit.HumanCultistAmbush",
+		Troop = "CultistAmbush",
+		Cost = 15,
+		Figure = "figure_civilian_03"
+	},
+	{
+		ID = "Unit.HumanSlave",
+		Troop = "NorthernSlave",
+		Cost = 7
+	},
 
 // Caravans
-	// {
-	// 	ID = "Human.CaravanHand",
-	// 	Troop = "CaravanHand",
-	// 	Cost = 10
-	// },
-	// {
-	// 	ID = "Human.CaravanGuard",
-	// 	Troop = "CaravanGuard",
-	// 	Cost = 14
-	// },
-	// {
-	// 	ID = "Human.CaravanDonkey",
-	// 	Troop = "CaravanDonkey",
-	// 	Cost = 10,      // 0 in Vanilla
-	// 	Figure = "cart_02"
-	// },
+	{
+		ID = "Unit.HumanCaravanHand",
+		Troop = "CaravanHand",
+		Cost = 10
+	},
+	{
+		ID = "Unit.HumanCaravanGuard",
+		Troop = "CaravanGuard",
+		Cost = 14
+	},
+	{
+		ID = "Unit.HumanCaravanDonkey",
+		Troop = "CaravanDonkey",
+		Cost = 10,      // 0 in Vanilla
+		Figure = "cart_02"
+	},
 
 // Militia
-	// {
-	// 	ID = "Human.Militia",
-	// 	Troop = "Militia",
-	// 	Cost = 10
-	// },
-	// {
-	// 	ID = "Human.MilitiaRanged",
-	// 	Troop = "MilitiaRanged",
-	// 	Cost = 10
-	// },
-	// {
-	// 	ID = "Human.MilitiaVeteran",
-	// 	Troop = "MilitiaVeteran",
-	// 	Cost = 15   // Vanilla 12
-	// },
-	// {
-	// 	ID = "Human.MilitiaCaptain",
-	// 	Troop = "MilitiaCaptain",
-	// 	Cost = 20
-	// },
+	{
+		ID = "Unit.HumanMilitia",
+		Troop = "Militia",
+		Cost = 10
+	},
+	{
+		ID = "Unit.HumanMilitiaRanged",
+		Troop = "MilitiaRanged",
+		Cost = 10
+	},
+	{
+		ID = "Unit.HumanMilitiaVeteran",
+		Troop = "MilitiaVeteran",
+		Cost = 15   // Vanilla 12
+	},
+	{
+		ID = "Unit.HumanMilitiaCaptain",
+		Troop = "MilitiaCaptain",
+		Cost = 20
+	},
 
 // Mercenaries
-	// {
-	// 	ID = "Human.BountyHunter",
-	// 	Troop = "BountyHunter",
-	// 	Cost = 25
-	// },
-	// {
-	// 	ID = "Human.BountyHunterRanged",
-	// 	Troop = "BountyHunterRanged",
-	// 	Cost = 20
-	// },
-	// {
-	// 	ID = "Human.ArmoredWardog",
-	// 	Troop = "ArmoredWardog",
-	// 	Cost = 9
-	// },
-	// {
-	// 	ID = "Human.MercenaryLOW",
-	// 	Troop = "MercenaryLOW",
-	// 	Cost = 18
-	// },
-	// {
-	// 	ID = "Human.Mercenary",
-	// 	Troop = "Mercenary",
-	// 	Cost = 25
-	// },
-	// {
-	// 	ID = "Human.MercenaryRanged",
-	// 	Troop = "MercenaryRanged",
-	// 	Cost = 25
-	// },
 	{
-		ID = "Human.MasterArcher",
-		Troop = "MasterArcher"
+		ID = "Unit.HumanBountyHunter",
+		Troop = "BountyHunter",
+		Cost = 25
 	},
 	{
-		ID = "Human.HedgeKnight",
-		Troop = "HedgeKnight"
+		ID = "Unit.HumanBountyHunterRanged",
+		Troop = "BountyHunterRanged",
+		Cost = 20
 	},
 	{
-		ID = "Human.Swordmaster",
-		Troop = "Swordmaster"
+		ID = "Unit.HumanWardog",
+		Troop = "Wardog",
+		Cost = 8
+	},
+
+	{
+		ID = "Unit.HumanMercenaryLOW",
+		Troop = "MercenaryLOW",
+		Cost = 18
+	},
+	{
+		ID = "Unit.HumanMercenary",
+		Troop = "Mercenary",
+		Cost = 25
+	},
+	{
+		ID = "Unit.HumanMercenaryRanged",
+		Troop = "MercenaryRanged",
+		Cost = 25
+	},
+	{
+		ID = "Unit.HumanMasterArcher",
+		Troop = "MasterArcher",
+	},
+	{
+		ID = "Unit.HumanHedgeKnight",
+		Troop = "HedgeKnight",
+	},
+	{
+		ID = "Unit.HumanSwordmaster",
+		Troop = "Swordmaster",
 	}
 ]
 
@@ -120,6 +121,7 @@ While there are ["figure_militia_01", "figure_militia_02"] it seems like they ar
 
 foreach (unitDef in units)
 {
-	unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
 	::DynamicSpawns.Public.registerUnit(unitDef);
 }

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
@@ -1,40 +1,40 @@
 local units = [
 // Civilians
 	{
-		ID = "Unit.Peasant",
+		ID = "Unit.RF.Peasant",
 		Troop = "Peasant",
 		Figure = "figure_civilian_01"
 	},
 	{
-		ID = "Unit.PeasantArmed",
+		ID = "Unit.RF.PeasantArmed",
 		Troop = "PeasantArmed",
 		Figure = "figure_civilian_01"
 	},
 	{
-		ID = "Unit.SouthernPeasant",
+		ID = "Unit.RF.SouthernPeasant",
 		Troop = "SouthernPeasant"
 	},
 	{
-		ID = "Unit.CultistAmbush",
+		ID = "Unit.RF.CultistAmbush",
 		Troop = "CultistAmbush",
 		Figure = "figure_civilian_03"
 	},
 	{
-		ID = "Unit.NorthernSlave",
+		ID = "Unit.RF.NorthernSlave",
 		Troop = "NorthernSlave"
 	},
 
 // Caravans
 	{
-		ID = "Unit.CaravanHand",
+		ID = "Unit.RF.CaravanHand",
 		Troop = "CaravanHand"
 	},
 	{
-		ID = "Unit.CaravanGuard",
+		ID = "Unit.RF.CaravanGuard",
 		Troop = "CaravanGuard"
 	},
 	{
-		ID = "Unit.CaravanDonkey",
+		ID = "Unit.RF.CaravanDonkey",
 		Troop = "CaravanDonkey",
 		Cost = 10,      // 0 in Vanilla
 		Figure = "cart_02"
@@ -42,20 +42,20 @@ local units = [
 
 // Militia
 	{
-		ID = "Unit.Militia",
+		ID = "Unit.RF.Militia",
 		Troop = "Militia"
 	},
 	{
-		ID = "Unit.MilitiaRanged",
+		ID = "Unit.RF.MilitiaRanged",
 		Troop = "MilitiaRanged"
 	},
 	{
-		ID = "Unit.MilitiaVeteran",
+		ID = "Unit.RF.MilitiaVeteran",
 		Troop = "MilitiaVeteran",
 		Cost = 15   // Vanilla 12
 	},
 	{
-		ID = "Unit.MilitiaCaptain",
+		ID = "Unit.RF.MilitiaCaptain",
 		Troop = "MilitiaCaptain",
 		Cost = 20,
 		StartingResourceMin = 144	// In Vanilla they appear in a group of 144 cost
@@ -63,42 +63,42 @@ local units = [
 
 // Mercenaries
 	{
-		ID = "Unit.BountyHunter",
+		ID = "Unit.RF.BountyHunter",
 		Troop = "BountyHunter"
 	},
 	{
-		ID = "Unit.BountyHunterRanged",
+		ID = "Unit.RF.BountyHunterRanged",
 		Troop = "BountyHunterRanged"
 	},
 	{
-		ID = "Unit.Wardog",
+		ID = "Unit.RF.Wardog",
 		Troop = "Wardog"
 	},
 
 	{
-		ID = "Unit.MercenaryLOW",
+		ID = "Unit.RF.MercenaryLOW",
 		Troop = "MercenaryLOW"
 	},
 	{
-		ID = "Unit.Mercenary",
+		ID = "Unit.RF.Mercenary",
 		Troop = "Mercenary"
 	},
 	{
-		ID = "Unit.MercenaryRanged",
+		ID = "Unit.RF.MercenaryRanged",
 		Troop = "MercenaryRanged"
 	},
 	{
-		ID = "Unit.MasterArcher",
+		ID = "Unit.RF.MasterArcher",
 		Troop = "MasterArcher",
 		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
 	},
 	{
-		ID = "Unit.HedgeKnight",
+		ID = "Unit.RF.HedgeKnight",
 		Troop = "HedgeKnight",
 		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
 	},
 	{
-		ID = "Unit.Swordmaster",
+		ID = "Unit.RF.Swordmaster",
 		Troop = "Swordmaster",
 		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
 	}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
@@ -74,11 +74,6 @@ local units = [
 		ID = "Unit.RF.Wardog",
 		Troop = "Wardog"
 	},
-
-	{
-		ID = "Unit.RF.MercenaryLOW",
-		Troop = "MercenaryLOW"
-	},
 	{
 		ID = "Unit.RF.Mercenary",
 		Troop = "Mercenary"

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
@@ -85,17 +85,17 @@ local units = [
 	{
 		ID = "Unit.RF.MasterArcher",
 		Troop = "MasterArcher",
-		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
+		StartingResourceMin = 286	// In Vanilla they appear in a group of 286 cost
 	},
 	{
 		ID = "Unit.RF.HedgeKnight",
 		Troop = "HedgeKnight",
-		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
+		StartingResourceMin = 286	// In Vanilla they appear in a group of 286 cost
 	},
 	{
 		ID = "Unit.RF.Swordmaster",
 		Troop = "Swordmaster",
-		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
+		StartingResourceMin = 286	// In Vanilla they appear in a group of 286 cost
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
@@ -1,47 +1,47 @@
 local units = [
 // Civilians
 	{
-		ID = "Unit.HumanPeasant",
+		ID = "Unit.Peasant",
 		Troop = "Peasant",
 		Cost = 10,
 		Figure = "figure_civilian_01"
 	},
 	{
-		ID = "Unit.HumanPeasantArmed",
+		ID = "Unit.PeasantArmed",
 		Troop = "PeasantArmed",
 		Cost = 10,
 		Figure = "figure_civilian_01"
 	},
 	{
-		ID = "Unit.HumanSouthernPeasant",
+		ID = "Unit.SouthernPeasant",
 		Troop = "SouthernPeasant",
 		Cost = 10
 	},
 	{
-		ID = "Unit.HumanCultistAmbush",
+		ID = "Unit.CultistAmbush",
 		Troop = "CultistAmbush",
 		Cost = 15,
 		Figure = "figure_civilian_03"
 	},
 	{
-		ID = "Unit.HumanSlave",
+		ID = "Unit.NorthernSlave",
 		Troop = "NorthernSlave",
 		Cost = 7
 	},
 
 // Caravans
 	{
-		ID = "Unit.HumanCaravanHand",
+		ID = "Unit.CaravanHand",
 		Troop = "CaravanHand",
 		Cost = 10
 	},
 	{
-		ID = "Unit.HumanCaravanGuard",
+		ID = "Unit.CaravanGuard",
 		Troop = "CaravanGuard",
 		Cost = 14
 	},
 	{
-		ID = "Unit.HumanCaravanDonkey",
+		ID = "Unit.CaravanDonkey",
 		Troop = "CaravanDonkey",
 		Cost = 10,      // 0 in Vanilla
 		Figure = "cart_02"
@@ -49,68 +49,68 @@ local units = [
 
 // Militia
 	{
-		ID = "Unit.HumanMilitia",
+		ID = "Unit.Militia",
 		Troop = "Militia",
 		Cost = 10
 	},
 	{
-		ID = "Unit.HumanMilitiaRanged",
+		ID = "Unit.MilitiaRanged",
 		Troop = "MilitiaRanged",
 		Cost = 10
 	},
 	{
-		ID = "Unit.HumanMilitiaVeteran",
+		ID = "Unit.MilitiaVeteran",
 		Troop = "MilitiaVeteran",
 		Cost = 15   // Vanilla 12
 	},
 	{
-		ID = "Unit.HumanMilitiaCaptain",
+		ID = "Unit.MilitiaCaptain",
 		Troop = "MilitiaCaptain",
 		Cost = 20
 	},
 
 // Mercenaries
 	{
-		ID = "Unit.HumanBountyHunter",
+		ID = "Unit.BountyHunter",
 		Troop = "BountyHunter",
 		Cost = 25
 	},
 	{
-		ID = "Unit.HumanBountyHunterRanged",
+		ID = "Unit.BountyHunterRanged",
 		Troop = "BountyHunterRanged",
 		Cost = 20
 	},
 	{
-		ID = "Unit.HumanWardog",
+		ID = "Unit.Wardog",
 		Troop = "Wardog",
 		Cost = 8
 	},
 
 	{
-		ID = "Unit.HumanMercenaryLOW",
+		ID = "Unit.MercenaryLOW",
 		Troop = "MercenaryLOW",
 		Cost = 18
 	},
 	{
-		ID = "Unit.HumanMercenary",
+		ID = "Unit.Mercenary",
 		Troop = "Mercenary",
 		Cost = 25
 	},
 	{
-		ID = "Unit.HumanMercenaryRanged",
+		ID = "Unit.MercenaryRanged",
 		Troop = "MercenaryRanged",
 		Cost = 25
 	},
 	{
-		ID = "Unit.HumanMasterArcher",
+		ID = "Unit.MasterArcher",
 		Troop = "MasterArcher",
 	},
 	{
-		ID = "Unit.HumanHedgeKnight",
+		ID = "Unit.HedgeKnight",
 		Troop = "HedgeKnight",
 	},
 	{
-		ID = "Unit.HumanSwordmaster",
+		ID = "Unit.Swordmaster",
 		Troop = "Swordmaster",
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/human_units.nut
@@ -3,42 +3,35 @@ local units = [
 	{
 		ID = "Unit.Peasant",
 		Troop = "Peasant",
-		Cost = 10,
 		Figure = "figure_civilian_01"
 	},
 	{
 		ID = "Unit.PeasantArmed",
 		Troop = "PeasantArmed",
-		Cost = 10,
 		Figure = "figure_civilian_01"
 	},
 	{
 		ID = "Unit.SouthernPeasant",
-		Troop = "SouthernPeasant",
-		Cost = 10
+		Troop = "SouthernPeasant"
 	},
 	{
 		ID = "Unit.CultistAmbush",
 		Troop = "CultistAmbush",
-		Cost = 15,
 		Figure = "figure_civilian_03"
 	},
 	{
 		ID = "Unit.NorthernSlave",
-		Troop = "NorthernSlave",
-		Cost = 7
+		Troop = "NorthernSlave"
 	},
 
 // Caravans
 	{
 		ID = "Unit.CaravanHand",
-		Troop = "CaravanHand",
-		Cost = 10
+		Troop = "CaravanHand"
 	},
 	{
 		ID = "Unit.CaravanGuard",
-		Troop = "CaravanGuard",
-		Cost = 14
+		Troop = "CaravanGuard"
 	},
 	{
 		ID = "Unit.CaravanDonkey",
@@ -50,13 +43,11 @@ local units = [
 // Militia
 	{
 		ID = "Unit.Militia",
-		Troop = "Militia",
-		Cost = 10
+		Troop = "Militia"
 	},
 	{
 		ID = "Unit.MilitiaRanged",
-		Troop = "MilitiaRanged",
-		Cost = 10
+		Troop = "MilitiaRanged"
 	},
 	{
 		ID = "Unit.MilitiaVeteran",
@@ -72,34 +63,28 @@ local units = [
 // Mercenaries
 	{
 		ID = "Unit.BountyHunter",
-		Troop = "BountyHunter",
-		Cost = 25
+		Troop = "BountyHunter"
 	},
 	{
 		ID = "Unit.BountyHunterRanged",
-		Troop = "BountyHunterRanged",
-		Cost = 20
+		Troop = "BountyHunterRanged"
 	},
 	{
 		ID = "Unit.Wardog",
-		Troop = "Wardog",
-		Cost = 8
+		Troop = "Wardog"
 	},
 
 	{
 		ID = "Unit.MercenaryLOW",
-		Troop = "MercenaryLOW",
-		Cost = 18
+		Troop = "MercenaryLOW"
 	},
 	{
 		ID = "Unit.Mercenary",
-		Troop = "Mercenary",
-		Cost = 25
+		Troop = "Mercenary"
 	},
 	{
 		ID = "Unit.MercenaryRanged",
-		Troop = "MercenaryRanged",
-		Cost = 25
+		Troop = "MercenaryRanged"
 	},
 	{
 		ID = "Unit.MasterArcher",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
@@ -1,0 +1,59 @@
+local units = [
+	{
+		ID = "Unit.NobleFootman",
+		Troop = "Footman",
+		Cost = 20
+	},
+	{
+		ID = "Unit.NobleBillman",
+		Troop = "Billman",
+		Cost = 15
+	},
+	{
+		ID = "Unit.NobleArbalester",
+		Troop = "Arbalester",
+		Cost = 20
+	},
+	{
+		ID = "Unit.NobleArmoredWardog",
+		Troop = "ArmoredWardog",
+		Cost = 8
+	},
+	{
+		ID = "Unit.NobleStandardBearer",
+		Troop = "StandardBearer",
+		Cost = 20,
+		Figure = "figure_noble_02"
+	},
+	{
+		ID = "Unit.NobleSergeant",
+		Troop = "Sergeant",
+		Cost = 25,
+		Figure = "figure_noble_02"
+	},
+	{
+		ID = "Unit.NobleZweihander",
+		Troop = "Greatsword",
+		Cost = 25
+	},
+	{
+		ID = "Unit.NobleKnight",
+		Troop = "Knight",
+		Cost = 35,
+		Figure = "figure_noble_03"
+	},
+
+	{   // This already exists under human_units but noble caravans use a different figure
+		ID = "Unit.NobleCaravanDonkey",
+		Troop = "CaravanDonkey",
+		Cost = 10,      // 0 in Vanilla
+		Figure = "cart_01"
+	}
+]
+
+foreach (unitDef in units)
+{
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	::DynamicSpawns.Public.registerUnit(unitDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
@@ -18,21 +18,25 @@ local units = [
 	{
 		ID = "Unit.NobleStandardBearer",
 		Troop = "StandardBearer",
-		Figure = "figure_noble_02"
+		Figure = "figure_noble_02",
+		StartingResourceMin = 200	// In Vanilla they appear in a group of 240 cost
 	},
 	{
 		ID = "Unit.NobleSergeant",
 		Troop = "Sergeant",
-		Figure = "figure_noble_02"
+		Figure = "figure_noble_02",
+		StartingResourceMin = 200	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
 	{
 		ID = "Unit.NobleZweihander",
-		Troop = "Greatsword"
+		Troop = "Greatsword",
+		StartingResourceMin = 325	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
 	{
 		ID = "Unit.NobleKnight",
 		Troop = "Knight",
-		Figure = "figure_noble_03"
+		Figure = "figure_noble_03",
+		StartingResourceMin = 325	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
 
 	{   // This already exists under human_units but noble caravans use a different figure

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
@@ -2,44 +2,36 @@ local units = [
 	{
 		ID = "Unit.NobleFootman",
 		Troop = "Footman",
-		Cost = 20
 	},
 	{
 		ID = "Unit.NobleBillman",
 		Troop = "Billman",
-		Cost = 15
 	},
 	{
 		ID = "Unit.NobleArbalester",
-		Troop = "Arbalester",
-		Cost = 20
+		Troop = "Arbalester"
 	},
 	{
 		ID = "Unit.NobleArmoredWardog",
-		Troop = "ArmoredWardog",
-		Cost = 8
+		Troop = "ArmoredWardog"
 	},
 	{
 		ID = "Unit.NobleStandardBearer",
 		Troop = "StandardBearer",
-		Cost = 20,
 		Figure = "figure_noble_02"
 	},
 	{
 		ID = "Unit.NobleSergeant",
 		Troop = "Sergeant",
-		Cost = 25,
 		Figure = "figure_noble_02"
 	},
 	{
 		ID = "Unit.NobleZweihander",
-		Troop = "Greatsword",
-		Cost = 25
+		Troop = "Greatsword"
 	},
 	{
 		ID = "Unit.NobleKnight",
 		Troop = "Knight",
-		Cost = 35,
 		Figure = "figure_noble_03"
 	},
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
@@ -1,44 +1,43 @@
 local units = [
 	{
-		ID = "Unit.RF.NobleFootman",
+		ID = "Unit.RF.Footman",
 		Troop = "Footman",
 	},
 	{
-		ID = "Unit.RF.NobleBillman",
+		ID = "Unit.RF.Billman",
 		Troop = "Billman",
 	},
 	{
-		ID = "Unit.RF.NobleArbalester",
+		ID = "Unit.RF.Arbalester",
 		Troop = "Arbalester"
 	},
 	{
-		ID = "Unit.RF.NobleArmoredWardog",
+		ID = "Unit.RF.ArmoredWardog",
 		Troop = "ArmoredWardog"
 	},
 	{
-		ID = "Unit.RF.NobleStandardBearer",
+		ID = "Unit.RF.StandardBearer",
 		Troop = "StandardBearer",
 		Figure = "figure_noble_02",
 		StartingResourceMin = 200	// In Vanilla they appear in a group of 240 cost
 	},
 	{
-		ID = "Unit.RF.NobleSergeant",
+		ID = "Unit.RF.Sergeant",
 		Troop = "Sergeant",
 		Figure = "figure_noble_02",
 		StartingResourceMin = 200	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
 	{
-		ID = "Unit.RF.NobleZweihander",
+		ID = "Unit.RF.Greatsword",
 		Troop = "Greatsword",
 		StartingResourceMin = 325	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
 	{
-		ID = "Unit.RF.NobleKnight",
+		ID = "Unit.RF.Knight",
 		Troop = "Knight",
 		Figure = "figure_noble_03",
 		StartingResourceMin = 325	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
-
 	{   // This already exists under human_units but noble caravans use a different figure
 		ID = "Unit.RF.NobleCaravanDonkey",
 		Troop = "CaravanDonkey",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/noble_units.nut
@@ -1,46 +1,46 @@
 local units = [
 	{
-		ID = "Unit.NobleFootman",
+		ID = "Unit.RF.NobleFootman",
 		Troop = "Footman",
 	},
 	{
-		ID = "Unit.NobleBillman",
+		ID = "Unit.RF.NobleBillman",
 		Troop = "Billman",
 	},
 	{
-		ID = "Unit.NobleArbalester",
+		ID = "Unit.RF.NobleArbalester",
 		Troop = "Arbalester"
 	},
 	{
-		ID = "Unit.NobleArmoredWardog",
+		ID = "Unit.RF.NobleArmoredWardog",
 		Troop = "ArmoredWardog"
 	},
 	{
-		ID = "Unit.NobleStandardBearer",
+		ID = "Unit.RF.NobleStandardBearer",
 		Troop = "StandardBearer",
 		Figure = "figure_noble_02",
 		StartingResourceMin = 200	// In Vanilla they appear in a group of 240 cost
 	},
 	{
-		ID = "Unit.NobleSergeant",
+		ID = "Unit.RF.NobleSergeant",
 		Troop = "Sergeant",
 		Figure = "figure_noble_02",
 		StartingResourceMin = 200	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
 	{
-		ID = "Unit.NobleZweihander",
+		ID = "Unit.RF.NobleZweihander",
 		Troop = "Greatsword",
 		StartingResourceMin = 325	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
 	{
-		ID = "Unit.NobleKnight",
+		ID = "Unit.RF.NobleKnight",
 		Troop = "Knight",
 		Figure = "figure_noble_03",
 		StartingResourceMin = 325	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
 
 	{   // This already exists under human_units but noble caravans use a different figure
-		ID = "Unit.NobleCaravanDonkey",
+		ID = "Unit.RF.NobleCaravanDonkey",
 		Troop = "CaravanDonkey",
 		Cost = 10,      // 0 in Vanilla
 		Figure = "cart_01"

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
@@ -29,19 +29,19 @@ local units = [
 		ID = "Unit.RF.DesertStalker",
 		Troop = "DesertStalker",
 		Figure = "figure_nomad_05",
-		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
+		StartingResourceMin = 350	// In Vanilla they appear in a group of 350 cost
 	},
 	{
 		ID = "Unit.RF.Executioner",
 		Troop = "Executioner",
 		Figure = "figure_nomad_05",
-		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
+		StartingResourceMin = 350	// In Vanilla they appear in a group of 350 cost
 	},
 	{
 		ID = "Unit.RF.DesertDevil",
 		Troop = "DesertDevil",
 		Figure = "figure_nomad_05",
-		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
+		StartingResourceMin = 350	// In Vanilla they appear in a group of 350 cost
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
@@ -1,0 +1,57 @@
+local units = [
+	{
+		ID = "Unit.NomadCutthroat",
+		Troop = "NomadCutthroat",
+		Figure = "figure_nomad_01",     // Official "Cutthroat" figure
+		Cost = 12
+	},
+	{
+		ID = "Unit.NomadSlinger",
+		Troop = "NomadSlinger",
+		Figure = "figure_nomad_03",     // Seems to be the "Slinger" figure but it may aswell not exist or be used for variations/other entities
+		Cost = 12
+	},
+	{
+		ID = "Unit.NomadOutlaw",
+		Troop = "NomadOutlaw",
+		Figure = "figure_nomad_02",     // Official "Outlaw" figure
+		Cost = 25
+	},
+	{
+		ID = "Unit.NomadArcher",
+		Troop = "NomadArcher",
+		Figure = "figure_nomad_04",
+		Cost = 15
+	},
+	{
+		ID = "Unit.NomadLeader",
+		Troop = "NomadLeader",
+		Figure = "figure_nomad_05",
+		Cost = 30
+	},
+	{
+		ID = "Unit.NomadDesertStalker",
+		Troop = "DesertStalker",
+		Figure = "figure_nomad_05",
+		Cost = 40
+	},
+	{
+		ID = "Unit.NomadExecutioner",
+		Troop = "Executioner",
+		Figure = "figure_nomad_05",
+		Cost = 40
+	},
+	{
+		ID = "Unit.NomadDesertDevil",
+		Troop = "DesertDevil",
+		Figure = "figure_nomad_05",
+		Cost = 40
+	}
+]
+
+foreach (unitDef in units)
+{
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	::DynamicSpawns.Public.registerUnit(unitDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
@@ -2,50 +2,42 @@ local units = [
 	{
 		ID = "Unit.NomadCutthroat",
 		Troop = "NomadCutthroat",
-		Figure = "figure_nomad_01",     // Official "Cutthroat" figure
-		Cost = 12
+		Figure = "figure_nomad_01"     // Official "Cutthroat" figure
 	},
 	{
 		ID = "Unit.NomadSlinger",
 		Troop = "NomadSlinger",
-		Figure = "figure_nomad_03",     // Seems to be the "Slinger" figure but it may aswell not exist or be used for variations/other entities
-		Cost = 12
+		Figure = "figure_nomad_03"     // Seems to be the "Slinger" figure but it may aswell not exist or be used for variations/other entities
 	},
 	{
 		ID = "Unit.NomadOutlaw",
 		Troop = "NomadOutlaw",
-		Figure = "figure_nomad_02",     // Official "Outlaw" figure
-		Cost = 25
+		Figure = "figure_nomad_02"     // Official "Outlaw" figure
 	},
 	{
 		ID = "Unit.NomadArcher",
 		Troop = "NomadArcher",
-		Figure = "figure_nomad_04",
-		Cost = 15
+		Figure = "figure_nomad_04"
 	},
 	{
 		ID = "Unit.NomadLeader",
 		Troop = "NomadLeader",
-		Figure = "figure_nomad_05",
-		Cost = 30
+		Figure = "figure_nomad_05"
 	},
 	{
 		ID = "Unit.NomadDesertStalker",
 		Troop = "DesertStalker",
-		Figure = "figure_nomad_05",
-		Cost = 40
+		Figure = "figure_nomad_05"
 	},
 	{
 		ID = "Unit.NomadExecutioner",
 		Troop = "Executioner",
-		Figure = "figure_nomad_05",
-		Cost = 40
+		Figure = "figure_nomad_05"
 	},
 	{
 		ID = "Unit.NomadDesertDevil",
 		Troop = "DesertDevil",
-		Figure = "figure_nomad_05",
-		Cost = 40
+		Figure = "figure_nomad_05"
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
@@ -1,44 +1,44 @@
 local units = [
 	{
-		ID = "Unit.NomadCutthroat",
+		ID = "Unit.RF.NomadCutthroat",
 		Troop = "NomadCutthroat",
 		Figure = "figure_nomad_01"     // Official "Cutthroat" figure
 	},
 	{
-		ID = "Unit.NomadSlinger",
+		ID = "Unit.RF.NomadSlinger",
 		Troop = "NomadSlinger",
 		Figure = "figure_nomad_03"     // Seems to be the "Slinger" figure but it may aswell not exist or be used for variations/other entities
 	},
 	{
-		ID = "Unit.NomadOutlaw",
+		ID = "Unit.RF.NomadOutlaw",
 		Troop = "NomadOutlaw",
 		Figure = "figure_nomad_02"     // Official "Outlaw" figure
 	},
 	{
-		ID = "Unit.NomadArcher",
+		ID = "Unit.RF.NomadArcher",
 		Troop = "NomadArcher",
 		Figure = "figure_nomad_04"
 	},
 	{
-		ID = "Unit.NomadLeader",
+		ID = "Unit.RF.NomadLeader",
 		Troop = "NomadLeader",
 		Figure = "figure_nomad_05",
 		StartingResourceMin = 170 // In Vanilla they appear in a group of 170 cost
 	},
 	{
-		ID = "Unit.NomadDesertStalker",
+		ID = "Unit.RF.NomadDesertStalker",
 		Troop = "DesertStalker",
 		Figure = "figure_nomad_05",
 		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
 	},
 	{
-		ID = "Unit.NomadExecutioner",
+		ID = "Unit.RF.NomadExecutioner",
 		Troop = "Executioner",
 		Figure = "figure_nomad_05",
 		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
 	},
 	{
-		ID = "Unit.NomadDesertDevil",
+		ID = "Unit.RF.NomadDesertDevil",
 		Troop = "DesertDevil",
 		Figure = "figure_nomad_05",
 		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
@@ -22,22 +22,26 @@ local units = [
 	{
 		ID = "Unit.NomadLeader",
 		Troop = "NomadLeader",
-		Figure = "figure_nomad_05"
+		Figure = "figure_nomad_05",
+		StartingResourceMin = 170 // In Vanilla they appear in a group of 170 cost
 	},
 	{
 		ID = "Unit.NomadDesertStalker",
 		Troop = "DesertStalker",
-		Figure = "figure_nomad_05"
+		Figure = "figure_nomad_05",
+		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
 	},
 	{
 		ID = "Unit.NomadExecutioner",
 		Troop = "Executioner",
-		Figure = "figure_nomad_05"
+		Figure = "figure_nomad_05",
+		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
 	},
 	{
 		ID = "Unit.NomadDesertDevil",
 		Troop = "DesertDevil",
-		Figure = "figure_nomad_05"
+		Figure = "figure_nomad_05",
+		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/nomad_units.nut
@@ -26,19 +26,19 @@ local units = [
 		StartingResourceMin = 170 // In Vanilla they appear in a group of 170 cost
 	},
 	{
-		ID = "Unit.RF.NomadDesertStalker",
+		ID = "Unit.RF.DesertStalker",
 		Troop = "DesertStalker",
 		Figure = "figure_nomad_05",
 		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
 	},
 	{
-		ID = "Unit.RF.NomadExecutioner",
+		ID = "Unit.RF.Executioner",
 		Troop = "Executioner",
 		Figure = "figure_nomad_05",
 		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
 	},
 	{
-		ID = "Unit.RF.NomadDesertDevil",
+		ID = "Unit.RF.DesertDevil",
 		Troop = "DesertDevil",
 		Figure = "figure_nomad_05",
 		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/orc_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/orc_units.nut
@@ -1,31 +1,31 @@
 local units = [
 	{
-		ID = "Unit.OrcYoungLOW",
+		ID = "Unit.RF.OrcYoungLOW",
 		Troop = "OrcYoungLOW",
 		Figure = "figure_orc_01"       // I assume this is OrcYoung without Armor and without Helmet
 	},
 	{
-		ID = "Unit.OrcYoung",
+		ID = "Unit.RF.OrcYoung",
 		Troop = "OrcYoung",
 		Figure = ["figure_orc_02", "figure_orc_06"]       // I assume this is OrcYoung only with Helmet (02) and OrcYoung only with Armor (06)
 	},
 	{
-		ID = "Unit.OrcBerserker",
+		ID = "Unit.RF.OrcBerserker",
 		Troop = "OrcBerserker",
 		Figure = "figure_orc_03"        // I'm sure this is OrcBerserker
 	},
 	{
-		ID = "Unit.OrcWarriorLOW",
+		ID = "Unit.RF.OrcWarriorLOW",
 		Troop = "OrcWarriorLOW",
 		Figure = "figure_orc_04"        // I'm sure this is OrcWarrior
 	},
 	{
-		ID = "Unit.OrcWarrior",
+		ID = "Unit.RF.OrcWarrior",
 		Troop = "OrcWarrior",
 		Figure = "figure_orc_04"       // I'm sure this is OrcWarrior
 	},
 	{
-		ID = "Unit.OrcWarlord",
+		ID = "Unit.RF.OrcWarlord",
 		Troop = "OrcWarlord",
 		Figure = "figure_orc_05"       // I'm sure this is OrcWarlord
 	}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/orc_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/orc_units.nut
@@ -1,10 +1,5 @@
 local units = [
 	{
-		ID = "Unit.RF.OrcYoungLOW",
-		Troop = "OrcYoungLOW",
-		Figure = "figure_orc_01"       // I assume this is OrcYoung without Armor and without Helmet
-	},
-	{
 		ID = "Unit.RF.OrcYoung",
 		Troop = "OrcYoung",
 		Figure = ["figure_orc_02", "figure_orc_06"]       // I assume this is OrcYoung only with Helmet (02) and OrcYoung only with Armor (06)
@@ -13,11 +8,6 @@ local units = [
 		ID = "Unit.RF.OrcBerserker",
 		Troop = "OrcBerserker",
 		Figure = "figure_orc_03"        // I'm sure this is OrcBerserker
-	},
-	{
-		ID = "Unit.RF.OrcWarriorLOW",
-		Troop = "OrcWarriorLOW",
-		Figure = "figure_orc_04"        // I'm sure this is OrcWarrior
 	},
 	{
 		ID = "Unit.RF.OrcWarrior",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/orc_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/orc_units.nut
@@ -1,0 +1,45 @@
+local units = [
+	{
+		ID = "Unit.OrcYoungLOW",
+		Troop = "OrcYoungLOW",
+		Figure = "figure_orc_01",       // I assume this is OrcYoung without Armor and without Helmet
+		Cost = 13
+	},
+	{
+		ID = "Unit.OrcYoung",
+		Troop = "OrcYoung",
+		Figure = ["figure_orc_02", "figure_orc_06"],       // I assume this is OrcYoung only with Helmet (02) and OrcYoung only with Armor (06)
+		Cost = 16
+	},
+	{
+		ID = "Unit.OrcBerserker",
+		Troop = "OrcBerserker",
+		Figure = "figure_orc_03"        // I'm sure this is OrcBerserker
+		Cost = 25
+	},
+	{
+		ID = "Unit.OrcWarriorLOW",
+		Troop = "OrcWarriorLOW",
+		Figure = "figure_orc_04"        // I'm sure this is OrcWarrior
+		Cost = 30
+	},
+	{
+		ID = "Unit.OrcWarrior",
+		Troop = "OrcWarrior",
+		Figure = "figure_orc_04",       // I'm sure this is OrcWarrior
+		Cost = 40
+	},
+	{
+		ID = "Unit.OrcWarlord",
+		Troop = "OrcWarlord",
+		Figure = "figure_orc_05",       // I'm sure this is OrcWarlord
+		Cost = 50
+	}
+]
+
+foreach (unitDef in units)
+{
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	::DynamicSpawns.Public.registerUnit(unitDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/orc_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/orc_units.nut
@@ -2,38 +2,32 @@ local units = [
 	{
 		ID = "Unit.OrcYoungLOW",
 		Troop = "OrcYoungLOW",
-		Figure = "figure_orc_01",       // I assume this is OrcYoung without Armor and without Helmet
-		Cost = 13
+		Figure = "figure_orc_01"       // I assume this is OrcYoung without Armor and without Helmet
 	},
 	{
 		ID = "Unit.OrcYoung",
 		Troop = "OrcYoung",
-		Figure = ["figure_orc_02", "figure_orc_06"],       // I assume this is OrcYoung only with Helmet (02) and OrcYoung only with Armor (06)
-		Cost = 16
+		Figure = ["figure_orc_02", "figure_orc_06"]       // I assume this is OrcYoung only with Helmet (02) and OrcYoung only with Armor (06)
 	},
 	{
 		ID = "Unit.OrcBerserker",
 		Troop = "OrcBerserker",
 		Figure = "figure_orc_03"        // I'm sure this is OrcBerserker
-		Cost = 25
 	},
 	{
 		ID = "Unit.OrcWarriorLOW",
 		Troop = "OrcWarriorLOW",
 		Figure = "figure_orc_04"        // I'm sure this is OrcWarrior
-		Cost = 30
 	},
 	{
 		ID = "Unit.OrcWarrior",
 		Troop = "OrcWarrior",
-		Figure = "figure_orc_04",       // I'm sure this is OrcWarrior
-		Cost = 40
+		Figure = "figure_orc_04"       // I'm sure this is OrcWarrior
 	},
 	{
 		ID = "Unit.OrcWarlord",
 		Troop = "OrcWarlord",
-		Figure = "figure_orc_05",       // I'm sure this is OrcWarlord
-		Cost = 50
+		Figure = "figure_orc_05"       // I'm sure this is OrcWarlord
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
@@ -1,44 +1,44 @@
 local units = [
 	{
-		ID = "Unit.SouthernConscript",
+		ID = "Unit.Conscript",
 		Troop = "Conscript",
 		Cost = 20,
 		Figure = "figure_southern_01"
 	},
 	{
-		ID = "Unit.SouthernConscript_Polearm",
+		ID = "Unit.Conscript_Polearm",
 		Troop = "ConscriptPolearm",
 		Cost = 15
 	},
 	{
-		ID = "Unit.SouthernOfficer",
+		ID = "Unit.Officer",
 		Troop = "Officer",
 		Cost = 25,
 		Figure = "figure_southern_02"
 	},
 	{
-		ID = "Unit.SouthernGunner",
+		ID = "Unit.Gunner",
 		Troop = "Gunner",
 		Cost = 20
 	},
 	{
-		ID = "Unit.SouthernEngineer",
+		ID = "Unit.Engineer",
 		Troop = "Engineer",
 		Cost = 10
 	},
 	{
-		ID = "Unit.SouthernMortar",
+		ID = "Unit.Mortar",
 		Troop = "Mortar",
 		Cost = 20,
 		SubPartyDef = {ID = "MortarEngineers"}
 	},
 	{
-		ID = "Unit.SouthernAssassin",
+		ID = "Unit.Assassin",
 		Troop = "Assassin",
 		Cost = 35
 	},
 	{
-		ID = "Unit.SouthernSlave",
+		ID = "Unit.Slave",
 		Troop = "Slave",
 		Cost = 7
 	},

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
@@ -39,7 +39,7 @@ local units = [
 
 // Caravans
 	{
-		ID = "Unit.RF.SouthernCaravanDonkey",
+		ID = "Unit.RF.SouthernDonkey",
 		Troop = "SouthernDonkey",
 		Figure = "cart_02",
 		Cost = 10      // 0 in Vanilla

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
@@ -2,45 +2,37 @@ local units = [
 	{
 		ID = "Unit.Conscript",
 		Troop = "Conscript",
-		Cost = 20,
 		Figure = "figure_southern_01"
 	},
 	{
 		ID = "Unit.Conscript_Polearm",
-		Troop = "ConscriptPolearm",
-		Cost = 15
+		Troop = "ConscriptPolearm"
 	},
 	{
 		ID = "Unit.Officer",
 		Troop = "Officer",
-		Cost = 25,
 		Figure = "figure_southern_02"
 	},
 	{
 		ID = "Unit.Gunner",
-		Troop = "Gunner",
-		Cost = 20
+		Troop = "Gunner"
 	},
 	{
 		ID = "Unit.Engineer",
-		Troop = "Engineer",
-		Cost = 10
+		Troop = "Engineer"
 	},
 	{
 		ID = "Unit.Mortar",
 		Troop = "Mortar",
-		Cost = 20,
 		SubPartyDef = {ID = "MortarEngineers"}
 	},
 	{
 		ID = "Unit.Assassin",
-		Troop = "Assassin",
-		Cost = 35
+		Troop = "Assassin"
 	},
 	{
 		ID = "Unit.Slave",
-		Troop = "Slave",
-		Cost = 7
+		Troop = "Slave"
 	},
 
 // Caravans

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
@@ -1,45 +1,45 @@
 local units = [
 	{
-		ID = "Unit.Conscript",
+		ID = "Unit.RF.Conscript",
 		Troop = "Conscript",
 		Figure = "figure_southern_01"
 	},
 	{
-		ID = "Unit.Conscript_Polearm",
+		ID = "Unit.RF.Conscript_Polearm",
 		Troop = "ConscriptPolearm"
 	},
 	{
-		ID = "Unit.Officer",
+		ID = "Unit.RF.Officer",
 		Troop = "Officer",
 		Figure = "figure_southern_02",
 		StartingResourceMin = 250 // In Vanilla they appear in a group of 250 cost
 	},
 	{
-		ID = "Unit.Gunner",
+		ID = "Unit.RF.Gunner",
 		Troop = "Gunner"
 	},
 	{
-		ID = "Unit.Engineer",
+		ID = "Unit.RF.Engineer",
 		Troop = "Engineer"
 	},
 	{
-		ID = "Unit.Mortar",
+		ID = "Unit.RF.Mortar",
 		Troop = "Mortar",
 		StartingResourceMin = 340, // In Vanilla they appear in a group of 340 cost
 		SubPartyDef = {ID = "MortarEngineers"}
 	},
 	{
-		ID = "Unit.Assassin",
+		ID = "Unit.RF.Assassin",
 		Troop = "Assassin"
 	},
 	{
-		ID = "Unit.Slave",
+		ID = "Unit.RF.Slave",
 		Troop = "Slave"
 	},
 
 // Caravans
 	{
-		ID = "Unit.SouthernCaravanDonkey",
+		ID = "Unit.RF.SouthernCaravanDonkey",
 		Troop = "SouthernDonkey",
 		Figure = "cart_02",
 		Cost = 10      // 0 in Vanilla

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
@@ -11,7 +11,8 @@ local units = [
 	{
 		ID = "Unit.Officer",
 		Troop = "Officer",
-		Figure = "figure_southern_02"
+		Figure = "figure_southern_02",
+		StartingResourceMin = 250 // In Vanilla they appear in a group of 250 cost
 	},
 	{
 		ID = "Unit.Gunner",
@@ -24,6 +25,7 @@ local units = [
 	{
 		ID = "Unit.Mortar",
 		Troop = "Mortar",
+		StartingResourceMin = 340, // In Vanilla they appear in a group of 340 cost
 		SubPartyDef = {ID = "MortarEngineers"}
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
@@ -1,0 +1,60 @@
+local units = [
+	{
+		ID = "Unit.SouthernConscript",
+		Troop = "Conscript",
+		Cost = 20,
+		Figure = "figure_southern_01"
+	},
+	{
+		ID = "Unit.SouthernConscript_Polearm",
+		Troop = "ConscriptPolearm",
+		Cost = 15
+	},
+	{
+		ID = "Unit.SouthernOfficer",
+		Troop = "Officer",
+		Cost = 25,
+		Figure = "figure_southern_02"
+	},
+	{
+		ID = "Unit.SouthernGunner",
+		Troop = "Gunner",
+		Cost = 20
+	},
+	{
+		ID = "Unit.SouthernEngineer",
+		Troop = "Engineer",
+		Cost = 10
+	},
+	{
+		ID = "Unit.SouthernMortar",
+		Troop = "Mortar",
+		Cost = 20,
+		SubPartyDef = {ID = "MortarEngineers"}
+	},
+	{
+		ID = "Unit.SouthernAssassin",
+		Troop = "Assassin",
+		Cost = 35
+	},
+	{
+		ID = "Unit.SouthernSlave",
+		Troop = "Slave",
+		Cost = 7
+	},
+
+// Caravans
+	{
+		ID = "Unit.SouthernCaravanDonkey",
+		Troop = "SouthernDonkey",
+		Figure = "cart_02",
+		Cost = 10      // 0 in Vanilla
+	}
+]
+
+foreach (unitDef in units)
+{
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	::DynamicSpawns.Public.registerUnit(unitDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
@@ -1,0 +1,196 @@
+// This Combines Units from spawnlist_zombies and spawnlist_undead
+local units = [
+// Zombies
+	{
+		ID = "Unit.UndeadZombie",
+		Troop = "Zombie",
+		Figure = "figure_zombie_01",       // Exclusiv
+		Cost = 6
+	},
+	{
+		ID = "Unit.UndeadZombieYeoman",
+		Troop = "ZombieYeoman",
+		Figure = "figure_zombie_02",
+		Cost = 12
+	},
+	{
+		ID = "Unit.UndeadZombieNomad",
+		Troop = "ZombieNomad",
+		Figure = "figure_zombie_03",
+		Cost = 12
+	},
+	{
+		ID = "Unit.UndeadFallenHero",     // Fallen Hero
+		Troop = "ZombieKnight",
+		Figure = "figure_zombie_03",
+		Cost = 24
+	},
+	{
+		ID = "Unit.UndeadNecromancer",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],    // In Vanilla 02 is only used for Scourge Spawns. But there they still use 01 randomly aswell
+		Cost = 30
+	},
+
+// Necromancer with Bodyguards
+	{
+		ID = "Unit.UndeadNecromancerY",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12,
+		SubPartyDef = {ID = "SubPartyYeoman"}
+	},
+	{
+		ID = "Unit.UndeadNecromancerK",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 24,
+		SubPartyDef = {ID = "SubPartyKnight"}
+	},
+	{
+		ID = "Unit.UndeadNecromancerYK",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12 + 24,
+		SubPartyDef = {ID = "SubPartyYeomanKnight"}
+	},
+	{
+		ID = "Unit.UndeadNecromancerKK",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 24 + 24,
+		SubPartyDef = {ID = "SubPartyKnightKnight"}
+	},
+
+// Necromancer with Nomad Bodyguards
+	{
+		ID = "Unit.UndeadNecromancerN",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12,
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1 }
+	},
+	{
+		ID = "Unit.UndeadNecromancerNN",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12 + 12,
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2 }
+	},
+	{
+		ID = "Unit.UndeadNecromancerNNN",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12 + 12 + 12,
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3 }
+	}
+
+// Bodyguards for Necromancer
+	{
+		ID = "Unit.UndeadYeomanBodyguard",
+		Troop = "ZombieYeomanBodyguard",
+		Figure = "figure_zombie_02",
+		Cost = 12
+	},
+	{
+		ID = "Unit.UndeadZombieNomadBodyguard",
+		Troop = "ZombieNomadBodyguard",
+		Figure = "figure_zombie_03",
+		Cost = 12
+	},
+	{
+		ID = "Unit.UndeadFallenHeroBodyguard",
+		Troop = "ZombieKnightBodyguard",
+		Figure = "figure_zombie_03",
+		Cost = 24
+	},
+
+// Ghosts
+	{
+		ID = "Unit.UndeadGhost",
+		Troop = "Ghost",
+		Figure = "figure_ghost_01",     // Exclusiv
+		Cost = 20
+	},
+
+// Skeletons
+	{
+		ID = "Unit.UndeadSkeletonLight",
+		Troop = "SkeletonLight",
+		Figure = "figure_skeleton_01",      // Exclusiv
+		Cost = 13
+	},
+	{
+		ID = "Unit.UndeadSkeletonMedium",
+		Troop = "SkeletonMedium",
+		Figure = "figure_skeleton_02",
+		Cost = 20
+	},
+	{
+		ID = "Unit.UndeadSkeletonMediumPolearm",
+		Troop = "SkeletonMediumPolearm",
+		Figure = "figure_skeleton_02",
+		Cost = 25
+	},
+	{
+		ID = "Unit.UndeadSkeletonHeavy",
+		Troop = "SkeletonHeavy",
+		Figure = "figure_skeleton_03",
+		Cost = 35
+	},
+	{
+		ID = "Unit.UndeadSkeletonHeavyPolearm",
+		Troop = "SkeletonHeavyPolearm",
+		Figure = "figure_skeleton_03",
+		Cost = 35
+	},
+	{
+		ID = "Unit.UndeadSkeletonPriest",
+		Troop = "SkeletonPriest",
+		Figure = "figure_skeleton_04",
+		Cost = 40
+	},
+	{
+		ID = "Unit.UndeadSkeletonPriestH",
+		Troop = "SkeletonPriest",
+		Figure = "figure_skeleton_04",
+		Cost = 40 + 30,
+		SubPartyDef = {ID = "SubPartyHonor"}
+	},
+	{
+		ID = "Unit.UndeadSkeletonPriestHH",
+		Troop = "SkeletonPriest",
+		Figure = "figure_skeleton_04",
+		Cost = 40 + 30 + 30,
+		SubPartyDef = {ID = "SubPartyHonorHonor"}
+	},
+
+// Bodyguards for Priests
+	{
+		ID = "Unit.UndeadSkeletonHeavyBodyguard",
+		Troop = "SkeletonHeavyBodyguard",
+		Figure = "figure_zombie_03",
+		Cost = 30
+	},
+
+// Vampire
+	{
+		ID = "Unit.UndeadVampireLOW",
+		Troop = "VampireLOW",
+		Figure = "figure_vampire_01",       // Exclusiv
+		Cost = 30
+	},
+	{
+		ID = "Unit.UndeadVampire",
+		Troop = "Vampire",
+		Figure = "figure_vampire_02",       // Exclusiv
+		Cost = 40
+	}
+]
+
+foreach (unitDef in units)
+{
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	::DynamicSpawns.Public.registerUnit(unitDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
@@ -8,27 +8,32 @@ local units = [
 	{
 		ID = "Unit.SkeletonMedium",
 		Troop = "SkeletonMedium",
-		Figure = "figure_skeleton_02"
+		Figure = "figure_skeleton_02",
+		StartingResourceMin = 125
 	},
 	{
 		ID = "Unit.SkeletonMediumPolearm",
 		Troop = "SkeletonMediumPolearm",
-		Figure = "figure_skeleton_02"
+		Figure = "figure_skeleton_02",
+		StartingResourceMin = 125
 	},
 	{
 		ID = "Unit.SkeletonHeavy",
 		Troop = "SkeletonHeavy",
-		Figure = "figure_skeleton_03"
+		Figure = "figure_skeleton_03",
+		StartingResourceMin = 175
 	},
 	{
 		ID = "Unit.SkeletonHeavyPolearm",
 		Troop = "SkeletonHeavyPolearm",
-		Figure = "figure_skeleton_03"
+		Figure = "figure_skeleton_03",
+		StartingResourceMin = 175
 	},
 	{
 		ID = "Unit.SkeletonPriest",
 		Troop = "SkeletonPriest",
-		Figure = "figure_skeleton_04"
+		Figure = "figure_skeleton_04",
+		StartingResourceMin = 225
 	},
 	{
 		ID = "Unit.SkeletonPriestH",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
@@ -59,11 +59,6 @@ local units = [
 
 // Vampire
 	{
-		ID = "Unit.RF.VampireLOW",
-		Troop = "VampireLOW",
-		Figure = "figure_vampire_01"       // Exclusive
-	},
-	{
 		ID = "Unit.RF.Vampire",
 		Troop = "Vampire",
 		Figure = "figure_vampire_02"       // Exclusive

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
@@ -1,123 +1,9 @@
-// This Combines Units from spawnlist_zombies and spawnlist_undead
 local units = [
-// Zombies
-	{
-		ID = "Unit.UndeadZombie",
-		Troop = "Zombie",
-		Figure = "figure_zombie_01",       // Exclusiv
-		Cost = 6
-	},
-	{
-		ID = "Unit.UndeadZombieYeoman",
-		Troop = "ZombieYeoman",
-		Figure = "figure_zombie_02",
-		Cost = 12
-	},
-	{
-		ID = "Unit.UndeadZombieNomad",
-		Troop = "ZombieNomad",
-		Figure = "figure_zombie_03",
-		Cost = 12
-	},
-	{
-		ID = "Unit.UndeadFallenHero",     // Fallen Hero
-		Troop = "ZombieKnight",
-		Figure = "figure_zombie_03",
-		Cost = 24
-	},
-	{
-		ID = "Unit.UndeadNecromancer",
-		Troop = "Necromancer",
-		Figure = ["figure_necromancer_01", "figure_necromancer_02"],    // In Vanilla 02 is only used for Scourge Spawns. But there they still use 01 randomly aswell
-		Cost = 30
-	},
-
-// Necromancer with Bodyguards
-	{
-		ID = "Unit.UndeadNecromancerY",
-		Troop = "Necromancer",
-		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		Cost = 30 + 12,
-		SubPartyDef = {ID = "SubPartyYeoman"}
-	},
-	{
-		ID = "Unit.UndeadNecromancerK",
-		Troop = "Necromancer",
-		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		Cost = 30 + 24,
-		SubPartyDef = {ID = "SubPartyKnight"}
-	},
-	{
-		ID = "Unit.UndeadNecromancerYK",
-		Troop = "Necromancer",
-		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		Cost = 30 + 12 + 24,
-		SubPartyDef = {ID = "SubPartyYeomanKnight"}
-	},
-	{
-		ID = "Unit.UndeadNecromancerKK",
-		Troop = "Necromancer",
-		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		Cost = 30 + 24 + 24,
-		SubPartyDef = {ID = "SubPartyKnightKnight"}
-	},
-
-// Necromancer with Nomad Bodyguards
-	{
-		ID = "Unit.UndeadNecromancerN",
-		Troop = "Necromancer",
-		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		Cost = 30 + 12,
-		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1 }
-	},
-	{
-		ID = "Unit.UndeadNecromancerNN",
-		Troop = "Necromancer",
-		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		Cost = 30 + 12 + 12,
-		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2 }
-	},
-	{
-		ID = "Unit.UndeadNecromancerNNN",
-		Troop = "Necromancer",
-		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		Cost = 30 + 12 + 12 + 12,
-		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3 }
-	}
-
-// Bodyguards for Necromancer
-	{
-		ID = "Unit.UndeadYeomanBodyguard",
-		Troop = "ZombieYeomanBodyguard",
-		Figure = "figure_zombie_02",
-		Cost = 12
-	},
-	{
-		ID = "Unit.UndeadZombieNomadBodyguard",
-		Troop = "ZombieNomadBodyguard",
-		Figure = "figure_zombie_03",
-		Cost = 12
-	},
-	{
-		ID = "Unit.UndeadFallenHeroBodyguard",
-		Troop = "ZombieKnightBodyguard",
-		Figure = "figure_zombie_03",
-		Cost = 24
-	},
-
-// Ghosts
-	{
-		ID = "Unit.UndeadGhost",
-		Troop = "Ghost",
-		Figure = "figure_ghost_01",     // Exclusiv
-		Cost = 20
-	},
-
 // Skeletons
 	{
 		ID = "Unit.UndeadSkeletonLight",
 		Troop = "SkeletonLight",
-		Figure = "figure_skeleton_01",      // Exclusiv
+		Figure = "figure_skeleton_01",      // Exclusive
 		Cost = 13
 	},
 	{
@@ -177,13 +63,13 @@ local units = [
 	{
 		ID = "Unit.UndeadVampireLOW",
 		Troop = "VampireLOW",
-		Figure = "figure_vampire_01",       // Exclusiv
+		Figure = "figure_vampire_01",       // Exclusive
 		Cost = 30
 	},
 	{
 		ID = "Unit.UndeadVampire",
 		Troop = "Vampire",
-		Figure = "figure_vampire_02",       // Exclusiv
+		Figure = "figure_vampire_02",       // Exclusive
 		Cost = 40
 	}
 ]

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
@@ -1,50 +1,50 @@
 local units = [
 // Skeletons
 	{
-		ID = "Unit.UndeadSkeletonLight",
+		ID = "Unit.SkeletonLight",
 		Troop = "SkeletonLight",
 		Figure = "figure_skeleton_01",      // Exclusive
 		Cost = 13
 	},
 	{
-		ID = "Unit.UndeadSkeletonMedium",
+		ID = "Unit.SkeletonMedium",
 		Troop = "SkeletonMedium",
 		Figure = "figure_skeleton_02",
 		Cost = 20
 	},
 	{
-		ID = "Unit.UndeadSkeletonMediumPolearm",
+		ID = "Unit.SkeletonMediumPolearm",
 		Troop = "SkeletonMediumPolearm",
 		Figure = "figure_skeleton_02",
 		Cost = 25
 	},
 	{
-		ID = "Unit.UndeadSkeletonHeavy",
+		ID = "Unit.SkeletonHeavy",
 		Troop = "SkeletonHeavy",
 		Figure = "figure_skeleton_03",
 		Cost = 35
 	},
 	{
-		ID = "Unit.UndeadSkeletonHeavyPolearm",
+		ID = "Unit.SkeletonHeavyPolearm",
 		Troop = "SkeletonHeavyPolearm",
 		Figure = "figure_skeleton_03",
 		Cost = 35
 	},
 	{
-		ID = "Unit.UndeadSkeletonPriest",
+		ID = "Unit.SkeletonPriest",
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		Cost = 40
 	},
 	{
-		ID = "Unit.UndeadSkeletonPriestH",
+		ID = "Unit.SkeletonPriestH",
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		Cost = 40 + 30,
 		SubPartyDef = {ID = "SubPartyHonor"}
 	},
 	{
-		ID = "Unit.UndeadSkeletonPriestHH",
+		ID = "Unit.SkeletonPriestHH",
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		Cost = 40 + 30 + 30,
@@ -53,7 +53,7 @@ local units = [
 
 // Bodyguards for Priests
 	{
-		ID = "Unit.UndeadSkeletonHeavyBodyguard",
+		ID = "Unit.SkeletonHeavyBodyguard",
 		Troop = "SkeletonHeavyBodyguard",
 		Figure = "figure_zombie_03",
 		Cost = 30
@@ -61,13 +61,13 @@ local units = [
 
 // Vampire
 	{
-		ID = "Unit.UndeadVampireLOW",
+		ID = "Unit.VampireLOW",
 		Troop = "VampireLOW",
 		Figure = "figure_vampire_01",       // Exclusive
 		Cost = 30
 	},
 	{
-		ID = "Unit.UndeadVampire",
+		ID = "Unit.Vampire",
 		Troop = "Vampire",
 		Figure = "figure_vampire_02",       // Exclusive
 		Cost = 40

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
@@ -1,49 +1,49 @@
 local units = [
 // Skeletons
 	{
-		ID = "Unit.SkeletonLight",
+		ID = "Unit.RF.SkeletonLight",
 		Troop = "SkeletonLight",
 		Figure = "figure_skeleton_01"      // Exclusive
 	},
 	{
-		ID = "Unit.SkeletonMedium",
+		ID = "Unit.RF.SkeletonMedium",
 		Troop = "SkeletonMedium",
 		Figure = "figure_skeleton_02",
 		StartingResourceMin = 125
 	},
 	{
-		ID = "Unit.SkeletonMediumPolearm",
+		ID = "Unit.RF.SkeletonMediumPolearm",
 		Troop = "SkeletonMediumPolearm",
 		Figure = "figure_skeleton_02",
 		StartingResourceMin = 125
 	},
 	{
-		ID = "Unit.SkeletonHeavy",
+		ID = "Unit.RF.SkeletonHeavy",
 		Troop = "SkeletonHeavy",
 		Figure = "figure_skeleton_03",
 		StartingResourceMin = 175
 	},
 	{
-		ID = "Unit.SkeletonHeavyPolearm",
+		ID = "Unit.RF.SkeletonHeavyPolearm",
 		Troop = "SkeletonHeavyPolearm",
 		Figure = "figure_skeleton_03",
 		StartingResourceMin = 175
 	},
 	{
-		ID = "Unit.SkeletonPriest",
+		ID = "Unit.RF.SkeletonPriest",
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 225
 	},
 	{
-		ID = "Unit.SkeletonPriestH",
+		ID = "Unit.RF.SkeletonPriestH",
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		Cost = 40 + 30,
 		SubPartyDef = {ID = "SubPartyHonor"}
 	},
 	{
-		ID = "Unit.SkeletonPriestHH",
+		ID = "Unit.RF.SkeletonPriestHH",
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		Cost = 40 + 30 + 30,
@@ -52,19 +52,19 @@ local units = [
 
 // Bodyguards for Priests
 	{
-		ID = "Unit.SkeletonHeavyBodyguard",
+		ID = "Unit.RF.SkeletonHeavyBodyguard",
 		Troop = "SkeletonHeavyBodyguard",
 		Figure = "figure_zombie_03"
 	},
 
 // Vampire
 	{
-		ID = "Unit.VampireLOW",
+		ID = "Unit.RF.VampireLOW",
 		Troop = "VampireLOW",
 		Figure = "figure_vampire_01"       // Exclusive
 	},
 	{
-		ID = "Unit.Vampire",
+		ID = "Unit.RF.Vampire",
 		Troop = "Vampire",
 		Figure = "figure_vampire_02"       // Exclusive
 	}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
@@ -3,38 +3,32 @@ local units = [
 	{
 		ID = "Unit.SkeletonLight",
 		Troop = "SkeletonLight",
-		Figure = "figure_skeleton_01",      // Exclusive
-		Cost = 13
+		Figure = "figure_skeleton_01"      // Exclusive
 	},
 	{
 		ID = "Unit.SkeletonMedium",
 		Troop = "SkeletonMedium",
-		Figure = "figure_skeleton_02",
-		Cost = 20
+		Figure = "figure_skeleton_02"
 	},
 	{
 		ID = "Unit.SkeletonMediumPolearm",
 		Troop = "SkeletonMediumPolearm",
-		Figure = "figure_skeleton_02",
-		Cost = 25
+		Figure = "figure_skeleton_02"
 	},
 	{
 		ID = "Unit.SkeletonHeavy",
 		Troop = "SkeletonHeavy",
-		Figure = "figure_skeleton_03",
-		Cost = 35
+		Figure = "figure_skeleton_03"
 	},
 	{
 		ID = "Unit.SkeletonHeavyPolearm",
 		Troop = "SkeletonHeavyPolearm",
-		Figure = "figure_skeleton_03",
-		Cost = 35
+		Figure = "figure_skeleton_03"
 	},
 	{
 		ID = "Unit.SkeletonPriest",
 		Troop = "SkeletonPriest",
-		Figure = "figure_skeleton_04",
-		Cost = 40
+		Figure = "figure_skeleton_04"
 	},
 	{
 		ID = "Unit.SkeletonPriestH",
@@ -55,22 +49,19 @@ local units = [
 	{
 		ID = "Unit.SkeletonHeavyBodyguard",
 		Troop = "SkeletonHeavyBodyguard",
-		Figure = "figure_zombie_03",
-		Cost = 30
+		Figure = "figure_zombie_03"
 	},
 
 // Vampire
 	{
 		ID = "Unit.VampireLOW",
 		Troop = "VampireLOW",
-		Figure = "figure_vampire_01",       // Exclusive
-		Cost = 30
+		Figure = "figure_vampire_01"       // Exclusive
 	},
 	{
 		ID = "Unit.Vampire",
 		Troop = "Vampire",
-		Figure = "figure_vampire_02",       // Exclusive
-		Cost = 40
+		Figure = "figure_vampire_02"       // Exclusive
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -33,7 +33,7 @@ local units = [
 		ID = "Unit.RF.NecromancerY",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		StartingResourceMin = 100,
+		StartingResourceMin = 100, // In Vanilla they appear in a group of 100 cost
 		Cost = 30 + 12,
 		SubPartyDef = {ID = "SubPartyYeoman"}
 	},
@@ -41,7 +41,7 @@ local units = [
 		ID = "Unit.RF.NecromancerK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		StartingResourceMin = 320,
+		StartingResourceMin = 320, // In Vanilla they appear in a group of 320 cost
 		Cost = 30 + 24,
 		SubPartyDef = {ID = "SubPartyKnight"}
 	},
@@ -49,7 +49,7 @@ local units = [
 		ID = "Unit.RF.NecromancerYK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		StartingResourceMin = 360,
+		StartingResourceMin = 360, // In Vanilla they appear in a group of 415 cost
 		Cost = 30 + 12 + 24,
 		SubPartyDef = {ID = "SubPartyYeomanKnight"}
 	},
@@ -57,7 +57,7 @@ local units = [
 		ID = "Unit.RF.NecromancerKK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
-		StartingResourceMin = 420,
+		StartingResourceMin = 420, // In Vanilla they appear in a group of 415 cost
 		Cost = 30 + 24 + 24,
 		SubPartyDef = {ID = "SubPartyKnightKnight"}
 	},

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -1,31 +1,31 @@
 local units = [
 // Zombies
 	{
-		ID = "Unit.UndeadZombie",
+		ID = "Unit.Zombie",
 		Troop = "Zombie",
 		Figure = "figure_zombie_01",       // Exclusiv
 		Cost = 6
 	},
 	{
-		ID = "Unit.UndeadZombieYeoman",
+		ID = "Unit.ZombieYeoman",
 		Troop = "ZombieYeoman",
 		Figure = "figure_zombie_02",
 		Cost = 12
 	},
 	{
-		ID = "Unit.UndeadZombieNomad",
+		ID = "Unit.ZombieNomad",
 		Troop = "ZombieNomad",
 		Figure = "figure_zombie_03",
 		Cost = 12
 	},
 	{
-		ID = "Unit.UndeadFallenHero",     // Fallen Hero
+		ID = "Unit.FallenHero",     // Fallen Hero
 		Troop = "ZombieKnight",
 		Figure = "figure_zombie_03",
 		Cost = 24
 	},
 	{
-		ID = "Unit.UndeadNecromancer",
+		ID = "Unit.Necromancer",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],    // In Vanilla 02 is only used for Scourge Spawns. But there they still use 01 randomly aswell
 		Cost = 30
@@ -33,28 +33,28 @@ local units = [
 
 // Necromancer with Bodyguards
 	{
-		ID = "Unit.UndeadNecromancerY",
+		ID = "Unit.NecromancerY",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12,
 		SubPartyDef = {ID = "SubPartyYeoman"}
 	},
 	{
-		ID = "Unit.UndeadNecromancerK",
+		ID = "Unit.NecromancerK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 24,
 		SubPartyDef = {ID = "SubPartyKnight"}
 	},
 	{
-		ID = "Unit.UndeadNecromancerYK",
+		ID = "Unit.NecromancerYK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12 + 24,
 		SubPartyDef = {ID = "SubPartyYeomanKnight"}
 	},
 	{
-		ID = "Unit.UndeadNecromancerKK",
+		ID = "Unit.NecromancerKK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 24 + 24,
@@ -63,21 +63,21 @@ local units = [
 
 // Necromancer with Nomad Bodyguards
 	{
-		ID = "Unit.UndeadNecromancerN",
+		ID = "Unit.NecromancerN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12,
 		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1 }
 	},
 	{
-		ID = "Unit.UndeadNecromancerNN",
+		ID = "Unit.NecromancerNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12 + 12,
 		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2 }
 	},
 	{
-		ID = "Unit.UndeadNecromancerNNN",
+		ID = "Unit.NecromancerNNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12 + 12 + 12,
@@ -86,19 +86,19 @@ local units = [
 
 // Bodyguards for Necromancer
 	{
-		ID = "Unit.UndeadYeomanBodyguard",
+		ID = "Unit.YeomanBodyguard",
 		Troop = "ZombieYeomanBodyguard",
 		Figure = "figure_zombie_02",
 		Cost = 12
 	},
 	{
-		ID = "Unit.UndeadZombieNomadBodyguard",
+		ID = "Unit.ZombieNomadBodyguard",
 		Troop = "ZombieNomadBodyguard",
 		Figure = "figure_zombie_03",
 		Cost = 12
 	},
 	{
-		ID = "Unit.UndeadFallenHeroBodyguard",
+		ID = "Unit.FallenHeroBodyguard",
 		Troop = "ZombieKnightBodyguard",
 		Figure = "figure_zombie_03",
 		Cost = 24
@@ -106,7 +106,7 @@ local units = [
 
 // Ghosts
 	{
-		ID = "Unit.UndeadGhost",
+		ID = "Unit.Ghost",
 		Troop = "Ghost",
 		Figure = "figure_ghost_01",     // Exclusiv
 		Cost = 20

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -1,0 +1,121 @@
+local units = [
+// Zombies
+	{
+		ID = "Unit.UndeadZombie",
+		Troop = "Zombie",
+		Figure = "figure_zombie_01",       // Exclusiv
+		Cost = 6
+	},
+	{
+		ID = "Unit.UndeadZombieYeoman",
+		Troop = "ZombieYeoman",
+		Figure = "figure_zombie_02",
+		Cost = 12
+	},
+	{
+		ID = "Unit.UndeadZombieNomad",
+		Troop = "ZombieNomad",
+		Figure = "figure_zombie_03",
+		Cost = 12
+	},
+	{
+		ID = "Unit.UndeadFallenHero",     // Fallen Hero
+		Troop = "ZombieKnight",
+		Figure = "figure_zombie_03",
+		Cost = 24
+	},
+	{
+		ID = "Unit.UndeadNecromancer",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],    // In Vanilla 02 is only used for Scourge Spawns. But there they still use 01 randomly aswell
+		Cost = 30
+	},
+
+// Necromancer with Bodyguards
+	{
+		ID = "Unit.UndeadNecromancerY",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12,
+		SubPartyDef = {ID = "SubPartyYeoman"}
+	},
+	{
+		ID = "Unit.UndeadNecromancerK",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 24,
+		SubPartyDef = {ID = "SubPartyKnight"}
+	},
+	{
+		ID = "Unit.UndeadNecromancerYK",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12 + 24,
+		SubPartyDef = {ID = "SubPartyYeomanKnight"}
+	},
+	{
+		ID = "Unit.UndeadNecromancerKK",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 24 + 24,
+		SubPartyDef = {ID = "SubPartyKnightKnight"}
+	},
+
+// Necromancer with Nomad Bodyguards
+	{
+		ID = "Unit.UndeadNecromancerN",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12,
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1 }
+	},
+	{
+		ID = "Unit.UndeadNecromancerNN",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12 + 12,
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2 }
+	},
+	{
+		ID = "Unit.UndeadNecromancerNNN",
+		Troop = "Necromancer",
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		Cost = 30 + 12 + 12 + 12,
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3 }
+	}
+
+// Bodyguards for Necromancer
+	{
+		ID = "Unit.UndeadYeomanBodyguard",
+		Troop = "ZombieYeomanBodyguard",
+		Figure = "figure_zombie_02",
+		Cost = 12
+	},
+	{
+		ID = "Unit.UndeadZombieNomadBodyguard",
+		Troop = "ZombieNomadBodyguard",
+		Figure = "figure_zombie_03",
+		Cost = 12
+	},
+	{
+		ID = "Unit.UndeadFallenHeroBodyguard",
+		Troop = "ZombieKnightBodyguard",
+		Figure = "figure_zombie_03",
+		Cost = 24
+	},
+
+// Ghosts
+	{
+		ID = "Unit.UndeadGhost",
+		Troop = "Ghost",
+		Figure = "figure_ghost_01",     // Exclusiv
+		Cost = 20
+	},
+]
+
+foreach (unitDef in units)
+{
+	if (!("Cost" in unitDef))
+		unitDef.Cost <- ::Const.World.Spawn.Troops[unitDef.Troop].Cost;
+	::DynamicSpawns.Public.registerUnit(unitDef);
+}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -17,7 +17,7 @@ local units = [
 		Figure = "figure_zombie_03"
 	},
 	{
-		ID = "Unit.RF.FallenHero",     // Fallen Hero
+		ID = "Unit.RF.ZombieKnight",     // Fallen Hero
 		Troop = "ZombieKnight",
 		Figure = "figure_zombie_03",
 		StartingResourceMin = 200
@@ -83,7 +83,7 @@ local units = [
 
 // Bodyguards for Necromancer
 	{
-		ID = "Unit.RF.YeomanBodyguard",
+		ID = "Unit.RF.ZombieYeomanBodyguard",
 		Troop = "ZombieYeomanBodyguard",
 		Figure = "figure_zombie_02"
 	},
@@ -93,7 +93,7 @@ local units = [
 		Figure = "figure_zombie_03"
 	},
 	{
-		ID = "Unit.RF.FallenHeroBodyguard",
+		ID = "Unit.RF.ZombieKnightBodyguard",
 		Troop = "ZombieKnightBodyguard",
 		Figure = "figure_zombie_03"
 	},

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -1,57 +1,57 @@
 local units = [
 // Zombies
 	{
-		ID = "Unit.Zombie",
+		ID = "Unit.RF.Zombie",
 		Troop = "Zombie",
 		Figure = "figure_zombie_01"       // Exclusiv
 	},
 	{
-		ID = "Unit.ZombieYeoman",
+		ID = "Unit.RF.ZombieYeoman",
 		Troop = "ZombieYeoman",
 		Figure = "figure_zombie_02",
 		StartingResourceMin = 75
 	},
 	{
-		ID = "Unit.ZombieNomad",
+		ID = "Unit.RF.ZombieNomad",
 		Troop = "ZombieNomad",
 		Figure = "figure_zombie_03"
 	},
 	{
-		ID = "Unit.FallenHero",     // Fallen Hero
+		ID = "Unit.RF.FallenHero",     // Fallen Hero
 		Troop = "ZombieKnight",
 		Figure = "figure_zombie_03",
 		StartingResourceMin = 200
 	},
 	{
-		ID = "Unit.Necromancer",
+		ID = "Unit.RF.Necromancer",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"]    // In Vanilla 02 is only used for Scourge Spawns. But there they still use 01 randomly aswell
 	},
 
 // Necromancer with Bodyguards
 	{
-		ID = "Unit.NecromancerY",
+		ID = "Unit.RF.NecromancerY",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12,
 		SubPartyDef = {ID = "SubPartyYeoman"}
 	},
 	{
-		ID = "Unit.NecromancerK",
+		ID = "Unit.RF.NecromancerK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 24,
 		SubPartyDef = {ID = "SubPartyKnight"}
 	},
 	{
-		ID = "Unit.NecromancerYK",
+		ID = "Unit.RF.NecromancerYK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12 + 24,
 		SubPartyDef = {ID = "SubPartyYeomanKnight"}
 	},
 	{
-		ID = "Unit.NecromancerKK",
+		ID = "Unit.RF.NecromancerKK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 24 + 24,
@@ -60,21 +60,21 @@ local units = [
 
 // Necromancer with Nomad Bodyguards
 	{
-		ID = "Unit.NecromancerN",
+		ID = "Unit.RF.NecromancerN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12,
 		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1 }
 	},
 	{
-		ID = "Unit.NecromancerNN",
+		ID = "Unit.RF.NecromancerNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12 + 12,
 		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2 }
 	},
 	{
-		ID = "Unit.NecromancerNNN",
+		ID = "Unit.RF.NecromancerNNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12 + 12 + 12,
@@ -83,24 +83,24 @@ local units = [
 
 // Bodyguards for Necromancer
 	{
-		ID = "Unit.YeomanBodyguard",
+		ID = "Unit.RF.YeomanBodyguard",
 		Troop = "ZombieYeomanBodyguard",
 		Figure = "figure_zombie_02"
 	},
 	{
-		ID = "Unit.ZombieNomadBodyguard",
+		ID = "Unit.RF.ZombieNomadBodyguard",
 		Troop = "ZombieNomadBodyguard",
 		Figure = "figure_zombie_03"
 	},
 	{
-		ID = "Unit.FallenHeroBodyguard",
+		ID = "Unit.RF.FallenHeroBodyguard",
 		Troop = "ZombieKnightBodyguard",
 		Figure = "figure_zombie_03"
 	},
 
 // Ghosts
 	{
-		ID = "Unit.Ghost",
+		ID = "Unit.RF.Ghost",
 		Troop = "Ghost",
 		Figure = "figure_ghost_01"     // Exclusiv
 	},

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -33,6 +33,7 @@ local units = [
 		ID = "Unit.RF.NecromancerY",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		StartingResourceMin = 100,
 		Cost = 30 + 12,
 		SubPartyDef = {ID = "SubPartyYeoman"}
 	},
@@ -40,6 +41,7 @@ local units = [
 		ID = "Unit.RF.NecromancerK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		StartingResourceMin = 320,
 		Cost = 30 + 24,
 		SubPartyDef = {ID = "SubPartyKnight"}
 	},
@@ -47,6 +49,7 @@ local units = [
 		ID = "Unit.RF.NecromancerYK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		StartingResourceMin = 360,
 		Cost = 30 + 12 + 24,
 		SubPartyDef = {ID = "SubPartyYeomanKnight"}
 	},
@@ -54,6 +57,7 @@ local units = [
 		ID = "Unit.RF.NecromancerKK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		StartingResourceMin = 420,
 		Cost = 30 + 24 + 24,
 		SubPartyDef = {ID = "SubPartyKnightKnight"}
 	},
@@ -63,6 +67,7 @@ local units = [
 		ID = "Unit.RF.NecromancerN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		StartingResourceMin = 110,
 		Cost = 30 + 12,
 		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1 }
 	},
@@ -70,6 +75,7 @@ local units = [
 		ID = "Unit.RF.NecromancerNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		StartingResourceMin = 130,
 		Cost = 30 + 12 + 12,
 		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2 }
 	},
@@ -77,6 +83,7 @@ local units = [
 		ID = "Unit.RF.NecromancerNNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
+		StartingResourceMin = 170,
 		Cost = 30 + 12 + 12 + 12,
 		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3 }
 	}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -8,7 +8,8 @@ local units = [
 	{
 		ID = "Unit.ZombieYeoman",
 		Troop = "ZombieYeoman",
-		Figure = "figure_zombie_02"
+		Figure = "figure_zombie_02",
+		StartingResourceMin = 75
 	},
 	{
 		ID = "Unit.ZombieNomad",
@@ -18,7 +19,8 @@ local units = [
 	{
 		ID = "Unit.FallenHero",     // Fallen Hero
 		Troop = "ZombieKnight",
-		Figure = "figure_zombie_03"
+		Figure = "figure_zombie_03",
+		StartingResourceMin = 200
 	},
 	{
 		ID = "Unit.Necromancer",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -3,7 +3,7 @@ local units = [
 	{
 		ID = "Unit.RF.Zombie",
 		Troop = "Zombie",
-		Figure = "figure_zombie_01"       // Exclusiv
+		Figure = "figure_zombie_01"       // Exclusive
 	},
 	{
 		ID = "Unit.RF.ZombieYeoman",
@@ -102,7 +102,7 @@ local units = [
 	{
 		ID = "Unit.RF.Ghost",
 		Troop = "Ghost",
-		Figure = "figure_ghost_01"     // Exclusiv
+		Figure = "figure_ghost_01"     // Exclusive
 	},
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -3,32 +3,27 @@ local units = [
 	{
 		ID = "Unit.Zombie",
 		Troop = "Zombie",
-		Figure = "figure_zombie_01",       // Exclusiv
-		Cost = 6
+		Figure = "figure_zombie_01"       // Exclusiv
 	},
 	{
 		ID = "Unit.ZombieYeoman",
 		Troop = "ZombieYeoman",
-		Figure = "figure_zombie_02",
-		Cost = 12
+		Figure = "figure_zombie_02"
 	},
 	{
 		ID = "Unit.ZombieNomad",
 		Troop = "ZombieNomad",
-		Figure = "figure_zombie_03",
-		Cost = 12
+		Figure = "figure_zombie_03"
 	},
 	{
 		ID = "Unit.FallenHero",     // Fallen Hero
 		Troop = "ZombieKnight",
-		Figure = "figure_zombie_03",
-		Cost = 24
+		Figure = "figure_zombie_03"
 	},
 	{
 		ID = "Unit.Necromancer",
 		Troop = "Necromancer",
-		Figure = ["figure_necromancer_01", "figure_necromancer_02"],    // In Vanilla 02 is only used for Scourge Spawns. But there they still use 01 randomly aswell
-		Cost = 30
+		Figure = ["figure_necromancer_01", "figure_necromancer_02"]    // In Vanilla 02 is only used for Scourge Spawns. But there they still use 01 randomly aswell
 	},
 
 // Necromancer with Bodyguards
@@ -88,28 +83,24 @@ local units = [
 	{
 		ID = "Unit.YeomanBodyguard",
 		Troop = "ZombieYeomanBodyguard",
-		Figure = "figure_zombie_02",
-		Cost = 12
+		Figure = "figure_zombie_02"
 	},
 	{
 		ID = "Unit.ZombieNomadBodyguard",
 		Troop = "ZombieNomadBodyguard",
-		Figure = "figure_zombie_03",
-		Cost = 12
+		Figure = "figure_zombie_03"
 	},
 	{
 		ID = "Unit.FallenHeroBodyguard",
 		Troop = "ZombieKnightBodyguard",
-		Figure = "figure_zombie_03",
-		Cost = 24
+		Figure = "figure_zombie_03"
 	},
 
 // Ghosts
 	{
 		ID = "Unit.Ghost",
 		Troop = "Ghost",
-		Figure = "figure_ghost_01",     // Exclusiv
-		Cost = 20
+		Figure = "figure_ghost_01"     // Exclusiv
 	},
 ]
 


### PR DESCRIPTION
This PR will be merged in a squashed single commit co-authored by @LordMidas , @Darxo  and @Uberbagel .

It copies the implementation of dynamic spawns for all factions from the Dynamic Spawns Framework but then makes some adjustments e.g.:
- Rename units and unitblocks based on our own conventions.
- Move StartingResourceMin into UnitDefs.
- Remove Cost from UnitDefs because we pull that directly from the Troop.

This means that Reforged will have its own implementation of Dynamic Spawns which we will iterate on over time. The current implementation in DSF will get pulled out of the framework in a separate place for safekeeping. 

This PR needs to be merged before any further changes to the dynamic spawns in Reforged can be made.