### PR TITLE
fix: use setWeaponType instead of addWeaponType

### DIFF
--- a/mod_reforged/hooks/items/weapons/oriental/nomad_sling.nut
+++ b/mod_reforged/hooks/items/weapons/oriental/nomad_sling.nut
@@ -3,6 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 0;
-		this.addWeaponType(::Const.Items.WeaponType.Sling);
+		this.setWeaponType(::Const.Items.WeaponType.Sling | ::Const.Items.WeaponType.Throwing);
 	}
 });

--- a/mod_reforged/hooks/items/weapons/staff_sling.nut
+++ b/mod_reforged/hooks/items/weapons/staff_sling.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.Reach = 0;
-		this.addWeaponType(::Const.Items.WeaponType.Sling);
+		this.setWeaponType(::Const.Items.WeaponType.Sling | ::Const.Items.WeaponType.Throwing);
 	}
 
 	q.onEquip = @() function()


### PR DESCRIPTION
This is a fix because of how the hook in MSU works that breaks Categories when using addWeaponType. Once the MSU behavior is fixed, we can revert to using addWeaponType.