### PR TITLE
fix: add 100ms to onFollow of fling back and line breaker

### DIFF
--- a/mod_reforged/hooks/skills/actives/fling_back_skill.nut
+++ b/mod_reforged/hooks/skills/actives/fling_back_skill.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/fling_back_skill", function(q) {
+	// We delay the onFollow of this skill by another 100ms because otherwise the entity doesn't follow through with this function properly when at very high speeds using some faster combat speed mods
+	q.onFollow = @(__original) function( _tag )
+	{
+		if (::Time.getVirtualSpeed() > 2)
+		{
+			::Time.scheduleEvent(::TimeUnit.Virtual, 100, __original, _tag);
+		}
+		else
+		{
+			__original(_tag);
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/line_breaker.nut
+++ b/mod_reforged/hooks/skills/actives/line_breaker.nut
@@ -33,4 +33,17 @@
 
 		return null;
 	}
+
+	// We delay the onFollow of this skill by another 100ms because otherwise the entity doesn't follow through with this function properly when at very high speeds using some faster combat speed mods
+	q.onFollow = @(__original) function( _tag )
+	{
+		if (::Time.getVirtualSpeed() > 2)
+		{
+			::Time.scheduleEvent(::TimeUnit.Virtual, 100, __original, _tag);
+		}
+		else
+		{
+			__original(_tag);
+		}
+	}
 });


### PR DESCRIPTION
This bandaid accounts for the mod Swifter that has faster combat speed

I playtested the Line Breaker delay alot and after that I didn't have any issues with my brothers or orcs not moving into the line-broken tile. Though I was also never playing on the highest speed. Only 3/3.5

Fling Back had the same issue. Though I haven't fought enough unholds to remember whether the issue was fixed