### PR TITLE
Refactor improve trait tooltips

### DIFF
--- a/mod_reforged/hooks/skills/traits/brute_trait.nut
+++ b/mod_reforged/hooks/skills/traits/brute_trait.nut
@@ -20,7 +20,7 @@
 		{
 			if (entry.id == 10 && entry.icon == "ui/icons/chance_to_hit_head.png")
 			{
-				entry.text = "Melee Damage is increased by " + ::MSU.Text.colorPositive("+15%") + " on a hit to the head";
+				entry.text = "Deal " + ::MSU.Text.colorPositive("15%") + " more Melee Damage on a hit to the head";
 				break;
 			}
 		}

--- a/mod_reforged/hooks/skills/traits/disloyal_trait.nut
+++ b/mod_reforged/hooks/skills/traits/disloyal_trait.nut
@@ -11,11 +11,11 @@
 	{
 		local ret = __original();
 		ret.push({
-			id = 5,
+			id = 10,
 			type = "text",
 			icon = "ui/icons/asset_money.png",
-			text = "Chance to desert on low mood is increased by " + ::MSU.Text.colorNegative("100%")
-		})
+			text = ::MSU.Text.colorNegative("100%") + " more chance to desert on low mood"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/traits/gluttonous_trait.nut
+++ b/mod_reforged/hooks/skills/traits/gluttonous_trait.nut
@@ -15,7 +15,7 @@
 		local ret = __original();
 
 		ret.push({
-			id = 5,
+			id = 10,
 			type = "text",
 			icon = "ui/icons/asset_daily_food.png",
 			text = "Consumes " + ::MSU.Text.colorNegative("+1") + " food daily"

--- a/mod_reforged/hooks/skills/traits/gluttonous_trait.nut
+++ b/mod_reforged/hooks/skills/traits/gluttonous_trait.nut
@@ -13,12 +13,21 @@
 	q.getTooltip = @(__original) function()
 	{
 		local ret = __original();
+
 		ret.push({
 			id = 5,
 			type = "text",
 			icon = "ui/icons/asset_daily_food.png",
 			text = "Consumes " + ::MSU.Text.colorNegative("+1") + " food daily"
 		})
+
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/asset_daily_food.png",
+			text = "Lose " + ::MSU.Text.colorNegative("100%") + " more mood when going hungry"
+		});
+
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/traits/gluttonous_trait.nut
+++ b/mod_reforged/hooks/skills/traits/gluttonous_trait.nut
@@ -25,7 +25,7 @@
 			id = 11,
 			type = "text",
 			icon = "ui/icons/asset_daily_food.png",
-			text = "Lose " + ::MSU.Text.colorNegative("100%") + " more mood when going hungry"
+			text = "Lose " + ::MSU.Text.colorNegative("100%") + " more mood due to going hungry"
 		});
 
 		return ret;

--- a/mod_reforged/hooks/skills/traits/greedy_trait.nut
+++ b/mod_reforged/hooks/skills/traits/greedy_trait.nut
@@ -15,7 +15,7 @@
 			id = 10,
 			type = "text",
 			icon = "ui/icons/asset_money.png",
-			text = ::MSU.Text.colorNegative("15%") + " more Daily wage"
+			text = ::MSU.Text.colorNegative("15%") + " more daily wage"
 		});
 		return ret;
 	}

--- a/mod_reforged/hooks/skills/traits/greedy_trait.nut
+++ b/mod_reforged/hooks/skills/traits/greedy_trait.nut
@@ -12,11 +12,11 @@
 	{
 		local ret = __original();
 		ret.push({
-			id = 5,
+			id = 10,
 			type = "text",
 			icon = "ui/icons/asset_money.png",
-			text = "Daily wage is increased by " + ::MSU.Text.colorNegative("15%")
-		})
+			text = ::MSU.Text.colorNegative("15%") + " more Daily wage"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/traits/loyal_trait.nut
+++ b/mod_reforged/hooks/skills/traits/loyal_trait.nut
@@ -12,7 +12,7 @@
 			id = 10,
 			type = "text",
 			icon = "ui/icons/asset_money.png",
-			text = ::MSU.Text.colorPositive("50%") + " less Chance to desert on low mood"
+			text = ::MSU.Text.colorPositive("50%") + " less chance to desert on low mood"
 		});
 		return ret;
 	}

--- a/mod_reforged/hooks/skills/traits/loyal_trait.nut
+++ b/mod_reforged/hooks/skills/traits/loyal_trait.nut
@@ -9,11 +9,11 @@
 	{
 		local ret = __original();
 		ret.push({
-			id = 5,
+			id = 10,
 			type = "text",
 			icon = "ui/icons/asset_money.png",
-			text = "Chance to desert on low mood is reduced by " + ::MSU.Text.colorPositive("50%")
-		})
+			text = ::MSU.Text.colorPositive("50%") + " less Chance to desert on low mood"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/traits/spartan_trait.nut
+++ b/mod_reforged/hooks/skills/traits/spartan_trait.nut
@@ -7,4 +7,25 @@
 			"pg.rf_vigorous": 0.5
 		};
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/asset_daily_food.png",
+			text = "Consumes " + ::MSU.Text.colorPositive("-1") + " food daily"
+		});
+
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/asset_daily_food.png",
+			text = "Lose " + ::MSU.Text.colorPositive("50%") + " less mood when going hungry"
+		});
+
+		return ret;
+	}
 });

--- a/mod_reforged/hooks/skills/traits/spartan_trait.nut
+++ b/mod_reforged/hooks/skills/traits/spartan_trait.nut
@@ -23,7 +23,7 @@
 			id = 11,
 			type = "text",
 			icon = "ui/icons/asset_daily_food.png",
-			text = "Lose " + ::MSU.Text.colorPositive("50%") + " less mood when going hungry"
+			text = "Lose " + ::MSU.Text.colorPositive("50%") + " less mood due to going hungry"
 		});
 
 		return ret;


### PR DESCRIPTION
This PR adds three new tooltips for vanilla effects that were not explained before.
It also improves previous adjustments to tooltips according to our recently fleshed out coding standards
- usage of more/less
- start id for effect tooltip lines at 10