### PR TITLE
refactor(balance): increase damage of wooden flail

### DIFF
--- a/mod_reforged/hooks/items/weapons/wooden_flail.nut
+++ b/mod_reforged/hooks/items/weapons/wooden_flail.nut
@@ -2,6 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
+		this.m.RegularDamage += 5;
+		this.m.RegularDamageMax += 5;
 		this.m.Reach = 2;
 	}
 


### PR DESCRIPTION
As discussed yesterday, this PR will buff the minimum and maximum damage of the wooden flail by +5 to bring it in line with the wooden stick and the knife.