### PR TITLE
feat: new enemy-only headless perk

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/kraken_tentacle.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/kraken_tentacle.nut
@@ -34,6 +34,7 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastLarge;
+		this.getSkills().add(::new("scripts/skills/perks/rf_perk_headless"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_crippling_strikes"));
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/lindwurm_tail.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/lindwurm_tail.nut
@@ -65,6 +65,7 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastHuge;
+		this.getSkills().add(::new("scripts/skills/perks/rf_perk_headless"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_sweeping_strikes"));
 		if (::Reforged.Config.IsLegendaryDifficulty)
     	{

--- a/mod_reforged/hooks/entity/tactical/enemies/sand_golem.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/sand_golem.nut
@@ -37,6 +37,7 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastSmall + 1;
+		this.getSkills().add(::new("scripts/skills/perks/rf_perk_headless"));
 		this.m.Skills.add(::MSU.new("scripts/skills/perks/perk_rf_concussive_strikes", function(o) {
     		o.m.IsForceEnabled = true;
 			o.m.IsForceMace = true;

--- a/mod_reforged/hooks/entity/tactical/enemies/schrat_small.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/schrat_small.nut
@@ -38,6 +38,7 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastSmall;
+		this.getSkills().add(::new("scripts/skills/perks/rf_perk_headless"));
 		this.m.Skills.add(this.new("scripts/skills/actives/rf_schrat_small_root_skill"));
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/spider_eggs.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/spider_eggs.nut
@@ -29,6 +29,7 @@
 
 		//Reforged
 		this.m.BaseProperties.IsAffectedByReach = false;
+		this.getSkills().add(::new("scripts/skills/perks/rf_perk_headless"));
 		this.getSkills().update()
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/zombie_knight.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/zombie_knight.nut
@@ -67,6 +67,15 @@
     	}
 	}
 
+	q.onResurrected = @(__original) function( _info)
+	{
+		__original(_info);
+		if (!_info.IsHeadAttached)
+		{
+			this.getSkills().add(::new("scripts/skills/perks/perk_rf_headless"));
+		}
+	}
+
 	q.makeMiniboss = @(__original) function()
 	{
 		local ret = __original();

--- a/scripts/skills/perks/perk_rf_headless.nut
+++ b/scripts/skills/perks/perk_rf_headless.nut
@@ -1,0 +1,34 @@
+this.perk_rf_headless <- ::inherit("scripts/skills/skill", {
+	m = {},
+	function create()
+	{
+		this.m.ID = "perk.rf_headless";
+		this.m.Name = "Headless";
+		this.m.Description = "This character has no head.";
+		this.m.Icon = "ui/perks/rf_death_dealer.png";	// TODO
+		this.m.Type = ::Const.SkillType.Perk | ::Const.SkillType.StatusEffect;
+		this.m.Order = ::Const.SkillOrder.Perk;
+		this.m.IsActive = false;
+		this.m.IsStacking = false;
+		this.m.IsHidden = false;
+	}
+
+	function onBeforeDamageReceived( _attacker, _skill, _hitInfo, superCurrent )
+	{
+		_hitInfo.BodyPart = ::Const.BodyPart.Body;
+	}
+
+	function getTooltip()
+	{
+		local tooltip = this.skill.getTooltip();
+
+		tooltip.push({
+			id = 5,
+			type = "text",
+			icon = "ui/icons/chance_to_hit_head.png",
+			text = "Every incoming damage will hit the body"
+		});
+
+		return tooltip;
+	}
+});


### PR DESCRIPTION
This branch is currently pure QoL by displaying the player exactly which enemies are "headless" and therefor only damage body-hits. This is done by implementing a new **headless** perk, which re-directs all hits to the body.

Future headless enemies just need this perk instead of implementing the headless effect silently in the onDamageReceived function of that actor.

TODO:
- Icon for this perk