### PR TITLE
feat: add support for skill-specific ReachBonus

### DIFF
--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/skills/skill", function(q) {
+	q.m.ReachBonus <- 0;	// Additional Reach granted by this skill during its use. Similar to the vanilla 'HitChanceBonus' except that it actually applies the bonus be default
+
 	q.isDuelistValid <- function()
 	{
 		return this.isAttack() && !this.isRanged() && this.getBaseValue("ActionPointCost") <= 4 && this.getBaseValue("MaxRange") == 1;
@@ -77,6 +79,16 @@
 		}
 
 		return ret;
+	}
+
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		if (_skill == this)
+		{
+			_properties.Reach += this.m.ReachBonus;
+		}
+
+		__original(_skill, _targetEntity, _properties);
 	}
 });
 


### PR DESCRIPTION
This feature will allow us to have different reach values for the attacks that a weapon provide.
Most notable the thrust attacks with Halberds or Goedendags might have +1 Reach compared to their Slash/Bludgeon attacks.

Similar to how we have different Action Point costs for the same skill by changing them from inside the weapon, we can now have the same thing for Reach values.

## Todo

- Automatically generated tooltip line?