### PR TITLE
feat: increase town interaction range while on a caravan mission

### DIFF
--- a/mod_reforged/hooks/config/tip_of_the_day.nut
+++ b/mod_reforged/hooks/config/tip_of_the_day.nut
@@ -19,7 +19,7 @@ for (local index = (::Const.TipOfTheDay.len() - 1); index >= 0; index--)
 }
 
 ::Const.TipOfTheDay.extend([
-    "You can interact with towns while on a caravan mission.",
+    "You can enter towns while on a caravan mission; even if they are 2 tiles away.",
     "The Mod Options have a lot of customizations regarding quality of life.",
     "Morale Checks are harder for every adjacent enemy and easier for every adjacent ally.",
     "Click on an active contract to focus on its target on the world map, if it is known to you.",

--- a/mod_reforged/hooks/config/tip_of_the_day.nut
+++ b/mod_reforged/hooks/config/tip_of_the_day.nut
@@ -19,7 +19,7 @@ for (local index = (::Const.TipOfTheDay.len() - 1); index >= 0; index--)
 }
 
 ::Const.TipOfTheDay.extend([
-    "You can enter towns while on a caravan mission; even if they are 2 tiles away.",
+	"You can enter towns while on a caravan mission, even if they are 2 tiles away.",
     "The Mod Options have a lot of customizations regarding quality of life.",
     "Morale Checks are harder for every adjacent enemy and easier for every adjacent ally.",
     "Click on an active contract to focus on its target on the world map, if it is known to you.",

--- a/mod_reforged/hooks/states/world_state.nut
+++ b/mod_reforged/hooks/states/world_state.nut
@@ -17,14 +17,16 @@
 	q.onMouseInput = @(__original) function( _mouse )
 	{
 		local ret = __original(_mouse);
+
+		// Hook, in order to increase the interaction range with towns while on a caravan mission
 		if (ret == false)	// If the original function wasn't able to process the mouseclick we try to do that with increased interaction range
 		{
-			local isEscorting = this.m.EscortedEntity != null && !this.m.EscortedEntity.isNull();
-			if (isEscorting && _mouse.getState() == 1 && !this.isInCameraMovementMode() && !this.m.WasInCameraMovementMode)
+			if (!::MSU.isNull(this.m.EscortedEntity) && _mouse.getState() == 1 && !this.isInCameraMovementMode() && !this.m.WasInCameraMovementMode)
 			{
 				foreach (entity in ::World.getAllEntitiesAndOneLocationAtPos(::World.getCamera().screenToWorld(_mouse.getX(), _mouse.getY()), 1.0))
 				{
-					if (entity.isParty()) continue;
+
+					if (!::MSU.isKindOf(_s, "settlement")) continue;
 					if (!entity.isEnterable()) continue;
 					if (!entity.isAlliedWithPlayer()) continue;
 

--- a/mod_reforged/hooks/states/world_state.nut
+++ b/mod_reforged/hooks/states/world_state.nut
@@ -13,4 +13,30 @@
 
     	return __original(_properties, _isPlayerInitiated, _isCombatantsVisible, _allowFormationPicking);
     }
+
+	q.onMouseInput = @(__original) function( _mouse )
+	{
+		local ret = __original(_mouse);
+		if (ret == false)	// If the original function wasn't able to process the mouseclick we try to do that with increased interaction range
+		{
+			local isEscorting = this.m.EscortedEntity != null && !this.m.EscortedEntity.isNull();
+			if (isEscorting && _mouse.getState() == 1 && !this.isInCameraMovementMode() && !this.m.WasInCameraMovementMode)
+			{
+				foreach (entity in ::World.getAllEntitiesAndOneLocationAtPos(::World.getCamera().screenToWorld(_mouse.getX(), _mouse.getY()), 1.0))
+				{
+					if (entity.isParty()) continue;
+					if (!entity.isEnterable()) continue;
+					if (!entity.isAlliedWithPlayer()) continue;
+
+					if (this.m.Player.getDistanceTo(entity) <= 200)		// Vanilla uses ::Const.World.CombatSettings.CombatPlayerDistance here which equals to 100 by default
+					{
+						this.enterLocation(entity);
+						return true;
+					}
+				}
+			}
+		}
+
+		return ret;
+	}
 });


### PR DESCRIPTION
This is done by replicating the important conditions for this kind of click. 

At the very end, we skip checking for whether player and target are on the same tile and also check for the increased range