### PR TITLE
refactor: remove promised potential from kingsguard cripple

### DIFF
--- a/mod_reforged/hooks/events/events/dlc4/kings_guard_1_event.nut
+++ b/mod_reforged/hooks/events/events/dlc4/kings_guard_1_event.nut
@@ -1,0 +1,12 @@
+::Reforged.HooksMod.hook("scripts/events/events/dlc4/kings_guard_1_event", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		local start = this.m.Screens[0].start;
+		this.m.Screens[0].start = function( _event )
+		{
+			start(_event);
+			_event.m.Dude.getPerkTree().removePerk("perk.rf_promised_potential");
+		}
+	}
+});

--- a/mod_reforged/hooks/events/events/dlc4/kings_guard_2_event.nut
+++ b/mod_reforged/hooks/events/events/dlc4/kings_guard_2_event.nut
@@ -1,0 +1,16 @@
+::Reforged.HooksMod.hook("scripts/events/events/dlc4/kings_guard_2_event", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		local start = this.m.Screens[0].start;
+		this.m.Screens[0].start = function( _event )
+		{
+			start(_event);
+			local kingsguard_perkTree = ::new("scripts/skills/backgrounds/kings_guard_background").m.PerkTree;
+			kingsguard_perkTree.setActor(_event.m.Dude);
+			kingsguard_perkTree.build();
+			_event.m.Dude.getPerkTree().merge(kingsguard_perkTree);
+			_event.m.Dude.resetPerks();
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/backgrounds/kings_guard_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/kings_guard_background.nut
@@ -19,7 +19,7 @@
 				"pgc.rf_shared_1": [
 					"pg.rf_resilient",
 					"pg.rf_unstoppable",
-					"pg.vicious"
+					"pg.rf_vicious"
 				],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [


### PR DESCRIPTION
This PR does 3 things:
- Remove Promised Potential perk from the cripple version of Kingsguard.
- Properly add the perk tree of the Kingsguard background to the perk tree of the cripple when he evolves into the kingsguard. (An update on the Dynamic Perks Framework side ensures that 13 columns are respected, overflown perks are moved into other tiers).
- Fix a typo in perk group id in kings_guard_background.