### PR TITLE
refactor: slightly adjust the combat difficulties

### DIFF
--- a/mod_reforged/hooks/config/global.nut
+++ b/mod_reforged/hooks/config/global.nut
@@ -137,3 +137,70 @@ local getDefaultFaction = ::Const.EntityType.getDefaultFaction;
 
 	return ret;
 }
+
+// The lowest two difficulties are now the same
+::Const.Difficulty.EnemyMult[0] = ::Const.Difficulty.EnemyMult[1];
+::Const.Difficulty.EnemyMult[2] += 0.05;
+::Const.Difficulty.NPCDamageMult <- [
+	0.9,
+	1.0,
+	1.0
+]
+::Const.Difficulty.generateTooltipInfo <- function( _tooltip, _difficulty )
+{
+	if (::Const.Difficulty.XPMult[_difficulty] != 1.0)
+	{
+		_tooltip.push({
+			id = 4,
+			type = "text",
+			icon = "ui/icons/xp_received.png",
+			text = ::MSU.Text.colorizeMult(::Const.Difficulty.XPMult[_difficulty], {AddSign = true}) + " Global Experience gained"
+		})
+	}
+
+	if (_difficulty == ::Const.Difficulty.Easy)
+	{
+		_tooltip.push({
+			id = 3,
+			type = "text",
+			icon = "ui/icons/melee_skill.png",
+			text = "Your characters have " + ::MSU.Text.colorGreen("+5%") + " chance to hit"
+		})
+		_tooltip.push({
+			id = 3,
+			type = "text",
+			icon = "ui/icons/melee_defense.png",
+			text = "Attacks against your characters have " + ::MSU.Text.colorRed("-5%") + " chance to hit"
+		})
+	}
+
+	if (::Const.Difficulty.NPCDamageMult[_difficulty] != 1.0)
+	{
+		_tooltip.push({
+			id = 7,
+			type = "text",
+			icon = "ui/icons/regular_damage.png",
+			text = ::MSU.Text.colorizeMult(::Const.Difficulty.NPCDamageMult[_difficulty], {AddSign = true}) + " Damage dealt by all other characters"
+		})
+	}
+
+	if (::Const.Difficulty.RetreatDefenseBonus[_difficulty] != 0)
+	{
+		_tooltip.push({
+			id = 6,
+			type = "text",
+			icon = "ui/icons/melee_defense.png",
+			text = ::MSU.Text.colorizeValue(::Const.Difficulty.RetreatDefenseBonus[_difficulty]) + " Melee Defense during Auto-Retreat"
+		})
+	}
+
+	if (::Const.Difficulty.EnemyMult[_difficulty] != 1.0)
+	{
+		_tooltip.push({
+			id = 5,
+			type = "text",
+			icon = "ui/icons/camp.png",
+			text = ::MSU.Text.colorizeMult(::Const.Difficulty.EnemyMult[_difficulty], {AddSign = true}) + " Enemy Party Resources"
+		})
+	}
+}

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -44,6 +44,15 @@
 		}
 	}
 
+	q.onAfterInit = @(__original) function()
+	{
+		__original();
+		if (this.getType() != ::Const.EntityType.Player)
+		{
+			this.m.BaseProperties.DamageTotalMult *= ::Const.Difficulty.NPCDamageMult[::World.Assets.getCombatDifficulty()];
+		}
+	}
+
 	q.onAttackOfOpportunity = @(__original) function( _entity, _isOnEnter )
 	{
 		this.m.IsPerformingAttackOfOpportunity = true;

--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -30,6 +30,54 @@
 						text = ::Reforged.Mod.Tooltips.parseString("The character\'s level measures [experience|Concept.Experience] in battle. Characters rise in levels as they gain experience and are able to increase their [attributes|Concept.CharacterAttribute] and gain [perks|Concept.Perk] that make them better at the mercenary profession.\n\nBeyond the " + ::Const.XP.MaxLevelWithPerkpoints + "th character level, characters are veterans and gain perk points " + (::Reforged.Config.VeteranPerksLevelStep == 1 ? "" : "only") + " every " + ::Reforged.Config.VeteranPerksLevelStep + "th level. They can still improve their attributes but the attribute gain per level is small.")
 					}
 				];
+
+			case "menu-screen.new-campaign.EasyDifficulty":
+				local ret = [
+					{
+						id = 1,
+						type = "title",
+						text = "Beginner Difficulty"
+					},
+					{
+						id = 2,
+						type = "description",
+						text = "Your men gain experience slightly faster and enemies are slightly weaker, to ease you into the game.\n\nRecommended for players new to the game."
+					}
+				];
+				::Const.Difficulty.generateTooltipInfo(ret, ::Const.Difficulty.Easy);
+				return ret;
+
+			case "menu-screen.new-campaign.NormalDifficulty":
+				local ret =  [
+					{
+						id = 1,
+						type = "title",
+						text = "Veteran Difficulty"
+					},
+					{
+						id = 2,
+						type = "description",
+						text = "Provides for a balanced playing experience that can be quite challenging.\n\nRecommended for veterans of the game or the genre."
+					}
+				];
+				::Const.Difficulty.generateTooltipInfo(ret, ::Const.Difficulty.Normal);
+				return ret;
+
+			case "menu-screen.new-campaign.HardDifficulty":
+				local ret =  [
+					{
+						id = 1,
+						type = "title",
+						text = "Expert Difficulty"
+					},
+					{
+						id = 2,
+						type = "description",
+						text = "Your opponents will be more challenging and numerous.\n\nRecommended for experts in the game who want an even deadlier challenge."
+					}
+				];
+				::Const.Difficulty.generateTooltipInfo(ret, ::Const.Difficulty.Hard);
+				return ret;
 		}
 
 		return __original(_entityId, _elementId, _elementOwner);


### PR DESCRIPTION
Add 10% damage nerf to all NPCs while on Easy difficulty 
Increase resource multiplier on Esay to 1.00 (up from 0.85) 
Increase resource multiplier on Hard difficulty to 1.20 (up from 1.15)

The goal is to make fights on easy more fun by having the player encounter more interesting and varied enemy types.
The slight increase for the Hard difficulty is meant to make the 3 difficulties slightly more distinct. I feel that 15% difference is not quite enough