### PR TITLE
refactor: require recover to re-enable fresh and furious

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1203,8 +1203,8 @@ foreach (vanillaDesc in vanillaDescriptions)
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"As long as your current [Fatigue|Concept.Fatigue] is below " + ::MSU.Text.colorRed("30%") + " of [Maximum Fatigue|Concept.MaximumFatigue] after gear, the [Action Point|Concept.ActionPoints] cost of the first skill used every [turn|Concept.Turn] is " + ::MSU.Text.colorGreen("halved") + ".",
-				"Does not expire when using a skill with no [Action Point|Concept.ActionPoints] and [Fatigue|Concept.Fatigue] cost."
+				"The [Action Point|Concept.ActionPoints] cost of the first non-free skill used every [turn|Concept.Turn] is " + ::MSU.Text.colorGreen("halved") + ".",
+				"The effect becomes disabled if you start a [turn|Concept.Turn] with " + ::MSU.Text.colorRed("30%") + " or more [Fatigue|Concept.Fatigue] built and remains disabled until you use [Recover|Skill+recover]."
 			]
 		}]
  	}),

--- a/scripts/skills/perks/perk_rf_fresh_and_furious.nut
+++ b/scripts/skills/perks/perk_rf_fresh_and_furious.nut
@@ -64,7 +64,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 
 	function onAfterUpdate( _properties )
 	{
-		if (!this.m.IsSpent && !this.m.RequiresRecover && this.isEnabled())
+		if (!this.m.IsSpent && !this.m.RequiresRecover)
 		{
 			foreach (skill in this.getContainer().getAllSkillsOfType(::Const.SkillType.Active))
 			{

--- a/scripts/skills/perks/perk_rf_fresh_and_furious.nut
+++ b/scripts/skills/perks/perk_rf_fresh_and_furious.nut
@@ -1,7 +1,9 @@
 this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 	m = {
 		IsUsingFreeSkill = false,
-		IsSpent = true
+		IsSpent = true,
+		RequiresRecover = false,
+		FatigueThreshold = 0.3
 	},
 	function create()
 	{
@@ -45,7 +47,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 
 	function isEnabled()
 	{
-		return this.getContainer().getActor().getFatigue() < 0.3 * this.getContainer().getActor().getFatigueMax();
+		return !this.m.RequiresRecover && this.getContainer().getActor().getFatigue() < this.m.FatigueThreshold * this.getContainer().getActor().getFatigueMax();
 	}
 
 	function onAfterUpdate( _properties )
@@ -83,16 +85,23 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
 	{
 		this.m.IsSpent = !this.m.IsUsingFreeSkill;
+
+		if (_skill.getID() == "actives.recover")
+			this.m.RequiresRecover = false;
 	}
 
 	function onTurnStart()
 	{
 		this.m.IsSpent = false;
+
+		if (this.getContainer().getActor().getFatigue() >= this.m.FatigueThreshold * this.getContainer().getActor().getFatigueMax())
+			this.m.RequiresRecover = true;
 	}
 
 	function onCombatFinished()
 	{
 		this.skill.onCombatFinished();
 		this.m.IsSpent = true;
+		this.m.RequiresRecover = false;
 	}
 });

--- a/scripts/skills/perks/perk_rf_fresh_and_furious.nut
+++ b/scripts/skills/perks/perk_rf_fresh_and_furious.nut
@@ -13,12 +13,13 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		this.m.Description = "This character is exceptionally fast when not fatigued.";
 		this.m.Icon = "ui/perks/rf_fresh_and_furious.png";
 		this.m.IconMini = "rf_fresh_and_furious_mini";
-		this.m.IconMiniBackup = this.m.IconMini;
 		this.m.Type = ::Const.SkillType.Perk | ::Const.SkillType.StatusEffect;
 		this.m.Order = ::Const.SkillOrder.Any;
 		this.m.IsActive = false;
 		this.m.IsStacking = false;
 		this.m.IsHidden = false;
+
+		this.m.IconMiniBackup = this.m.IconMini;
 	}
 
 	function isHidden()

--- a/scripts/skills/perks/perk_rf_fresh_and_furious.nut
+++ b/scripts/skills/perks/perk_rf_fresh_and_furious.nut
@@ -64,11 +64,6 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		return tooltip;
 	}
 
-	function isEnabled()
-	{
-		return this.getContainer().getActor().getFatigue() < this.m.FatigueThreshold * this.getContainer().getActor().getFatigueMax();
-	}
-
 	function onAfterUpdate( _properties )
 	{
 		if (!this.m.IsSpent && !this.m.RequiresRecover)
@@ -113,7 +108,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 	{
 		this.m.IsSpent = false;
 
-		if (this.isEnabled())
+		if (this.getContainer().getActor().getFatigue() < this.m.FatigueThreshold * this.getContainer().getActor().getFatigueMax())
 		{
 			this.m.Icon = ::Const.Perks.findById(this.getID()).Icon;
 			this.m.IconMini = this.m.IconMiniBackup;

--- a/scripts/skills/perks/perk_rf_fresh_and_furious.nut
+++ b/scripts/skills/perks/perk_rf_fresh_and_furious.nut
@@ -4,6 +4,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		IsSpent = true,
 		RequiresRecover = false,
 		FatigueThreshold = 0.3
+		IconMiniBackup = ""
 	},
 	function create()
 	{
@@ -12,6 +13,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		this.m.Description = "This character is exceptionally fast when not fatigued.";
 		this.m.Icon = "ui/perks/rf_fresh_and_furious.png";
 		this.m.IconMini = "rf_fresh_and_furious_mini";
+		this.m.IconMiniBackup = this.m.IconMini;
 		this.m.Type = ::Const.SkillType.Perk | ::Const.SkillType.StatusEffect;
 		this.m.Order = ::Const.SkillOrder.Any;
 		this.m.IsActive = false;
@@ -21,7 +23,12 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 
 	function isHidden()
 	{
-		return this.m.IsSpent || !this.isEnabled();
+		return this.m.IsSpent;
+	}
+
+	function getName()
+	{
+		return this.m.RequiresRecover ? this.m.Name + " (Disabled)" : this.m.Name;
 	}
 
 	function getTooltip()
@@ -109,11 +116,13 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		if (this.isEnabled())
 		{
 			this.m.Icon = ::Const.Perks.findById(this.getID()).Icon;
+			this.m.IconMini = this.m.IconMiniBackup;
 		}
 		else
 		{
 			this.m.RequiresRecover = true;
 			this.m.Icon = ::Const.Perks.findById(this.getID()).IconDisabled;
+			this.m.IconMini = "";
 		}
 	}
 

--- a/scripts/skills/perks/perk_rf_fresh_and_furious.nut
+++ b/scripts/skills/perks/perk_rf_fresh_and_furious.nut
@@ -34,7 +34,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/warning.png",
-				text = ::MSU.Text.colorRed("Disabled until this character uses [Recover|Skill+recover]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorRed("Disabled until this character uses [Recover|Skill+recover]"))
 			});
 		}
 		else
@@ -43,7 +43,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 				id = 11,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "The next non-free skill used has its Action Point cost [color=" + ::Const.UI.Color.PositiveValue + "]halved[/color]"
+				text = ::Reforged.Mod.Tooltips.parseString("The next non-free skill used has its [Action Point|Concept.ActionPoints] cost " + ::MSU.Text.colorGreen("halved"))
 			});
 		}
 
@@ -99,18 +99,18 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		this.m.IsSpent = !this.m.IsUsingFreeSkill;
 
 		if (_skill.getID() == "actives.recover")
-		{
 			this.m.RequiresRecover = false;
-			if (this.isEnabled())
-				this.m.Icon = ::Const.Perks.findById(this.getID()).Icon;
-		}
 	}
 
 	function onTurnStart()
 	{
 		this.m.IsSpent = false;
 
-		if (this.getContainer().getActor().getFatigue() >= this.m.FatigueThreshold * this.getContainer().getActor().getFatigueMax())
+		if (this.isEnabled())
+		{
+			this.m.Icon = ::Const.Perks.findById(this.getID()).Icon;
+		}
+		else
 		{
 			this.m.RequiresRecover = true;
 			this.m.Icon = ::Const.Perks.findById(this.getID()).IconDisabled;


### PR DESCRIPTION
Now checks fatigue against the threshold at the start of a turn. So going above the threshold during a turn will not disable it (i.e. require recover to re-activate it) as long as you can start your next turn below the threshold.