### PR TITLE
refactor: require atleast 1 hitpoint damage for cull to trigger

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -951,7 +951,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Type = ::UPD.EffectType.Passive,
 			Description = [
 				"Maximum Damage is increased by " + ::MSU.Text.colorGreen("10%") + " of the Maximum Damage of the currently equipped axe.",
-				"Hits to the head will instantly kill a target that has less than " + ::MSU.Text.colorRed("33%") + " [Hitpoints|Concept.Hitpoints] remaining after the hit.",
+				"Hits to the head which inflict at least 1 damage to [Hitpoints|Concept.Hitpoints] will instantly kill a target that has less than " + ::MSU.Text.colorRed("33%") + " [Hitpoints|Concept.Hitpoints] remaining after the hit.",
 				"Ignores [Nine Lives|Perk+perk_nine_lives] on the target.",
 				"If killed via culling, [decapitates|Concept.Fatality] the target.",
 				"Targets who have [Steel Brow|Perk+perk_steel_brow] or are under the effects of [Indomitable|NullEntitySkill+indomitable_effect] are immune to being culled."

--- a/scripts/skills/perks/perk_rf_cull.nut
+++ b/scripts/skills/perks/perk_rf_cull.nut
@@ -44,7 +44,7 @@ this.perk_rf_cull <- ::inherit("scripts/skills/skill", {
 
 	function onTargetHit( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
 	{
-		if (_bodyPart != ::Const.BodyPart.Head || !_skill.isAttack() || !this.isEnabled() || !_targetEntity.isAlive() || _targetEntity.isDying() || _targetEntity.getSkills().hasSkill("effects.indomitable") || _targetEntity.getSkills().hasSkill("perk.steel_brow"))
+		if (_damageInflictedHitpoints == 0 || _bodyPart != ::Const.BodyPart.Head || !_skill.isAttack() || !this.isEnabled() || !_targetEntity.isAlive() || _targetEntity.isDying() || _targetEntity.getSkills().hasSkill("effects.indomitable") || _targetEntity.getSkills().hasSkill("perk.steel_brow"))
 		{
 			return;
 		}


### PR DESCRIPTION
This will prevent all kinds of weird interactions where non-damaging attacks were able to procc cull.
Not only can that be a balancing concern with cheap attacks but it can also lead to crashes with skills that never expect the target to suddenly be dead after being used on it