### PR TITLE
refactor: rework concussive strikes

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -935,11 +935,12 @@ foreach (vanillaDesc in vanillaDescriptions)
  	}),
 	RF_ConcussiveStrikes = ::UPD.getDescription({
  		Fluff = "A strike to the head from this character means goodnight!",
+ 		Requirement = "Mace and Blunt Damage"
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Hits to the head with any weapon apply the [Dazed|Skill+dazed_effect] effect for 1 [turn|Concept.Turn]. This duration is increased to 2 [turns|Concept.Turn] for one-handed maces.",
-				"Hits to the head with two-handed maces apply the [Stunned|Skill+stunned_effect] for 1 [turn|Concept.Turn], and if the target is immune to being [stunned|Skill+stunned_effect], apply [Dazed|Skill+dazed_effect] for 1 [turn|Concept.Turn]."
+				"Hits to the head with one-handed maces apply the [Dazed|Skill+dazed_effect] effect for 1 [turn|Concept.Turn] and if the target is already [dazed|Skill+dazed_effect], apply [Stunned|Skill+stunned_effect] for one [turn|Concept.Turn].",
+				"Hits to the head with two-handed maces apply the [Stunned|Skill+stunned_effect] for 1 [turn|Concept.Turn].",
 			]
 		}]
  	}),

--- a/scripts/skills/perks/perk_rf_concussive_strikes.nut
+++ b/scripts/skills/perks/perk_rf_concussive_strikes.nut
@@ -1,7 +1,7 @@
 this.perk_rf_concussive_strikes <- ::inherit("scripts/skills/skill", {
 	m = {
 		IsForceEnabled = false,
-		IsForceMace = false,
+		RequiresWeapon = true,
 		IsForceTwoHanded = false
 	},
 	function create()
@@ -17,29 +17,33 @@ this.perk_rf_concussive_strikes <- ::inherit("scripts/skills/skill", {
 		this.m.IsHidden = false;
 	}
 
-	function isEnabled()
-	{
-		if (this.m.IsForceEnabled) return true;
-
-		if (this.getContainer().getActor().isDisarmed() || this.getContainer().getActor().getMainhandItem() == null) return false;
-
-		return true;
-	}
-
 	function onTargetHit( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
 	{
-		if (_bodyPart != ::Const.BodyPart.Head || !_skill.isAttack() || (!this.m.IsForceEnabled && !_skill.m.IsWeaponSkill) || !_targetEntity.isAlive() || _targetEntity.isDying() || !this.isEnabled())
-		{
+		if (_bodyPart != ::Const.BodyPart.Head || !_targetEntity.isAlive() || !this.isSkillValid(_skill))
 			return;
-		}
 
 		local actor = this.getContainer().getActor();
 		local weapon = actor.getMainhandItem();
-		local isMace = this.m.IsForceMace || (weapon != null && weapon.isWeaponType(::Const.Items.WeaponType.Mace));
+		local isTwoHanded = this.m.IsForceTwoHanded || (weapon != null && weapon.isItemType(::Const.Items.ItemType.TwoHanded));
 
-		if (isMace && (this.m.IsForceEnabled || _skill.getDamageType().contains(::Const.Damage.DamageType.Blunt)))
+		if (isTwoHanded)
 		{
-			if (this.m.IsForceTwoHanded || (weapon != null && weapon.isItemType(::Const.Items.ItemType.TwoHanded)))
+			if (!_targetEntity.getCurrentProperties().IsImmuneToStun)
+			{
+				if (!_targetEntity.getSkills().hasSkill("effects.stunned"))
+				{
+					_targetEntity.getSkills().add(::new("scripts/skills/effects/stunned_effect"));
+
+					if (!actor.isHiddenToPlayer() && _targetEntity.getTile().IsVisibleForPlayer)
+					{
+						::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(actor) + " has stunned " + ::Const.UI.getColorizedEntityName(_targetEntity) + " for one turn");
+					}
+				}
+			}
+		}
+		else
+		{
+			if (_targetEntity.getSkills().hasSkill("effects.dazed"))
 			{
 				if (!_targetEntity.getCurrentProperties().IsImmuneToStun)
 				{
@@ -58,22 +62,30 @@ this.perk_rf_concussive_strikes <- ::inherit("scripts/skills/skill", {
 			{
 				local effect = ::new("scripts/skills/effects/dazed_effect");
 				_targetEntity.getSkills().add(effect);
-				effect.setTurns(2);
+				effect.setTurns(1);
 				if (!actor.isHiddenToPlayer() && _targetEntity.getTile().IsVisibleForPlayer)
 				{
 					::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(actor) + " struck a blow that leaves " + ::Const.UI.getColorizedEntityName(_targetEntity) + " dazed for " + effect.m.TurnsLeft + " turns");
 				}
 			}
 		}
-		else if (!_targetEntity.getCurrentProperties().IsImmuneToDaze)
-		{
-			local effect = ::new("scripts/skills/effects/dazed_effect");
-			_targetEntity.getSkills().add(effect);
-			effect.setTurns(1);
-			if (!actor.isHiddenToPlayer() && _targetEntity.getTile().IsVisibleForPlayer)
-			{
-				::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(actor) + " struck a blow that leaves " + ::Const.UI.getColorizedEntityName(_targetEntity) + " dazed for " + effect.m.TurnsLeft + " turns");
-			}
-		}
+	}
+
+	function isSkillValid( _skill )
+	{
+		if (!_skill.isAttack())
+			return false;
+
+		if (this.m.IsForceEnabled)
+			return true;
+
+		if (!_skill.getDamageType().contains(::Const.Damage.DamageType.Blunt))
+			return false;
+
+		if (!this.m.RequiresWeapon)
+			return true;
+
+		local weapon = _skill.getItem();
+		return !::MSU.isNull(weapon) && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(::Const.Items.WeaponType.Mace);
 	}
 });


### PR DESCRIPTION
- Require mace and blunt damage
- 1h maces apply dazed and if already dazed then stun
- 2h maces apply stun