### PR TITLE
Mentors presence tweaks

### DIFF
--- a/scripts/skills/effects/rf_mentors_presence_effect.nut
+++ b/scripts/skills/effects/rf_mentors_presence_effect.nut
@@ -162,7 +162,7 @@ this.rf_mentors_presence_effect <- ::inherit("scripts/skills/skill", {
 
 	function onTurnStart()
 	{
-		if (::MSU.isNull(this.m.Mentor))
+		if (::MSU.isNull(this.m.Mentor) || this.m.Mentor.getMoraleState() == ::Const.MoraleState.Fleeing)
 			return;
 
 		local actor = this.getContainer().getActor();

--- a/scripts/skills/perks/perk_rf_mentor.nut
+++ b/scripts/skills/perks/perk_rf_mentor.nut
@@ -67,6 +67,9 @@ this.perk_rf_mentor <- ::inherit("scripts/skills/skill", {
 	function onStudentDeath( _fatalityType )
 	{
 		local actor = this.getContainer().getActor();
+		if (actor.getMoraleState() == ::Const.MoraleState.Fleeing || actor.getCurrentProperties().IsStunned)
+			return;
+
 		local adrenaline = ::new("scripts/skills/effects/adrenaline_effect");
 		if (!actor.isTurnStarted() && !actor.isTurnDone())
 		{


### PR DESCRIPTION
- As mentor: Don't gain bonuses from student's death when you are fleeing or stunned
- As student: Don't gain morale bonus at turn start when mentor is fleeing