### PR TITLE
refactor: rework arrow to the knee skill and effect

### DIFF
--- a/scripts/skills/actives/rf_arrow_to_the_knee_skill.nut
+++ b/scripts/skills/actives/rf_arrow_to_the_knee_skill.nut
@@ -1,91 +1,37 @@
-this.rf_arrow_to_the_knee_skill <- ::inherit("scripts/skills/skill", {
-	m = {
-		AdditionalAccuracy = 0,
-		AdditionalHitChance = -2
-	},
+this.rf_arrow_to_the_knee_skill <- ::inherit("scripts/skills/actives/quick_shot", {
+	m = {},
 	function create()
 	{
+		this.quick_shot.create();
 		this.m.ID = "actives.rf_arrow_to_the_knee";
 		this.m.Name = "Arrow to the Knee";
-		this.m.Description = "A debilitating shot aimed at the knees of your target, dealing reduced damage but reducing your target\'s Melee and Ranged defense and causing them to spend additional Action Points per tile moved.";
-		this.m.KilledString = "Shot";
+		this.m.Description = "A debilitating shot aimed at the knees of your target causing them to spend additional Action Points per tile moved.";
 		this.m.Icon = "skills/rf_arrow_to_the_knee_skill.png";
 		this.m.IconDisabled = "skills/rf_arrow_to_the_knee_skill_bw.png";
 		this.m.Overlay = "rf_arrow_to_the_knee_skill";
-		this.m.SoundOnUse = [
-			"sounds/combat/aimed_shot_01.wav",
-			"sounds/combat/aimed_shot_02.wav",
-			"sounds/combat/aimed_shot_03.wav"
-		];
-		this.m.SoundOnHit = [
-			"sounds/combat/arrow_hit_01.wav",
-			"sounds/combat/arrow_hit_02.wav",
-			"sounds/combat/arrow_hit_03.wav"
-		];
-		this.m.SoundOnHitShield = [
-			"sounds/combat/shield_hit_arrow_01.wav",
-			"sounds/combat/shield_hit_arrow_02.wav",
-			"sounds/combat/shield_hit_arrow_03.wav"
-		];
-		this.m.SoundOnMiss = [
-			"sounds/combat/arrow_miss_01.wav",
-			"sounds/combat/arrow_miss_02.wav",
-			"sounds/combat/arrow_miss_03.wav"
-		];
-		this.m.Type = ::Const.SkillType.Active;
-		this.m.Order = ::Const.SkillOrder.OffensiveTargeted;
-		this.m.Delay = 1000;
-		this.m.IsSerialized = false;
-		this.m.IsActive = true;
-		this.m.IsTargeted = true;
-		this.m.IsStacking = false;
-		this.m.IsAttack = true;
-		this.m.IsRanged = true;
-		this.m.IsWeaponSkill = true;
-		this.m.IsIgnoredAsAOO = true;
-		this.m.IsShowingProjectile = true;
-		this.m.IsDoingForwardMove = false;
-		this.m.InjuriesOnBody = ::Const.Injury.PiercingBody;
-		this.m.InjuriesOnHead = ::Const.Injury.PiercingHead;
-		this.m.DirectDamageMult = 0.4;
-		this.m.ActionPointCost = 7;
+		this.m.ActionPointCost = 4;
 		this.m.FatigueCost = 20;
-		this.m.MinRange = 1;
-		this.m.MaxRange = 7;
-		this.m.MaxLevelDifference = 4;
-		this.m.ProjectileType = ::Const.ProjectileType.Arrow;
+		this.m.AdditionalAccuracy = -10;
+		this.m.AdditionalHitChance = -4;
 	}
 
 	function getTooltip()
 	{
 		local tooltip = this.getRangedTooltip(this.getDefaultTooltip());
 
-		tooltip.extend([
-			{
-				id = 10,
-				type = "text",
-				icon = "ui/icons/damage_dealt.png",
-				text = "Deals [color=" + ::Const.UI.Color.NegativeValue + "]50%[/color] reduced damage"
-			},
-			{
-				id = 10,
-				type = "text",
-				icon = "ui/icons/special.png",
-				text = "Has a [color=" + ::Const.UI.Color.NegativeValue + "]0%[/color] chance to hit the head"
-			},
-			{
-				id = 10,
-				type = "text",
-				icon = "ui/icons/special.png",
-				text = "Target will have [color=" + ::Const.UI.Color.NegativeValue + "]-5[/color] Melee and Ranged defense for for 2 turns"
-			},
-			{
-				id = 10,
-				type = "text",
-				icon = "ui/icons/special.png",
-				text = "Target will require [color=" + ::Const.UI.Color.NegativeValue + "]2[/color] additional Action Points per tile moved for 2 turns"
-			}
-		]);
+		tooltip.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Will apply the [Arrow to the Knee|Skill+rf_arrow_to_the_knee_debuff_effect] on the target on a hit")
+		});
+
+		tooltip.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Will [Stagger|Skill+staggered_effect] the target on a hit")
+		});
 
 		local ammo = this.getAmmo();
 
@@ -121,94 +67,21 @@ this.rf_arrow_to_the_knee_skill <- ::inherit("scripts/skills/skill", {
 		return tooltip;
 	}
 
-	function isUsable()
-	{
-		return this.skill.isUsable() && this.getAmmo() > 0 && !this.getContainer().getActor().isEngagedInMelee();
-	}
-
-	function getAmmo()
-	{
-		local item = this.getContainer().getActor().getItems().getItemAtSlot(::Const.ItemSlot.Ammo);
-
-		if (item == null)
-		{
-			return 0;
-		}
-
-		if (item.getAmmoType() == ::Const.Items.AmmoType.Arrows)
-		{
-			return item.getAmmo();
-		}
-	}
-
-	function consumeAmmo()
-	{
-		local item = this.getContainer().getActor().getItems().getItemAtSlot(::Const.ItemSlot.Ammo);
-
-		if (item != null)
-		{
-			item.consumeAmmo();
-		}
-	}
-
-	function onAfterUpdate( _properties )
-	{
-		this.m.MaxRange = this.m.Item.getRangeMax() + (_properties.IsSpecializedInBows ? 1 : 0);
-		this.m.FatigueCostMult = _properties.IsSpecializedInBows ? ::Const.Combat.WeaponSpecFatigueMult : 1.0;
-	}
-
-	function onUse( _user, _targetTile )
-	{
-		this.consumeAmmo();
-
-		if (!_user.isHiddenToPlayer() || _targetTile.IsVisibleForPlayer)
-		{
-			this.getContainer().setBusy(true);
-			local tag = {
-				Skill = this,
-				User = _user,
-				TargetTile = _targetTile
-				TargetEntity = _targetTile.getEntity()
-			};
-			::Time.scheduleEvent(::TimeUnit.Virtual, this.m.Delay, this.onPerformAttack, tag);
-
-			if (!_user.isPlayerControlled() && _targetTile.getEntity().isPlayerControlled())
-			{
-				_user.getTile().addVisibilityForFaction(::Const.Faction.Player);
-			}
-
-			return true;
-		}
-		else
-		{
-			return this.attackEntity(_user, _targetTile.getEntity());
-		}
-	}
-
 	function onTargetHit( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
 	{
 		if (_skill == this && _targetEntity.isAlive())
 		{
 			_targetEntity.getSkills().add(::new("scripts/skills/effects/rf_arrow_to_the_knee_debuff_effect"));
+			_targetEntity.getSkills().add(::new("scripts/skills/effects/staggered_effect"));
 		}
-	}
-
-	function onPerformAttack( _tag )
-	{
-		_tag.Skill.getContainer().setBusy(false);
-		local ret = _tag.Skill.attackEntity(_tag.User, _tag.TargetTile.getEntity());
-		return ret;
 	}
 
 	function onAnySkillUsed( _skill, _targetEntity, _properties )
 	{
+		this.quick_shot.onAnySkillUsed(_skill, _targetEntity, _properties);
 		if (_skill == this)
 		{
-			_properties.RangedSkill += this.m.AdditionalAccuracy;
-			_properties.HitChanceAdditionalWithEachTile += this.m.AdditionalHitChance;
-			_properties.RangedDamageMult *= 0.5;
 			_properties.HitChanceMult[::Const.BodyPart.Head] *= 0.0;
 		}
 	}
 });
-

--- a/scripts/skills/effects/rf_arrow_to_the_knee_debuff_effect.nut
+++ b/scripts/skills/effects/rf_arrow_to_the_knee_debuff_effect.nut
@@ -2,7 +2,6 @@ this.rf_arrow_to_the_knee_debuff_effect <- ::inherit("scripts/skills/skill", {
 	m = {
 		StartingTurnsLeft = 2
 		TurnsLeft = 2
-		DefenseAdd = -5,
 		MovementAPCostAdditional = 2
 	},
 	function create()
@@ -23,26 +22,12 @@ this.rf_arrow_to_the_knee_debuff_effect <- ::inherit("scripts/skills/skill", {
 	{
 		local tooltip = this.skill.getTooltip();
 
-		tooltip.extend([
-			{
-				id = 10,
-				type = "text",
-				icon = "ui/icons/melee_defense.png",
-				text = ::MSU.Text.colorRed(this.m.DefenseAdd) + " Melee Defense"
-			},
-			{
-				id = 10,
-				type = "text",
-				icon = "ui/icons/ranged_defense.png",
-				text = ::MSU.Text.colorRed(this.m.DefenseAdd) + " Ranged Defense"
-			},
-			{
-				id = 10,
-				type = "text",
-				icon = "ui/icons/action_points.png",
-				text = ::MSU.Text.colorRed(this.m.MovementAPCostAdditional) + " additional Action Points per tile moved"
-			}
-		]);
+		tooltip.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/action_points.png",
+			text = ::MSU.Text.colorRed(this.m.MovementAPCostAdditional) + " additional Action Points per tile moved"
+		});
 
 		return tooltip;
 	}
@@ -54,8 +39,6 @@ this.rf_arrow_to_the_knee_debuff_effect <- ::inherit("scripts/skills/skill", {
 
 	function onUpdate( _properties )
 	{
-		_properties.MeleeDefense += this.m.DefenseAdd;
-		_properties.RangedDefense += this.m.DefenseAdd;
 		_properties.MovementAPCostAdditional += this.m.MovementAPCostAdditional;
 	}
 


### PR DESCRIPTION
- The active skill now inherits from quick_shot. This ensures that many effects which weren't properly accounted for in the original implementation but are implemented in vanilla e.g. _properties.IsSharpshooter are now automatically applied. Also cleans up the code quite a bit.
- Reduced AP cost to 4.
- Now applies Staggered effect as well.
- Removed defense malus from arrow to the knee debuff.