### PR TITLE
refactor: change the way that the retinue_slot_event will spawn

### DIFF
--- a/mod_reforged/hooks/events/special/retinue_slot_event.nut
+++ b/mod_reforged/hooks/events/special/retinue_slot_event.nut
@@ -1,0 +1,6 @@
+::Reforged.HooksMod.hook("scripts/events/events/special/retinue_slot_event", function (q) {
+	q.onUpdateScore = @() function()
+	{
+		return;		// This event no longer spawns naturally. Instead we fire it during the checkDesertion() check
+	}
+});

--- a/mod_reforged/hooks/states/world/asset_manager.nut
+++ b/mod_reforged/hooks/states/world/asset_manager.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/states/world/asset_manager", function(q) {
+	q.checkDesertion = @(__original) function()
+	{
+		__original();
+		if (!::World.Events.canFireEvent()) return;
+
+		local event = ::World.Events.getEvent("event.retinue_slot");
+		local unlockedSlots = ::World.Retinue.getNumberOfUnlockedSlots();
+		if (unlockedSlots > event.m.LastSlotsUnlocked && ::World.Retinue.getNumberOfCurrentFollowers() < unlockedSlots)
+		{
+			::World.Events.fire("event.retinue_slot", false);
+		}
+	}
+});


### PR DESCRIPTION
The retinue slot event has a 400 Score and almost always takes priority over regular events. It also replaces a regular random Event whenever it proccs.

This PR prevents the event from ever spawning randomly.

Instead we spawn it deterministically the moment you have a Retinue Slot unlocked right after the vanilla checkDesertion happens.