### PR TITLE
Rework angler perk and net pull skill

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -711,13 +711,13 @@ foreach (vanillaDesc in vanillaDescriptions)
  			{
  				Type = ::UPD.EffectType.Passive,
  				Description = [
- 					"Enemies have a " + ::MSU.Text.colorRed("-20%") + " chance to break from from nets you throw."
+ 					"Enemies [netted|Skill+net_effect] by you have a " + ::MSU.Text.colorRed("50%") + " increased [Action Point|Concept.ActionPoints] cost for using the [Break Free|Skill+break_free_skill] skill."
  				]
  			},
  			{
  				Type = ::UPD.EffectType.Active,
  				Description = [
- 					"Unlocks the [Net Pull|Skill+rf_net_pull_skill] skill that allows you to pull a target and net it, but does not gain the passive " + ::MSU.Text.colorRed("-20%") + " chance to break free."
+ 					"Unlocks the [Net Pull|Skill+rf_net_pull_skill] skill that allows you to pull a target and [net|Skill+net_effect] it."
  				]
  			}
  		]

--- a/scripts/skills/actives/rf_net_pull_skill.nut
+++ b/scripts/skills/actives/rf_net_pull_skill.nut
@@ -51,6 +51,12 @@ this.rf_net_pull_skill <- ::inherit("scripts/skills/skill", {
 			icon = "ui/icons/special.png",
 			text = "Has a [color=" + ::Const.UI.Color.PositiveValue + "]100%[/color] chance to net on a hit"
 		});
+		ret.push({
+			id = 12,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Has a " + ::MSU.Text.colorGreen("100%") " chance to [stagger|Skill+staggered_effect] on a hit")
+		});
 		return ret;
 	}
 
@@ -162,12 +168,16 @@ this.rf_net_pull_skill <- ::inherit("scripts/skills/skill", {
 		_entity.onDamageReceived(_tag.Attacker, _tag.Skill, _tag.HitInfo);
 
 		if (_entity.isAlive())
-			this.getContainer().getSkillByID("actives.throw_net").onUse(_tag.Attacker, _tag.TargetTile);
+		{
+			this.getContainer().getSkillByID("actives.throw_net").useForFree(_tag.TargetTile);
+			_entity.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
+		}
 	}
 
 	function onHookingComplete( _entity, _tag )
 	{
-		this.getContainer().getSkillByID("actives.throw_net").onUse(_tag.Attacker, _tag.TargetTile);
+		this.getContainer().getSkillByID("actives.throw_net").useForFree(_tag.TargetTile);
+		_entity.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
 		_tag.Attacker.setDirty(true);
 	}
 });

--- a/scripts/skills/actives/rf_net_pull_skill.nut
+++ b/scripts/skills/actives/rf_net_pull_skill.nut
@@ -109,7 +109,11 @@ this.rf_net_pull_skill <- ::inherit("scripts/skills/skill", {
 
 	function onVerifyTarget( _originTile, _targetTile )
 	{
-		return this.skill.onVerifyTarget(_originTile, _targetTile) && !_targetTile.getEntity().getCurrentProperties().IsRooted && !_targetTile.getEntity().getCurrentProperties().IsImmuneToKnockBackAndGrab && this.getPulledToTile(_originTile, _targetTile) != null;
+		if (!this.skill.onVerifyTarget(_originTile, _targetTile))
+			return false;
+
+		local targetProperties = _targetTile.getEntity().getCurrentProperties();
+		return !targetProperties.IsRooted && !targetProperties.IsImmuneToKnockBackAndGrab && !targetProperties.IsImmuneToRoot && this.getPulledToTile(_originTile, _targetTile) != null;
 	}
 
 	function onUse( _user, _targetTile )

--- a/scripts/skills/actives/rf_net_pull_skill.nut
+++ b/scripts/skills/actives/rf_net_pull_skill.nut
@@ -169,14 +169,14 @@ this.rf_net_pull_skill <- ::inherit("scripts/skills/skill", {
 
 		if (_entity.isAlive())
 		{
-			this.getContainer().getSkillByID("actives.throw_net").useForFree(_tag.TargetTile);
+			_tag.Attacker.getSkills().getSkillByID("actives.throw_net").useForFree(_tag.TargetTile);
 			_entity.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
 		}
 	}
 
 	function onHookingComplete( _entity, _tag )
 	{
-		this.getContainer().getSkillByID("actives.throw_net").useForFree(_tag.TargetTile);
+		_tag.Attacker.getSkills().getSkillByID("actives.throw_net").useForFree(_tag.TargetTile);
 		_entity.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
 		_tag.Attacker.setDirty(true);
 	}

--- a/scripts/skills/actives/rf_net_pull_skill.nut
+++ b/scripts/skills/actives/rf_net_pull_skill.nut
@@ -109,7 +109,7 @@ this.rf_net_pull_skill <- ::inherit("scripts/skills/skill", {
 
 	function onVerifyTarget( _originTile, _targetTile )
 	{
-		return this.skill.onVerifyTarget(_originTile, _targetTile) && !_targetTile.getEntity().getCurrentProperties().IsRooted && _targetTile.getEntity().getCurrentProperties().IsImmuneToKnockBackAndGrab && this.getPulledToTile(_originTile, _targetTile) != null;
+		return this.skill.onVerifyTarget(_originTile, _targetTile) && !_targetTile.getEntity().getCurrentProperties().IsRooted && !_targetTile.getEntity().getCurrentProperties().IsImmuneToKnockBackAndGrab && this.getPulledToTile(_originTile, _targetTile) != null;
 	}
 
 	function onUse( _user, _targetTile )

--- a/scripts/skills/perks/perk_rf_angler.nut
+++ b/scripts/skills/perks/perk_rf_angler.nut
@@ -24,6 +24,12 @@ this.perk_rf_angler <- ::inherit("scripts/skills/skill", {
 		}
 	}
 
+	function onAdded()
+	{
+		local offhand = this.getContainer().getActor().getOffhandItem();
+		if (offhand != null) this.onEquip(offhand);
+	}
+
 	function onEquip( _item )
 	{
 		if (_item.getSlotType() == ::Const.ItemSlot.Offhand && this.getContainer().hasSkill("actives.throw_net"))

--- a/scripts/skills/perks/perk_rf_angler.nut
+++ b/scripts/skills/perks/perk_rf_angler.nut
@@ -1,5 +1,7 @@
 this.perk_rf_angler <- ::inherit("scripts/skills/skill", {
-	m = {},
+	m = {
+		BreakFreeAPCostMult = 1.5
+	},
 	function create()
 	{
 		this.m.ID = "perk.rf_angler";
@@ -15,9 +17,10 @@ this.perk_rf_angler <- ::inherit("scripts/skills/skill", {
 
 	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
 	{
-		if (_skill.getID() == "actives.throw_net" && !_forFree)
+		if (_skill.getID() == "actives.throw_net")
 		{
-			_targetEntity.getSkills().getSkillByID("actives.break_free").m.ChanceBonus -= 20;
+			local breakFreeSkill = _targetEntity.getSkills().getSkillByID("actives.break_free");
+			breakFreeSkill.setBaseValue("ActionPointCost", ::Math.floor(breakFreeSkill.getBaseValue("ActionPointCost") * this.m.BreakFreeAPCostMult));
 		}
 	}
 


### PR DESCRIPTION
- Increase AP cost of Break Free skill on target by 1.5
- Apply Stagger via Net Pull
- Call useForFree instead of onUse in Net Pull to trigger an actual skill use function call relevant for next point:
- Allow angler to work with free usages of Throw Net (e.g. via net pull)

Also includes a few bug-fix commits.