### PR TITLE
refactor: rework en garde perk

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1055,9 +1055,10 @@ foreach (vanillaDesc in vanillaDescriptions)
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"When wielding a sword, if you have not moved from your position during your [turn|Concept.Turn], use [Riposte|Skill+riposte] freely at the end of your [turn|Concept.Turn] if your weapon has [Riposte|Skill+riposte].",
-				"If your weapon does not have [Riposte|Skill+riposte] and is two-handed, gain the [Rebuke|Skill+rf_rebuke_effect] effect, with an additional chance of " + ::MSU.Text.colorGreen("+15%") + " for returning a missed attack, instead until the start of your next [turn|Concept.Turn]. The attacks triggered from this [Rebuke|Skill+rf_rebuke_effect] do not build [Fatigue|Concept.Fatigue].",
-				"Does not build any [Fatigue|Concept.Fatigue] or cost any [Action Points|Concept.ActionPoints] but only triggers if you have at least " + ::MSU.Text.colorRed(15) + " [Fatigue|Concept.Fatigue] remaining."
+				"The double grip bonus for southern swords is not disabled when using an offhand item with less than " + ::MSU.Text.colorRed("10") + " weight."
+				"Use [Riposte|Skill+riposte] freely at the end of your [turn|Concept.Turn] if your weapon has [Riposte|Skill+riposte]. If your weapon does not have [Riposte|Skill+riposte] and is two-handed, gain the [Rebuke|Skill+rf_rebuke_effect] effect instead for one [turn|Concept.Turn], with an additional chance of " + ::MSU.Text.colorGreen("+15%") + " for returning a missed attack. The attacks triggered from this [Rebuke|Skill+rf_rebuke_effect] do not build [Fatigue|Concept.Fatigue].",
+				"This perk only triggers if you have at least " + ::MSU.Text.colorRed(15) + " [Fatigue|Concept.Fatigue] remaining.",
+				"Does not cost any [Action Points|Concept.ActionPoints]. Additionally, does not build any [Fatigue|Concept.Fatigue] if you have not moved from your position during your [turn|Concept.Turn], otherwise builds " + ::MSU.Text.colorRed(15) + " [Fatigue|Concept.Fatigue]."
 			]
 		}]
  	}),

--- a/mod_reforged/hooks/skills/special/double_grip.nut
+++ b/mod_reforged/hooks/skills/special/double_grip.nut
@@ -9,6 +9,21 @@
 		this.m.Description = "With the second hand free, this character can adopt a more versatile fighting style or get a firm double grip on his weapon to inflict additional damage."
 	}
 
+	// Overwrite vanilla function to allow double-gripping with southern swords with offhand item with the perk_rf_en_garde perk
+	q.canDoubleGrip = @() function()
+	{
+		local actor = this.getContainer().getActor();
+		local weapon = actor.getMainhandItem();
+		if (weapon == null || !weapon.isDoubleGrippable())
+			return false;
+
+		local offhand = actor.getOffhandItem();
+		if (offhand == null)
+			return true;
+
+		return offhand.getStaminaModifier() > -10 && weapon.isItemType(::Const.Items.ItemType.RF_Southern) && weapon.isWeaponType(::Const.Items.WeaponType.Sword) && this.getContainer().hasSkill("perk.rf_en_garde");
+	}
+
 	q.applyBonusOnUpdate <- function( _properties )
 	{
 		switch (this.m.CurrWeaponType)

--- a/scripts/skills/actives/rf_en_garde_toggle_skill.nut
+++ b/scripts/skills/actives/rf_en_garde_toggle_skill.nut
@@ -1,7 +1,7 @@
 this.rf_en_garde_toggle_skill <- ::inherit("scripts/skills/skill", {
 	m = {
 		IsOn = true,
-		IsSpent = false,
+		HasMoved = false,
 		FatigueRequired = 15
 	},
 	function create()
@@ -61,18 +61,15 @@ this.rf_en_garde_toggle_skill <- ::inherit("scripts/skills/skill", {
 
 	function onTurnStart()
 	{
-		this.m.IsSpent = false;
+		this.m.HasMoved = false;
 	}
 
-	function onUpdate( _properties )
+	function onMovementFinished( _tile )
 	{
-		if (this.getContainer().getActor().m.IsMoving)
+		local meisterhau = this.getContainer().getSkillByID("actives.rf_swordmaster_stance_meisterhau");
+		if (meisterhau == null || !meisterhau.m.IsOn)
 		{
-			local meisterhau = this.getContainer().getSkillByID("actives.rf_swordmaster_stance_meisterhau");
-			if (meisterhau == null || !meisterhau.m.IsOn)
-			{
-				this.m.IsSpent = true;
-			}
+			this.m.HasMoved = true;
 		}
 	}
 
@@ -83,7 +80,7 @@ this.rf_en_garde_toggle_skill <- ::inherit("scripts/skills/skill", {
 
 	function pickSkill()
 	{
-		if (this.m.IsSpent || !this.isEnabled()) return null;
+		if (!this.isEnabled()) return null;
 
 		if (this.getContainer().getActor().getFatigueMax() - this.getContainer().getActor().getFatigue() < this.m.FatigueRequired) return null;
 
@@ -111,7 +108,7 @@ this.rf_en_garde_toggle_skill <- ::inherit("scripts/skills/skill", {
 
 	function onTurnEnd()
 	{
-		if (this.m.IsSpent || !this.m.IsOn)
+		if (!this.m.IsOn)
 		{
 			return;
 		}
@@ -136,6 +133,10 @@ this.rf_en_garde_toggle_skill <- ::inherit("scripts/skills/skill", {
 				{
 					::Sound.play(this.m.ReturnFavorSounds[::Math.rand(0, this.m.ReturnFavorSounds.len() - 1)], ::Const.Sound.Volume.Skill * this.m.SoundVolume, actor.getPos());
 				}
+			}
+			if (this.m.HasMoved)
+			{
+				actor.setFatigue(::Math.min(actor.getFatigueMax(), actor.getFatigue() + this.m.FatigueRequired));
 			}
 		}
 	}

--- a/scripts/skills/actives/rf_en_garde_toggle_skill.nut
+++ b/scripts/skills/actives/rf_en_garde_toggle_skill.nut
@@ -45,6 +45,9 @@ this.rf_en_garde_toggle_skill <- ::inherit("scripts/skills/skill", {
 
 	function isEnabled()
 	{
+		if (this.getContainer().getActor().isDisarmed())
+			return false;
+
 		local weapon = this.getContainer().getActor().getMainhandItem();
 		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Sword))
 		{


### PR DESCRIPTION
- Allow Double Grip bonus for southern swords with offhand item with less than 10 weight.
- Allow triggering even after movement but in this case build 15 Fatigue.
- Fix: prevent en garde from triggering when disarmed.