### PR TITLE
feat: add player and target party strength to party and location tooltip

### DIFF
--- a/mod_reforged/hooks/entity/world/location.nut
+++ b/mod_reforged/hooks/entity/world/location.nut
@@ -17,6 +17,21 @@
 		::World.State.setPause(true);
 	}
 
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		if (!this.isHiddenToPlayer() && this.m.Troops.len() != 0 && this.getFaction() != 0)
+		{
+			ret.push({
+				id = 100,
+				type = "text",
+				icon = "ui/icons/icon_contract_swords.png",
+				text = format("Strength: %s / %s", ::MSU.Text.colorGreen(::World.State.getPlayer().getStrength()), ::MSU.Text.colorRed(this.getStrength()))
+			});
+		}
+		return ret;
+	}
+
 // New Functions
 	q.adjustBannerOffset <- function()	// This has to be called everytime that a brush for the banner sprite is set because that will reset the previous offset
 	{

--- a/mod_reforged/hooks/entity/world/party.nut
+++ b/mod_reforged/hooks/entity/world/party.nut
@@ -1,0 +1,16 @@
+::Reforged.HooksMod.hook("scripts/entity/world/party", function(q) {
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		if (!this.isHiddenToPlayer() && this.m.Troops.len() != 0)
+		{
+			ret.push({
+				id = 100,
+				type = "text",
+				icon = "ui/icons/icon_contract_swords.png",
+				text = format("Strength: %s / %s", ::MSU.Text.colorGreen(::World.State.getPlayer().getStrength()), ::MSU.Text.colorRed(this.getStrength()))
+			});
+		}
+		return ret;
+	}
+});


### PR DESCRIPTION
This is a helpful tool during the beta test to allow us to better judge the feedback about the spawns. Note: Right now it shows the strength even for parties for whom the troop composition is unknown - this is intended because we want to know the party strength for our data and feedback purposes even if the target party composition is unknown before attacking them.