### PR TITLE
refactor: require 'no current level-ups' for learning discovered talent

### DIFF
--- a/mod_reforged/config/perk_defs.nut
+++ b/mod_reforged/config/perk_defs.nut
@@ -454,6 +454,21 @@
 		Tooltip = ::Const.Strings.PerkDescription.RF_DiscoveredTalent,
 		Icon = "ui/perks/rf_discovered_talent.png",
 		IconDisabled = "ui/perks/rf_discovered_talent_bw.png",
+		function verifyPrerequisites( _player, _tooltip )
+		{
+			if (_player.getLevelUps() > 0)
+			{
+				_tooltip.push({
+					id = 3,
+					type = "hint",
+					icon = "ui/icons/icon_locked.png",
+					text = "Locked because this character must first spend all current attribute rolls"
+				});
+				return false;
+			}
+
+			return true;
+		}
 	},
 	{
 		ID = "perk.rf_survival_instinct",

--- a/scripts/skills/perks/perk_rf_discovered_talent.nut
+++ b/scripts/skills/perks/perk_rf_discovered_talent.nut
@@ -34,41 +34,10 @@ this.perk_rf_discovered_talent <- ::inherit("scripts/skills/skill", {
 			}
 		}
 
-		local requiredLevelUpsSpent = this.getContainer().hasSkill("perk.gifted") ? 5 : 4;
-
-		if (actor.m.LevelUpsSpent < requiredLevelUpsSpent)
-		{
-			local startIndex = requiredLevelUpsSpent - actor.m.LevelUpsSpent;
-			local attributes = array(actor.m.Attributes.len());
-
-			foreach (i, attributeLevelUps in actor.m.Attributes)
-			{
-				attributes[i] = array(startIndex);
-				for (local j = 0; j < startIndex; j++)
-				{
-					attributes[i][j] = attributeLevelUps[j];
-				}
-			}
-
-			actor.m.Attributes.clear();
-			actor.fillAttributeLevelUpValues(::Const.XP.MaxLevelWithPerkpoints - actor.getLevel() + actor.m.LevelUps);
-
-			foreach (i, attributeLevelUps in attributes)
-			{
-				foreach (j, levelup in attributeLevelUps)
-				{
-					actor.m.Attributes[i][j] = levelup;
-				}
-			}
-		}
-		else
-		{
-			actor.m.Attributes.clear();
-			actor.fillAttributeLevelUpValues(::Const.XP.MaxLevelWithPerkpoints - actor.getLevel() + actor.m.LevelUps);
-		}
-
+		// Because of its perk requirement we guaranteed that there are no pending past level-ups which would otherwise be overwritten
+		actor.m.Attributes.clear();
+		actor.fillAttributeLevelUpValues(::Const.XP.MaxLevelWithPerkpoints - actor.getLevel() + 1);
 		actor.m.LevelUps += 1;
-		actor.fillAttributeLevelUpValues(1);
 
 		this.m.IsApplied = true;
 	}


### PR DESCRIPTION
Simplify code of discovered talent skill

This is mostly a refactor to make the code cleaner.

But it can help prevent issues with alternative Gifted effects (like the in vanilla existing `spiritual_reward_item` that are pending on the player. Those are currently not accounted for and would be overwritten by this perk.


I tested this ingame and it works. The GUI even updates immediately once I spend the last level-up. No need to re-open the character screen as I feared at first