### PR TITLE
refactor: customize beardchance for eunuch, wildman and barbarian

### DIFF
--- a/mod_reforged/hooks/skills/backgrounds/barbarian_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/barbarian_background.nut
@@ -2,6 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
+		this.m.BeardChance = 90;
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_devious": 0,
 			"pg.rf_leadership": 0,

--- a/mod_reforged/hooks/skills/backgrounds/eunuch_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/eunuch_background.nut
@@ -2,6 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
+		this.m.BeardChance = 0;
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_devious": 1.5,
 			"pg.rf_tactician": 4,


### PR DESCRIPTION
In vanilla these three backgrounds have the same chance of spawning with a beard than anyone else: 60%.
I believe it is more thematic if that chance is adjusted for these backgrounds