### PR TITLE
refactor: allow castle-helmet noble helmet to appear again

### DIFF
--- a/mod_reforged/hooks/factions/faction_manager.nut
+++ b/mod_reforged/hooks/factions/faction_manager.nut
@@ -1,0 +1,20 @@
+::Reforged.HooksMod.hook("scripts/factions/faction_manager", function (q) {
+	q.createNobleHouses = @(__original) function()
+	{
+		// Switcheroo to allow the castle helmet faction to also appear
+		local oldMathRand = ::Math.rand;
+		::Math.rand = function( _min, _max )
+		{
+			if (_min == 2 && _max == 10) _min = 1;	// In vanilla only noble faction layouts 2 - 10 are considered. 1 is skipped. We fix that here.
+
+			return oldMathRand(_min, _max);
+		}
+
+		local ret = __original();
+
+		// Revert Switcheroo
+		::Math.rand = oldMathRand;
+
+		return ret;
+	}
+});


### PR DESCRIPTION
At some point this faction was "disabled" or just skipped to ever appear ingame randomly. Their custom art still exists but is unused ever since.

Instead of rewriting the whole vanilla function this hook switcheroos out the ::Math.rand function very briefly during the generation of a new map only.

![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/8236985f-920f-468a-a1ef-fc2c501fde0a)

I tested it ingame and after several tries, the castle faction finally appeared.