### PR TITLE
feat: double crafting output of throwables and lower value by about 30%

### DIFF
--- a/mod_reforged/hooks/crafting/blueprints/acid_flask_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/acid_flask_blueprint.nut
@@ -2,6 +2,6 @@
 	q.onCraft = @(__original) function( _stash )
 	{
 		__original(_stash);
-		_stash.add(::new("scripts/items/tools/acid_flask_item")); // crafting gives one additional yield over vanilla
+		_stash.add(::new(::IO.scriptFilenameByHash(this.m.PreviewCraftable.ClassNameHash))); // crafting gives one additional yield over vanilla
 	}
 });

--- a/mod_reforged/hooks/crafting/blueprints/acid_flask_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/acid_flask_blueprint.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/items/crafting/blueprints/acid_flask_blueprint", function(q) {
+	q.onCraft = @(__original) function( _stash )
+	{
+		__original(_stash);
+		_stash.add(::new("scripts/items/tools/acid_flask_item")); // crafting gives one additional yield over vanilla
+	}
+});

--- a/mod_reforged/hooks/crafting/blueprints/daze_bomb_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/daze_bomb_blueprint.nut
@@ -2,6 +2,6 @@
 	q.onCraft = @(__original) function( _stash )
 	{
 		__original(_stash);
-		_stash.add(::new("scripts/items/tools/daze_bomb_item")); // crafting gives one additional yield over vanilla
+		_stash.add(::new(::IO.scriptFilenameByHash(this.m.PreviewCraftable.ClassNameHash))); // crafting gives one additional yield over vanilla
 	}
 });

--- a/mod_reforged/hooks/crafting/blueprints/daze_bomb_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/daze_bomb_blueprint.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/items/crafting/blueprints/daze_bomb_blueprint", function(q) {
+	q.onCraft = @(__original) function( _stash )
+	{
+		__original(_stash);
+		_stash.add(::new("scripts/items/tools/daze_bomb_item")); // crafting gives one additional yield over vanilla
+	}
+});

--- a/mod_reforged/hooks/crafting/blueprints/fire_bomb_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/fire_bomb_blueprint.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/items/crafting/blueprints/fire_bomb_blueprint", function(q) {
+	q.onCraft = @(__original) function( _stash )
+	{
+		__original(_stash);
+		_stash.add(::new("scripts/items/tools/fire_bomb_item")); // crafting gives one additional yield over vanilla
+	}
+});

--- a/mod_reforged/hooks/crafting/blueprints/fire_bomb_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/fire_bomb_blueprint.nut
@@ -2,6 +2,6 @@
 	q.onCraft = @(__original) function( _stash )
 	{
 		__original(_stash);
-		_stash.add(::new("scripts/items/tools/fire_bomb_item")); // crafting gives one additional yield over vanilla
+		_stash.add(::new(::IO.scriptFilenameByHash(this.m.PreviewCraftable.ClassNameHash))); // crafting gives one additional yield over vanilla
 	}
 });

--- a/mod_reforged/hooks/crafting/blueprints/smoke_bomb_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/smoke_bomb_blueprint.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/items/crafting/blueprints/smoke_bomb_blueprint", function(q) {
+	q.onCraft = @(__original) function( _stash )
+	{
+		__original(_stash);
+		_stash.add(::new("scripts/items/tools/smoke_bomb_item")); // crafting gives one additional yield over vanilla
+	}
+});

--- a/mod_reforged/hooks/crafting/blueprints/smoke_bomb_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/smoke_bomb_blueprint.nut
@@ -2,6 +2,6 @@
 	q.onCraft = @(__original) function( _stash )
 	{
 		__original(_stash);
-		_stash.add(::new("scripts/items/tools/smoke_bomb_item")); // crafting gives one additional yield over vanilla
+		_stash.add(::new(::IO.scriptFilenameByHash(this.m.PreviewCraftable.ClassNameHash))); // crafting gives one additional yield over vanilla
 	}
 });

--- a/mod_reforged/hooks/items/tools/acid_flask_item.nut
+++ b/mod_reforged/hooks/items/tools/acid_flask_item.nut
@@ -1,5 +1,10 @@
-
 ::Reforged.HooksMod.hook("scripts/items/tools/acid_flask_item", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.Value = 275; // approximately 30% reduced from vanilla value of 400
+	}
+
 	q.onPutIntoBag <- function()
     {
 		local skill = ::new("scripts/skills/actives/rf_sling_acid_flask_skill");

--- a/mod_reforged/hooks/items/tools/daze_bomb_item.nut
+++ b/mod_reforged/hooks/items/tools/daze_bomb_item.nut
@@ -1,5 +1,10 @@
-
 ::Reforged.HooksMod.hook("scripts/items/tools/daze_bomb_item", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.Value = 350; // approximately 30% reduced from vanilla value of 500
+	}
+
 	q.onPutIntoBag <- function()
     {
 		local skill = ::new("scripts/skills/actives/rf_sling_daze_bomb_skill");

--- a/mod_reforged/hooks/items/tools/fire_bomb_item.nut
+++ b/mod_reforged/hooks/items/tools/fire_bomb_item.nut
@@ -1,5 +1,10 @@
-
 ::Reforged.HooksMod.hook("scripts/items/tools/fire_bomb_item", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.Value = 420; // approximately 30% reduced from vanilla value of 600
+	}
+
 	q.onPutIntoBag <- function()
     {
 		local skill = ::new("scripts/skills/actives/rf_sling_fire_bomb_skill");

--- a/mod_reforged/hooks/items/tools/smoke_bomb_item.nut
+++ b/mod_reforged/hooks/items/tools/smoke_bomb_item.nut
@@ -1,5 +1,10 @@
-
 ::Reforged.HooksMod.hook("scripts/items/tools/smoke_bomb_item", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.Value = 275; // approximately 30% reduced from vanilla value of 400
+	}
+
 	q.onPutIntoBag <- function()
     {
 		local skill = ::new("scripts/skills/actives/rf_sling_smoke_bomb_skill");


### PR DESCRIPTION
This primarily affects purchasing these items from the Alchemist buildings in the south. This change is based on player feedback as well as my own experience, having never bought those items at the Alchemist as they are far too expensive. Consider that the stated value in the file is still modified by buyprice modifiers of the faction/settlement.