### PR TITLE
refactor: make throw net unusable on root immune targets

### DIFF
--- a/mod_reforged/hooks/skills/actives/throw_net.nut
+++ b/mod_reforged/hooks/skills/actives/throw_net.nut
@@ -4,4 +4,9 @@
 		__original();
 		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.ThrowNet;
 	}
+
+	q.onVerifyTarget = @(__original) function( _originTile, _targetTile )
+	{
+		return __original(_originTile, _targetTile) && !_targetTile.getEntity().getCurrentProperties().IsImmuneToRoot;
+	}
 });


### PR DESCRIPTION
In vanilla you can throw the net on such targets but it will "miss" i.e. you will lose the net and the target won't get netted. I suggest we make the net unusable on such targets.