### PR TITLE
refactor: prevent nachzehrer from using swallow whole while netted

### DIFF
--- a/mod_reforged/hooks/skills/actives/swallow_whole_skill.nut
+++ b/mod_reforged/hooks/skills/actives/swallow_whole_skill.nut
@@ -1,4 +1,10 @@
 ::Reforged.HooksMod.hook("scripts/skills/actives/swallow_whole_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.Description = "Swallow an adjacent player controlled character. Cannot be used while netted.";
+	}
+
 	q.isUsable = @(__original) function()
 	{
 		if (this.getContainer().hasSkill("effects.net"))

--- a/mod_reforged/hooks/skills/actives/swallow_whole_skill.nut
+++ b/mod_reforged/hooks/skills/actives/swallow_whole_skill.nut
@@ -1,0 +1,11 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/swallow_whole_skill", function(q) {
+	q.isUsable = @(__original) function()
+	{
+		if (this.getContainer().hasSkill("effects.net"))
+		{
+			return false;
+		}
+
+		return __original();
+	}
+});


### PR DESCRIPTION
I brought up this idea a long time ago and I faintly remember that it was liked back then.

This change will give the player more tools to counter the swallow whole skill from nachzehrer. This will currently make those fights slightly easier but we can always adjust their power in other ways if this turns out problematic.