### PR TITLE
refactor(balance): replace double grip on zombies with +5 melee skill

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/zombie.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/zombie.nut
@@ -115,11 +115,12 @@
 		this.addDefaultStatusSprites();
 		this.getSprite("arms_icon").setBrightness(0.85);
 		this.getSprite("status_rooted").Scale = 0.55;
-		this.m.Skills.add(this.new("scripts/skills/special/double_grip"));
+		// this.m.Skills.add(this.new("scripts/skills/special/double_grip"));
 		this.m.Skills.add(this.new("scripts/skills/actives/zombie_bite"));
 		// this.m.Skills.add(this.new("scripts/skills/perks/perk_battle_forged"));
 
 		// Reforged
+		this.m.BaseProperties.MeleeSkill += 5;		// To offset the loss of double grip
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.Human;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_bear_down"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_wear_them_down"));


### PR DESCRIPTION
This will slightly buff all zombies with shield and those with two-handed weapons (even fallen heroes).
And it will slightly nerf all zombies that have a one-handed weapon and no shield.

But most importantly it will make breaking shields against zombies much more useful