### PR TITLE
refactor(balance): adjust dynamic perk weights

### DIFF
--- a/mod_reforged/config/skills.nut
+++ b/mod_reforged/config/skills.nut
@@ -1,4 +1,28 @@
 ::Reforged.Skills <- {
+	PerkTreeMultipliers = {
+		MeleeOnly = {
+			"pg.rf_bow": 0,
+			"pg.rf_crossbow": 0,
+			"pg.rf_throwing": 0,
+			"pg.rf_ranged": 0
+		},
+		MeleeSpecialist = {
+			"pg.rf_spear": 0.8,
+			"pg.rf_sword": 0.9
+		},
+		MeleeBackground = {
+			"pg.rf_bow": 0,
+			"pg.rf_crossbow": 0.8,
+			"pg.rf_ranged": 0.33
+		},
+		RangedBackground = {
+			"pg.rf_bow": 6,
+			"pg.rf_crossbow": 4,
+			"pg.rf_throwing": 2,
+			"pg.rf_ranged": 1.5
+		}
+	},
+
 	function addPerkGroup( _entity, _perkGroupID, _maxTier = 7 )
 	{
 		foreach (i, row in ::DynamicPerks.PerkGroups.findById(_perkGroupID).getTree())

--- a/mod_reforged/config/talent_multipliers.nut
+++ b/mod_reforged/config/talent_multipliers.nut
@@ -1,26 +1,30 @@
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Hitpoints, "pg.rf_large", 1.2);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Hitpoints, "pg.rf_sturdy", 1.2);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Hitpoints, "pg.rf_strong", 1.2);
 
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Bravery, "pg.rf_resilient", 1.2);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Bravery, "pg.rf_leadership", 1.2);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Bravery, "pg.special.rf_leadership", 2.0);
 
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Fatigue, "pg.rf_agile", 1.2);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Fatigue, "pg.rf_sturdy", 1.2);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Fatigue, "pg.rf_heavy_armor", 1.2);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Fatigue, "pg.rf_vigorous", 1.2);
 
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Initiative, "pg.rf_fast", 1.2);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Initiative, "pg.rf_agile", 1.2);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.Initiative, "pg.rf_light_armor", 1.2);
 
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_bow", 0.5);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_crossbow", 0.5);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_ranged", 0.5);
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_unstoppable", 1.2);
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_vicious", 1.2);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_axe", 1.15);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_cleaver", 1.15);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_dagger", 1.15);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_flail", 1.15);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_hammer", 1.15);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_mace", 1.15);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_polearm", 1.15);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_sword", 1.15);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_bow", 0.8);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_crossbow", 0.8);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_ranged", 0.5);
 
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedSkill, "pg.rf_bow", 3);
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedSkill, "pg.rf_crossbow", 2);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedSkill, "pg.rf_bow", 1.5);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedSkill, "pg.rf_crossbow", 1.5);
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedSkill, "pg.rf_throwing", 1.5);
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeSkill, "pg.rf_ranged", 2.0);
 
-::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeDefense, "pg.rf_resilient", 1.2);
 ::DynamicPerks.TalentMultipliers.add(::Const.Attributes.MeleeDefense, "pg.rf_trained", 1.2);
+
+::DynamicPerks.TalentMultipliers.add(::Const.Attributes.RangedDefense, "pg.rf_agile", 1.2);

--- a/mod_reforged/hooks/skills/backgrounds/adventurous_noble_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/adventurous_noble_background.nut
@@ -3,14 +3,15 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-            "pg.rf_devious": 0,
-            "pg.rf_leadership": 20,
-            "pg.rf_tactician": 6,
+            "pg.special.rf_leadership": 20,
+            "pg.rf_tactician": 3,
             "pg.rf_trained": 5,
-            "pg.rf_bow": 0,
-            "pg.rf_crossbow": 0,
-            "pg.rf_ranged": 0
+            "pg.rf_heavy_armor": 3
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/adventurous_noble_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/adventurous_noble_background.nut
@@ -24,4 +24,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/anatomist_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/anatomist_background.nut
@@ -28,4 +28,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/anatomist_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/anatomist_background.nut
@@ -3,19 +3,23 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_large": 0.75,
-			"pg.rf_leadership": 0.8,
-			"pg.rf_resilient": 0.75,
+			"pg.special.rf_leadership": 0.8,
+			"pg.rf_strong": 0.75,
+			"pg.rf_tactician": 2,
+			"pg.rf_vigorous": 0.75,
+			"pg.rf_hammer": 0.5,
+			"pg.rf_mace": 0.75,
+			"pg.rf_power": 0.75,
 			"pg.rf_shield": 0.75,
-			"pg.rf_sturdy": 0.75,
-			"pg.rf_tactician": 4,
-			"pg.rf_talented": 4
+			"pg.special.rf_student": 2,
 		};
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
-					"pg.rf_trapper"
+	                ::MSU.Class.WeightedContainer([
+	                    [30, "pg.rf_knave"],
+	                    [70, "pg.rf_trapper"]
+	                ])
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],

--- a/mod_reforged/hooks/skills/backgrounds/apprentice_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/apprentice_background.nut
@@ -3,15 +3,17 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 6
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
-				"pgc.rf_exclusive_1": [],
-				"pgc.rf_shared_1": [],
-				"pgc.rf_weapon": [],
-				"pgc.rf_armor": [],
-				"pgc.rf_fighting_style": []
+				"pg.rf_exclusive_1": [],
+				"pg.rf_shared_1": [],
+				"pg.rf_weapon": [],
+				"pg.rf_armor": [],
+				"pg.rf_fighting_style": []
 			}
 		});
 	}

--- a/mod_reforged/hooks/skills/backgrounds/apprentice_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/apprentice_background.nut
@@ -17,4 +17,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/assassin_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/assassin_background.nut
@@ -35,4 +35,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/assassin_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/assassin_background.nut
@@ -5,28 +5,24 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 4,
 			"pg.rf_fast": 4,
-			"pg.rf_large": 0.66,
-			"pg.rf_leadership": 0,
-			"pg.rf_resilient": 0.75,
-			"pg.rf_sturdy": 0.66,
-			"pg.rf_talented": 4,
+			"pg.special.rf_leadership": 0,
+			"pg.rf_strong": 0.66,
 			"pg.rf_unstoppable": 3,
 			"pg.rf_vicious": 3,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_dagger": 3,
+			"pg.rf_vigorous": 0.66,
 			"pg.rf_hammer": 0.5,
-			"pg.rf_mace": 0.75,
-			"pg.rf_spear": 0.75
+			"pg.rf_mace": 0.75
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
-					"pg.rf_trapper"
+					"pg.rf_knave"
 				],
-				"pgc.rf_shared_1": [
-					"pg.rf_devious"
-				],
+				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [
 					"pg.rf_light_armor",

--- a/mod_reforged/hooks/skills/backgrounds/assassin_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/assassin_southern_background.nut
@@ -5,31 +5,24 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 4,
 			"pg.rf_fast": 4,
-			"pg.rf_large": 0.66,
-			"pg.rf_leadership": 0,
-			"pg.rf_resilient": 0.75,
-			"pg.rf_sturdy": 0.66,
-			"pg.rf_talented": 4,
+			"pg.special.rf_leadership": 0,
+			"pg.rf_strong": 0.66,
 			"pg.rf_unstoppable": 3,
 			"pg.rf_vicious": 3,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_dagger": 3,
+			"pg.rf_vigorous": 0.66,
 			"pg.rf_hammer": 0.5,
-			"pg.rf_mace": 0.75,
-			"pg.rf_spear": 0.75,
-			"pg.rf_ranged": 0,
-			"pg.rf_shield": 0,
-			"pg.rf_swift": 3
+			"pg.rf_mace": 0.75
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
-					"pg.rf_trapper"
+					"pg.rf_knave"
 				],
-				"pgc.rf_shared_1": [
-					"pg.rf_devious"
-				],
+				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [
 					"pg.rf_light_armor",

--- a/mod_reforged/hooks/skills/backgrounds/assassin_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/assassin_southern_background.nut
@@ -35,4 +35,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/barbarian_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/barbarian_background.nut
@@ -35,4 +35,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/barbarian_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/barbarian_background.nut
@@ -4,9 +4,7 @@
 		__original();
 		this.m.BeardChance = 90;
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 0,
-			"pg.rf_leadership": 0,
-			"pg.rf_resilient": 2,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 0,
 			"pg.rf_trained": 0,
 			"pg.rf_unstoppable": 3,
@@ -15,10 +13,11 @@
 			"pg.rf_crossbow": 0,
 			"pg.rf_dagger": 0,
 			"pg.rf_polearm": 0,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
 			"pg.rf_ranged": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/bastard_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/bastard_background.nut
@@ -3,14 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_leadership": 0,
-			"pg.rf_tactician": 4,
-			"pg.rf_trained": 3,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_ranged": 0
+			"pg.special.rf_leadership": 0,
+			"pg.rf_tactician": 2,
+			"pg.rf_trained": 3
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/bastard_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/bastard_background.nut
@@ -20,4 +20,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/beast_hunter_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/beast_hunter_background.nut
@@ -4,11 +4,9 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 1.2,
-			"pg.rf_devious": 1.5,
 			"pg.rf_fast": 1.2,
-			"pg.rf_talented": 4,
-			"pg.rf_vicious": 2,
-			"pg.rf_dagger": 2
+			"pg.rf_trained": 2,
+			"pg.rf_vicious": 2
 		};
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {

--- a/mod_reforged/hooks/skills/backgrounds/beast_hunter_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/beast_hunter_background.nut
@@ -20,4 +20,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/beggar_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/beggar_background.nut
@@ -26,4 +26,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/beggar_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/beggar_background.nut
@@ -3,10 +3,12 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 0,
-			"pg.rf_tactician": 0,
-			"pg.rf_talented": 0
+			"pg.special.rf_leadership": 0,
+			"pg.rf_tactician": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
@@ -14,7 +16,12 @@
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
-				"pgc.rf_armor": [],
+				"pgc.rf_armor": [
+					::MSU.Class.WeightedContainer([
+					    [50, "pg.rf_light_armor"],
+					    [50, "pg.rf_medium_armor"]
+					])
+				],
 				"pgc.rf_fighting_style": []
 			}
 		});

--- a/mod_reforged/hooks/skills/backgrounds/beggar_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/beggar_southern_background.nut
@@ -26,4 +26,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/beggar_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/beggar_southern_background.nut
@@ -3,10 +3,12 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 0,
-			"pg.rf_tactician": 0,
-			"pg.rf_talented": 0
+			"pg.special.rf_leadership": 0,
+			"pg.rf_tactician": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
@@ -14,7 +16,12 @@
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
-				"pgc.rf_armor": [],
+				"pgc.rf_armor": [
+					::MSU.Class.WeightedContainer([
+					    [50, "pg.rf_light_armor"],
+					    [50, "pg.rf_medium_armor"]
+					])
+				],
 				"pgc.rf_fighting_style": []
 			}
 		});

--- a/mod_reforged/hooks/skills/backgrounds/belly_dancer_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/belly_dancer_background.nut
@@ -5,22 +5,23 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 2,
 			"pg.rf_fast": 2,
-			"pg.rf_large": 0.66,
-			"pg.rf_leadership": 0,
-			"pg.rf_resilient": 0.75,
-			"pg.rf_sturdy": 0.66,
-			"pg.rf_talented": 2,
+			"pg.special.rf_leadership": 0,
+			"pg.rf_strong": 0.66,
 			"pg.rf_vicious": 2,
-			"pg.rf_dagger": 2,
+			"pg.rf_vigorous": 0.66,
+			"pg.rf_flail": 0.75,
 			"pg.rf_hammer": 0.5,
 			"pg.rf_mace": 0.75,
-			"pg.rf_spear": 0.75,
 			"pg.rf_shield": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
-					"pg.rf_devious"
+					"pg.rf_knave"
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],

--- a/mod_reforged/hooks/skills/backgrounds/belly_dancer_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/belly_dancer_background.nut
@@ -35,4 +35,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/bowyer_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/bowyer_background.nut
@@ -23,4 +23,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/bowyer_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/bowyer_background.nut
@@ -4,9 +4,11 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_light_armor": 1.5,
-			"pg.rf_crossbow": 3,
-			"pg.rf_throwing": 2
+			"pg.rf_heavy_armor": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.RangedBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/brawler_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/brawler_background.nut
@@ -3,12 +3,12 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 3,
-			"pg.rf_unstoppable": 2,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_ranged": 0
+			"pg.special.rf_leadership": 3,
+			"pg.rf_unstoppable": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/butcher_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/butcher_background.nut
@@ -25,4 +25,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/butcher_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/butcher_background.nut
@@ -34,4 +34,27 @@
 				return _category.getMin() - 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorGreen("+10%") + " chance to hit with [Butcher\'s Cleaver|Item+butchers_cleaver]")
+		});
+		return ret;
+	}
+
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+
+		local weapon = _skill.getItem();
+		if (weapon != null && weapon.getID() == "weapon.butchers_cleaver")
+		{
+			_properties.MeleeSkill += 10;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/butcher_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/butcher_background.nut
@@ -3,19 +3,14 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 0.66,
-			"pg.rf_resilient": 0.66,
-			"pg.rf_sturdy": 0.66,
-			"pg.rf_talented": 0.5,
 			"pg.rf_vicious": 3,
 			"pg.rf_axe": 1.25,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_dagger": 2,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 1.25,
-			"pg.rf_ranged": 0
+			"pg.rf_spear": 0.8,
+			"pg.rf_sword": 1.25
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/butcher_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/butcher_southern_background.nut
@@ -25,4 +25,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/butcher_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/butcher_southern_background.nut
@@ -34,4 +34,27 @@
 				return _category.getMin() - 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorGreen("+10%") + " chance to hit with [Butcher\'s Cleaver|Item+butchers_cleaver]")
+		});
+		return ret;
+	}
+
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+
+		local weapon = _skill.getItem();
+		if (weapon != null && weapon.getID() == "weapon.butchers_cleaver")
+		{
+			_properties.MeleeSkill += 10;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/butcher_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/butcher_southern_background.nut
@@ -3,19 +3,14 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 0.66,
-			"pg.rf_resilient": 0.66,
-			"pg.rf_sturdy": 0.66,
-			"pg.rf_talented": 0.5,
 			"pg.rf_vicious": 3,
 			"pg.rf_axe": 1.25,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_dagger": 2,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 1.25,
-			"pg.rf_ranged": 0
+			"pg.rf_spear": 0.8,
+			"pg.rf_sword": 1.25
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/caravan_hand_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/caravan_hand_background.nut
@@ -3,8 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 0.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/caravan_hand_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/caravan_hand_southern_background.nut
@@ -3,8 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 0.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/companion_1h_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_1h_background.nut
@@ -3,10 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 0.75,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_bow": 0,
 			"pg.rf_crossbow": 0,
-			"pg.rf_ranged": 0
+			"pg.rf_ranged": 0.33
 		};
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {

--- a/mod_reforged/hooks/skills/backgrounds/companion_1h_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_1h_background.nut
@@ -30,4 +30,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/companion_1h_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_1h_southern_background.nut
@@ -30,4 +30,14 @@
 			}
 		});
 	}
+
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/companion_1h_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_1h_southern_background.nut
@@ -3,10 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 0.75,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_bow": 0,
 			"pg.rf_crossbow": 0,
-			"pg.rf_ranged": 0
+			"pg.rf_ranged": 0.33
 		};
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {

--- a/mod_reforged/hooks/skills/backgrounds/companion_2h_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_2h_background.nut
@@ -34,4 +34,14 @@
 			}
 		});
 	}
+
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/companion_2h_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_2h_background.nut
@@ -3,20 +3,19 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 0.5,
-			"pg.rf_devious": 0,
-			"pg.rf_fast": 0.5,
-			"pg.rf_leadership": 0,
+			"pg.rf_agile": 0.75,
+			"pg.rf_fast": 0.75,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 0,
 			"pg.rf_vicious": 1.5,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
 			"pg.rf_dagger": 0,
 			"pg.rf_spear": 0,
-			"pg.rf_sword": 0.8,
-			"pg.rf_throwing": 0,
-			"pg.rf_ranged": 0
+			"pg.rf_sword": 0.9,
+			"pg.rf_heavy_armor": 3
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/companion_2h_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_2h_southern_background.nut
@@ -34,4 +34,14 @@
 			}
 		});
 	}
+
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/companion_2h_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_2h_southern_background.nut
@@ -3,20 +3,19 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 0.5,
-			"pg.rf_devious": 0,
-			"pg.rf_fast": 0.5,
-			"pg.rf_leadership": 0,
+			"pg.rf_agile": 0.75,
+			"pg.rf_fast": 0.75,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 0,
 			"pg.rf_vicious": 1.5,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
 			"pg.rf_dagger": 0,
 			"pg.rf_spear": 0,
-			"pg.rf_sword": 0.8,
-			"pg.rf_throwing": 0,
-			"pg.rf_ranged": 0
+			"pg.rf_sword": 0.9,
+			"pg.rf_heavy_armor": 3
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/companion_ranged_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_ranged_background.nut
@@ -3,16 +3,16 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 1.5,
-			"pg.rf_fast": 1.5,
-			"pg.rf_leadership": 0,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 0,
 			"pg.rf_shield": 0
 		};
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],
-				"pgc.rf_shared_1": [],
+				"pgc.rf_shared_1": [
+					"pg.rf_agile",
+				],
 				"pgc.rf_weapon": [
 					"pg.rf_bow",
 					"pg.rf_crossbow",

--- a/mod_reforged/hooks/skills/backgrounds/companion_ranged_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_ranged_background.nut
@@ -28,4 +28,14 @@
 			}
 		});
 	}
+
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/companion_ranged_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_ranged_southern_background.nut
@@ -3,16 +3,16 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 1.5,
-			"pg.rf_fast": 1.5,
-			"pg.rf_leadership": 0,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 0,
 			"pg.rf_shield": 0
 		};
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],
-				"pgc.rf_shared_1": [],
+				"pgc.rf_shared_1": [
+					"pg.rf_agile",
+				],
 				"pgc.rf_weapon": [
 					"pg.rf_bow",
 					"pg.rf_crossbow",

--- a/mod_reforged/hooks/skills/backgrounds/companion_ranged_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/companion_ranged_southern_background.nut
@@ -28,4 +28,14 @@
 			}
 		});
 	}
+
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/converted_cultist_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/converted_cultist_background.nut
@@ -20,4 +20,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/converted_cultist_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/converted_cultist_background.nut
@@ -3,8 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			
+			"pg.special.rf_leadership": 4,
+			"pg.rf_vicious": 2,
+			"pg.rf_spear": 0.75,
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/cripple_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/cripple_background.nut
@@ -3,8 +3,11 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 0.25
+			"pg.rf_heavy_armor": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/cripple_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/cripple_background.nut
@@ -20,4 +20,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/cripple_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/cripple_southern_background.nut
@@ -3,8 +3,11 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 0.25
+			"pg.rf_heavy_armor": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/cripple_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/cripple_southern_background.nut
@@ -20,4 +20,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/crucified_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/crucified_background.nut
@@ -22,4 +22,16 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/crucified_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/crucified_background.nut
@@ -3,11 +3,18 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			
+			"pg.special.rf_leadership": 0,
+			"pg.rf_tactician": 0,
+			"pg.rf_vigorous": 2,
+			"pg.rf_dagger": 0,
+			"pg.rf_polearm": 0,
+			"pg.rf_spear": 0,
 		};
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
-				"pgc.rf_exclusive_1": [],
+				"pgc.rf_exclusive_1": [
+					"pg.rf_soldier"
+				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [],

--- a/mod_reforged/hooks/skills/backgrounds/crusader_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/crusader_background.nut
@@ -4,24 +4,19 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 0.5,
-			"pg.rf_devious": 0,
 			"pg.rf_fast": 0.5,
-			"pg.rf_large": 1,
-			"pg.rf_leadership": 0,
-			"pg.rf_sturdy": 2,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 0,
-			"pg.rf_talented": 0,
-			"pg.rf_unstoppable": 2,
-			"pg.rf_vicious": 2,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
+			"pg.rf_vigorous": 2,
 			"pg.rf_dagger": 0,
-			"pg.rf_polearm": 9,
+			"pg.rf_polearm": 0,
 			"pg.rf_spear": 0,
 
-            "pg.special.rf_professional": -1,
             "pg.special.rf_man_of_steel": -1
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/crusader_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/crusader_background.nut
@@ -37,4 +37,16 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/cultist_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/cultist_background.nut
@@ -3,12 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_fast": 0,
-			"pg.rf_leadership": 0,
-			"pg.rf_tactician": 0,
-			"pg.rf_shield": 0
+			"pg.special.rf_leadership": 4,
+			"pg.rf_vicious": 2,
+			"pg.rf_spear": 0.8
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/cultist_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/cultist_background.nut
@@ -22,4 +22,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/daytaler_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/daytaler_background.nut
@@ -19,4 +19,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/daytaler_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/daytaler_background.nut
@@ -3,8 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 0.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/daytaler_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/daytaler_southern_background.nut
@@ -19,4 +19,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/daytaler_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/daytaler_southern_background.nut
@@ -3,8 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 0.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/deserter_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/deserter_background.nut
@@ -22,4 +22,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/deserter_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/deserter_background.nut
@@ -3,14 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 2,
-			"pg.rf_leadership": 0,
-			"pg.rf_tactician": 4,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
-
-			"pg.special.rf_professional": -1
+			"pg.special.rf_leadership": 0,
+			"pg.rf_tactician": 4
 		};
+
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/disowned_noble_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/disowned_noble_background.nut
@@ -20,4 +20,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/disowned_noble_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/disowned_noble_background.nut
@@ -3,10 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_leadership": 0,
+			"pg.special.rf_leadership": 0,
+			"pg.rf_tactician": 2,
 			"pg.rf_trained": 3
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/eunuch_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/eunuch_background.nut
@@ -4,10 +4,12 @@
 		__original();
 		this.m.BeardChance = 0;
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
 			"pg.rf_tactician": 4,
-			"pg.rf_talented": 6
+			"pg.special.rf_student": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/eunuch_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/eunuch_background.nut
@@ -20,4 +20,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/eunuch_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/eunuch_southern_background.nut
@@ -2,11 +2,14 @@
 	q.create = @(__original) function()
 	{
 		__original();
+		this.m.BeardChance = 0;
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
 			"pg.rf_tactician": 4,
-			"pg.rf_talented": 6
+			"pg.special.rf_student": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/eunuch_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/eunuch_southern_background.nut
@@ -20,4 +20,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/farmhand_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/farmhand_background.nut
@@ -30,4 +30,34 @@
 				return _category.getMin() - 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorGreen("+10%") + " chance to hit with [Pitchfork|Item+pitchfork] and " + ::MSU.Text.colorGreen("+5%") + " chance to hit with [Hooked Blade|Item+hooked_blade]")
+		});
+		return ret;
+	}
+
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+
+		local weapon = _skill.getItem();
+		if (weapon != null)
+		{
+			if (weapon.getID() == "weapon.pitchfork")
+			{
+				_properties.MeleeSkill += 10;
+			}
+			else if (weapon.getID() == "weapon.hooked_blade")
+			{
+				_properties.MeleeSkill += 5;
+			}
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/farmhand_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/farmhand_background.nut
@@ -21,4 +21,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/farmhand_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/farmhand_background.nut
@@ -3,11 +3,12 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 2,
-			"pg.rf_resilient": 2,
-			"pg.rf_sturdy": 2,
-			"pg.rf_talented": 0.5
+			"pg.rf_strong": 2,
+			"pg.rf_vigorous": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/fisherman_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/fisherman_background.nut
@@ -3,11 +3,12 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 0.66,
-			"pg.rf_sturdy": 0.66,
-			"pg.rf_talented": 0.5,
+			"pg.rf_strong": 0.8,
 			"pg.rf_unstoppable": 1.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/fisherman_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/fisherman_background.nut
@@ -22,4 +22,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/fisherman_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/fisherman_southern_background.nut
@@ -3,11 +3,12 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 0.66,
-			"pg.rf_sturdy": 0.66,
-			"pg.rf_talented": 0.5,
+			"pg.rf_strong": 0.8,
 			"pg.rf_unstoppable": 1.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/fisherman_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/fisherman_southern_background.nut
@@ -22,4 +22,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/flagellant_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/flagellant_background.nut
@@ -3,17 +3,18 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 10,
-			"pg.rf_resilient": 3,
-			"pg.rf_sturdy": 3,
+			"pg.special.rf_leadership": 10,
+			"pg.rf_vigorous": 3,
 			"pg.rf_vicious": 3,
-			"pg.rf_bow": 0,
+			"pg.rf_heavy_armor": 0,
 			"pg.rf_crossbow": 0,
 			"pg.rf_power": 2,
-			"pg.rf_ranged": 0,
 			"pg.rf_shield": 0,
 			"pg.rf_swift": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/flagellant_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/flagellant_background.nut
@@ -25,4 +25,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/gambler_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gambler_background.nut
@@ -3,10 +3,9 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 2,
-			"pg.rf_devious": 2,
-			"pg.rf_fast": 2,
-			"pg.rf_leadership": 7.5,
+			"pg.rf_agile": 3,
+			"pg.rf_fast": 3,
+			"pg.special.rf_leadership": 7.5,
 			"pg.rf_tactician": 4,
 			"pg.rf_shield": 0.5
 		};

--- a/mod_reforged/hooks/skills/backgrounds/gambler_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gambler_background.nut
@@ -19,4 +19,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/gambler_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gambler_southern_background.nut
@@ -3,10 +3,9 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 2,
-			"pg.rf_devious": 2,
-			"pg.rf_fast": 2,
-			"pg.rf_leadership": 7.5,
+			"pg.rf_agile": 3,
+			"pg.rf_fast": 3,
+			"pg.special.rf_leadership": 7.5,
 			"pg.rf_tactician": 4,
 			"pg.rf_shield": 0.5
 		};

--- a/mod_reforged/hooks/skills/backgrounds/gambler_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gambler_southern_background.nut
@@ -19,4 +19,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/gladiator_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gladiator_background.nut
@@ -35,4 +35,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/gladiator_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gladiator_background.nut
@@ -3,19 +3,17 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_leadership": 0,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 5,
-			"pg.rf_talented": 6,
 			"pg.rf_trained": 3,
 			"pg.rf_unstoppable": 2,
 			"pg.rf_bow": 0,
 			"pg.rf_crossbow": 0,
 			"pg.rf_dagger": 0,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
-			"pg.rf_ranged": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/gladiator_origin_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gladiator_origin_background.nut
@@ -31,4 +31,18 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+			case "pgc.rf_armor":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/gladiator_origin_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gladiator_origin_background.nut
@@ -3,21 +3,17 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_leadership": 0,
-			"pg.rf_tactician": 5,
-			"pg.rf_talented": 6,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_trained": 3,
 			"pg.rf_unstoppable": 2,
 			"pg.rf_bow": 0,
 			"pg.rf_crossbow": 0,
-			"pg.rf_dagger": 0,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
-			"pg.rf_ranged": 0
 
 			"pg.special.rf_professional": -1
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/gravedigger_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gravedigger_background.nut
@@ -3,10 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 4,
-			"pg.rf_talented": 0.5,
+			"pg.special.rf_leadership": 4,
 			"pg.rf_unstoppable": 2
 		};
+
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/gravedigger_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gravedigger_background.nut
@@ -22,4 +22,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/graverobber_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/graverobber_background.nut
@@ -19,4 +19,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/graverobber_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/graverobber_background.nut
@@ -3,10 +3,12 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 3,
-			"pg.rf_leadership": 5,
+			"pg.special.rf_leadership": 5,
 			"pg.rf_unstoppable": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/hedge_knight_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/hedge_knight_background.nut
@@ -35,4 +35,16 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/hedge_knight_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/hedge_knight_background.nut
@@ -4,31 +4,24 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 0,
-			"pg.rf_devious": 0,
 			"pg.rf_fast": 0,
-			"pg.rf_leadership": 0,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 0,
-			"pg.rf_talented": 4,
 			"pg.rf_unstoppable": 2,
 			"pg.rf_vicious": 2,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
 			"pg.rf_dagger": 0,
-			"pg.rf_polearm": 0,
-			"pg.rf_spear": 0,
-			"pg.rf_throwing": 0,
+			"pg.rf_polearm": 0.25,
+			"pg.rf_spear": 0.2,
+			"pg.rf_throwing": 0.9,
 
             "pg.special.rf_man_of_steel": -1
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
-				"pgc.rf_exclusive_1": [
-					"pg.rf_soldier",
-					::MSU.Class.WeightedContainer([
-	                    [10, "pg.special.rf_professional"],
-	                    [90, "DynamicPerks_NoPerkGroup"]
-	                ])
-				],
+				"pgc.rf_exclusive_1": [],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [

--- a/mod_reforged/hooks/skills/backgrounds/historian_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/historian_background.nut
@@ -19,4 +19,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/historian_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/historian_background.nut
@@ -4,8 +4,11 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_tactician": 4,
-			"pg.rf_trained": 4
+			"pg.special.student": -1
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/historian_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/historian_southern_background.nut
@@ -19,4 +19,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/historian_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/historian_southern_background.nut
@@ -4,8 +4,11 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_tactician": 4,
-			"pg.rf_trained": 4
+			"pg.special.student": -1
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/houndmaster_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/houndmaster_background.nut
@@ -3,8 +3,11 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 2
+			"pg.special.rf_leadership": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/hunter_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/hunter_background.nut
@@ -5,9 +5,8 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 1.5,
 			"pg.rf_fast": 1.5,
-			"pg.rf_leadership": 0,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 0,
-			"pg.rf_talented": 3,
 			"pg.rf_shield": 0
 		};
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({

--- a/mod_reforged/hooks/skills/backgrounds/hunter_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/hunter_background.nut
@@ -28,4 +28,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/juggler_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/juggler_background.nut
@@ -26,4 +26,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/juggler_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/juggler_background.nut
@@ -4,19 +4,18 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 3,
-			"pg.rf_devious": 1.5,
 			"pg.rf_fast": 3,
-			"pg.rf_talented": 3,
 			"pg.rf_flail": 3,
-			"pg.rf_polearm": 1.5
+			"pg.rf_polearm": 1.5,
+			"pg.rf_heavy_armor": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
-					::MSU.Class.WeightedContainer([
-	                    [20, "pg.rf_trapper"],
-	                    [80, "DynamicPerks_NoPerkGroup"]
-	                ])
+                    "pg.rf_knave"
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],

--- a/mod_reforged/hooks/skills/backgrounds/juggler_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/juggler_southern_background.nut
@@ -4,20 +4,18 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 3,
-			"pg.rf_devious": 1.5,
 			"pg.rf_fast": 3,
-			"pg.rf_talented": 3,
 			"pg.rf_flail": 3,
 			"pg.rf_polearm": 1.5,
-			"pg.rf_swift": 5
+			"pg.rf_heavy_armor": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
-					::MSU.Class.WeightedContainer([
-	                    [20, "pg.rf_trapper"],
-	                    [80, "DynamicPerks_NoPerkGroup"]
-	                ])
+                    "pg.rf_knave"
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],

--- a/mod_reforged/hooks/skills/backgrounds/juggler_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/juggler_southern_background.nut
@@ -26,4 +26,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/killer_on_the_run_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/killer_on_the_run_background.nut
@@ -3,15 +3,19 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 3,
-			"pg.rf_leadership": 0,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_dagger": 2,
 			"pg.rf_flail": 2,
 			"pg.rf_polearm": 1.25
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
-				"pgc.rf_exclusive_1": [],
+				"pgc.rf_exclusive_1": [
+                    "pg.rf_knave"
+				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [],

--- a/mod_reforged/hooks/skills/backgrounds/killer_on_the_run_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/killer_on_the_run_background.nut
@@ -23,4 +23,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/kings_guard_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/kings_guard_background.nut
@@ -29,4 +29,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/kings_guard_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/kings_guard_background.nut
@@ -3,23 +3,18 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
-			"pg.rf_throwing": 0,
-
-			"pg.special.rf_professional": -1
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
 					"pg.rf_soldier"
 				],
 				"pgc.rf_shared_1": [
-					"pg.rf_resilient",
-					"pg.rf_unstoppable",
-					"pg.rf_vicious"
+					"pg.rf_unstoppable"
 				],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [

--- a/mod_reforged/hooks/skills/backgrounds/lindwurm_slayer_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/lindwurm_slayer_background.nut
@@ -4,17 +4,17 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 2,
-			"pg.rf_devious": 1.5,
 			"pg.rf_fast": 2,
-			"pg.rf_leadership": 0,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_vicious": 3,
 			"pg.rf_bow": 0,
 			"pg.rf_crossbow": 0,
 			"pg.rf_dagger": 0,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
 			"pg.rf_ranged": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/lindwurm_slayer_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/lindwurm_slayer_background.nut
@@ -29,4 +29,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/lumberjack_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/lumberjack_background.nut
@@ -26,4 +26,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/lumberjack_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/lumberjack_background.nut
@@ -35,4 +35,27 @@
 				return _category.getMin() + 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorGreen("+10%") + " chance to hit with [Woodcutter\'s Axe|Item+woodcutters_axe] and [Hatchet|Item+hatchet]")
+		});
+		return ret;
+	}
+
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+
+		local weapon = _skill.getItem();
+		if (weapon != null && (weapon.getID() == "weapon.woodcutters_axe" || weapon.getID() == "weapon.hatchet"))
+		{
+			_properties.MeleeSkill += 10;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/lumberjack_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/lumberjack_background.nut
@@ -3,12 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 2,
-			"pg.rf_leadership": 2,
-			"pg.rf_resilient": 2,
-			"pg.rf_sturdy": 2,
-			"pg.rf_swift": 0.5
+			"pg.rf_strong": 2,
+			"pg.special.rf_leadership": 2,
+			"pg.rf_vigorous": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/manhunter_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/manhunter_background.nut
@@ -3,12 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_leadership": 2,
-			"pg.rf_talented": 2,
+			"pg.special.rf_leadership": 2,
 			"pg.rf_tactician": 2,
 			"pg.rf_vicious": 1.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/mason_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/mason_background.nut
@@ -3,11 +3,14 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 3,
 			"pg.rf_flail": 1.5,
 			"pg.rf_hammer": 2,
-			"pg.rf_mace": 1.5
+			"pg.rf_mace": 1.5,
+			"pg.special.rf_student": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/mason_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/mason_background.nut
@@ -23,4 +23,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/messenger_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/messenger_background.nut
@@ -20,4 +20,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/messenger_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/messenger_background.nut
@@ -3,9 +3,11 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 0.66,
-			"pg.rf_resilient": 0.66
+			"pg.rf_strong": 0.66
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/militia_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/militia_background.nut
@@ -3,8 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/miller_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/miller_background.nut
@@ -20,4 +20,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/miller_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/miller_background.nut
@@ -3,8 +3,11 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 0.66
+			"pg.rf_strong": 1.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/miner_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/miner_background.nut
@@ -35,4 +35,27 @@
 				return _category.getMin() - 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorGreen("+10%") + " chance to hit with [Pickaxe|Item+pickaxe]")
+		});
+		return ret;
+	}
+
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+
+		local weapon = _skill.getItem();
+		if (weapon != null && weapon.getID() == "weapon.pickaxe")
+		{
+			_properties.MeleeSkill += 10;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/miner_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/miner_background.nut
@@ -26,4 +26,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/miner_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/miner_background.nut
@@ -3,12 +3,15 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 2,
-			"pg.rf_sturdy": 0.165,
-			"pg.rf_talented": 0.5,
+			"pg.rf_strong": 2,
+			"pg.rf_vigorous": 0.165,
 			"pg.rf_flail": 1.5,
 			"pg.rf_mace": 1.5
+			"pg.rf_swift": 0.5,
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/minstrel_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/minstrel_background.nut
@@ -3,13 +3,14 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_large": 0.75,
-			"pg.rf_leadership": 7.5,
-			"pg.rf_resilient": 0.25,
-			"pg.rf_sturdy": 0.25,
-			"pg.rf_talented": 5
+			"pg.rf_strong": 0.75,
+			"pg.special.rf_leadership": 7.5,
+			"pg.rf_vigorous": 0.25,
+			"pg.special.discovered_talent": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/minstrel_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/minstrel_background.nut
@@ -24,4 +24,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/monk_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/monk_background.nut
@@ -25,4 +25,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/monk_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/monk_background.nut
@@ -3,17 +3,19 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 0,
-			"pg.rf_leadership": 7.5,
-			"pg.rf_resilient": 0.5,
-			"pg.rf_sturdy": 0.5,
+			"pg.rf_vigorous": 0.5,
 			"pg.rf_unstoppable": 0,
 			"pg.rf_vicious": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],
-				"pgc.rf_shared_1": [],
+				"pgc.rf_shared_1": [
+					"pg.special.rf_leadership"
+				],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [
 					"pg.rf_light_armor",

--- a/mod_reforged/hooks/skills/backgrounds/monk_turned_flagellant_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/monk_turned_flagellant_background.nut
@@ -3,8 +3,17 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			
+			"pg.special.rf_leadership": 10,
+			"pg.rf_vigorous": 3,
+			"pg.rf_vicious": 0
+			"pg.rf_heavy_armor": 0,
+			"pg.rf_power": 2,
+			"pg.rf_shield": 0,
+			"pg.rf_swift": 2,
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/monk_turned_flagellant_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/monk_turned_flagellant_background.nut
@@ -24,4 +24,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/nomad_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/nomad_background.nut
@@ -26,4 +26,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/nomad_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/nomad_background.nut
@@ -35,4 +35,61 @@
 				return _category.getMin() + 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Can use the [Throw Dirt|Skill+throw_dirt_skill] skill once per [turn|Concept.Turn]")
+		});
+		return ret;
+	}
+
+	q.onAdded = @(__original) function()
+	{
+		__original();
+		this.getContainer().add(::new("scripts/skills/actives/throw_dirt_skill"));
+	}
+
+	q.onRemoved = @(__original) function()
+	{
+		__original();
+		this.getContainer().removeByID("actives.throw_dirt");
+	}
+
+	q.onAnySkillExecuted = @(__original) function( _skill, _targetTile, _targetEntity, _forFree )
+	{
+		__original(_skill, _targetTile, _targetEntity, _forFree);
+		if (_skill.getID() == "actives.throw_dirt")
+		{
+			_skill.m.IsUsable = false;
+		}
+	}
+
+	q.onTurnStart = @(__original) function()
+	{
+		__original();
+		local throwDirt = this.getContainer().getSkillByID("actives.throw_dirt");
+		if (throwDirt != null)
+		{
+			throwDirt.m.IsUsable = true;
+		}
+	}
+
+	q.onQueryTooltip = @(__original) function( _skill, _tooltip )
+	{
+		__original(_skill, _tooltip);
+		if (_skill.getID() == "actives.throw_dirt" && !_skill.m.IsUsable)
+		{
+			_tooltip.push({
+				id = 20,
+				type = "text",
+				icon = "ui/icons/warning.png",
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorRed("Can only be used once per [turn|Concept.Turn]"))
+			});
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/nomad_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/nomad_background.nut
@@ -3,15 +3,17 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
 			"pg.rf_tactician": 3,
-			"pg.rf_talented": 2,
 			"pg.rf_trained": 1.4,
 			"pg.rf_unstoppable": 1.5,
 			"pg.rf_vicious": 1.5,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8
+			"pg.rf_bow": 0,
+			"pg.rf_crossbow": 0,
+			"pg.rf_ranged": 0.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/nomad_ranged_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/nomad_ranged_background.nut
@@ -28,4 +28,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/nomad_ranged_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/nomad_ranged_background.nut
@@ -3,18 +3,14 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
 			"pg.rf_tactician": 3,
-			"pg.rf_talented": 2,
 			"pg.rf_trained": 1.4,
 			"pg.rf_unstoppable": 1.5,
 			"pg.rf_vicious": 1.5,
-			"pg.rf_bow": 3,
-			"pg.rf_crossbow": 2,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
-			"pg.rf_throwing": 1.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.RangedBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/old_gladiator_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/old_gladiator_background.nut
@@ -4,23 +4,19 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 0.5,
-			"pg.rf_devious": 3,
 			"pg.rf_fast": 0.5,
-			"pg.rf_large": 0.5,
-			"pg.rf_leadership": 0,
-			"pg.rf_sturdy": 0.5,
+			"pg.rf_strong": 0.5,
+			"pg.special.rf_leadership": 0,
+			"pg.rf_vigorous": 0.5,
 			"pg.rf_tactician": 10,
 			"pg.rf_unstoppable": 2,
 			"pg.rf_vicious": 2,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_dagger": 0,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
-			"pg.rf_ranged": 0
-
-            "pg.special.rf_professional": -1
+			"pg.rf_dagger": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/old_gladiator_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/old_gladiator_background.nut
@@ -30,4 +30,15 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+			case "pgc.rf_weapon":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/old_paladin_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/old_paladin_background.nut
@@ -3,27 +3,22 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 0,
-			"pg.rf_large": 0.5,
-			"pg.rf_sturdy": 0.5,
+			"pg.rf_strong": 0.5,
+			"pg.rf_vigorous": 0.5,
 			"pg.rf_tactician": 4,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_dagger": 0,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
-			"pg.rf_throwing": 0,
-			"pg.rf_ranged": 0,
-
-			"pg.special.rf_professional": -1
+			"pg.rf_dagger": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
 					"pg.rf_soldier"
 				],
 				"pgc.rf_shared_1": [
-					"pg.rf_leadership"
+					"pg.special.rf_leadership"
 				],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [],

--- a/mod_reforged/hooks/skills/backgrounds/old_paladin_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/old_paladin_background.nut
@@ -26,4 +26,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+
+			case "pgc.rf_armor":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/orc_slayer_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/orc_slayer_background.nut
@@ -39,4 +39,16 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_weapon":
+				return _category.getMin() + 3;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/orc_slayer_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/orc_slayer_background.nut
@@ -4,23 +4,21 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 0.5,
-			"pg.rf_devious": 0,
 			"pg.rf_fast": 0.5,
-			"pg.rf_large": 2,
-			"pg.rf_leadership": 0,
-			"pg.rf_sturdy": 2,
+			"pg.rf_strong": 2,
+			"pg.special.rf_leadership": 0,
+			"pg.rf_vigorous": 2,
 			"pg.rf_tactician": 0,
-			"pg.rf_talented": 0,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
 			"pg.rf_dagger": 0,
 			"pg.rf_polearm": 0,
 			"pg.rf_spear": 0,
-			"pg.rf_sword": 0.8,
-			"pg.rf_throwing": 0,
+			"pg.rf_sword": 0.9
 
 			"pg.special.rf_professional": -1
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/pacified_flagellant_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/pacified_flagellant_background.nut
@@ -3,14 +3,24 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			
+			"pg.rf_vigorous": 0.5,
+			"pg.rf_unstoppable": 0,
+			"pg.rf_vicious": 0,
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],
-				"pgc.rf_shared_1": [],
+				"pgc.rf_shared_1": [
+					"pg.special.rf_leadership"
+				],
 				"pgc.rf_weapon": [],
-				"pgc.rf_armor": [],
+				"pgc.rf_armor": [
+					"pg.rf_light_armor",
+					"pg.rf_medium_armor"
+				],
 				"pgc.rf_fighting_style": []
 			}
 		});

--- a/mod_reforged/hooks/skills/backgrounds/pacified_flagellant_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/pacified_flagellant_background.nut
@@ -25,4 +25,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/paladin_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/paladin_background.nut
@@ -27,4 +27,17 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+
+			case "pgc.rf_armor":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/paladin_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/paladin_background.nut
@@ -4,20 +4,17 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 2,
-			"pg.rf_devious": 0,
 			"pg.rf_fast": 2,
-			"pg.rf_leadership": 20,
+			"pg.special.rf_leadership": 20,
 			"pg.rf_tactician": 4,
 			"pg.rf_talented": 2,
 			"pg.rf_unstoppable": 3,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_dagger": 0,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
-			"pg.rf_throwing": 0,
-			"pg.rf_ranged": 0
+			"pg.rf_dagger": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/peddler_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/peddler_background.nut
@@ -4,16 +4,14 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 1.2,
-			"pg.rf_devious": 1.5,
 			"pg.rf_fast": 1.2,
-			"pg.rf_sturdy": 2,
-			"pg.rf_talented": 2,
-			"pg.rf_trained": 0.5,
 			"pg.rf_unstoppable": 0.5,
 			"pg.rf_vicious": 0.5,
-			"pg.rf_power": 0.5,
-			"pg.rf_swift": 0.5
+			"pg.special.student": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/peddler_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/peddler_background.nut
@@ -22,4 +22,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/peddler_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/peddler_southern_background.nut
@@ -4,16 +4,14 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 1.2,
-			"pg.rf_devious": 1.5,
 			"pg.rf_fast": 1.2,
-			"pg.rf_sturdy": 2,
-			"pg.rf_talented": 2,
-			"pg.rf_trained": 0.5,
 			"pg.rf_unstoppable": 0.5,
 			"pg.rf_vicious": 0.5,
-			"pg.rf_power": 0.5,
-			"pg.rf_swift": 0.5
+			"pg.special.student": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/peddler_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/peddler_southern_background.nut
@@ -22,4 +22,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/pimp_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/pimp_background.nut
@@ -23,4 +23,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/pimp_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/pimp_background.nut
@@ -5,15 +5,14 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 1.2,
 			"pg.rf_fast": 1.2,
-			"pg.rf_leadership": 2,
-			"pg.rf_sturdy": 2,
-			"pg.rf_talented": 3,
+			"pg.special.rf_leadership": 2,
 			"pg.rf_trained": 0.75,
 			"pg.rf_unstoppable": 0.75,
-			"pg.rf_vicious": 0.75,
-			"pg.rf_power": 0.75,
-			"pg.rf_swift": 0.75
+			"pg.rf_vicious": 0.75
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/poacher_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/poacher_background.nut
@@ -19,4 +19,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/poacher_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/poacher_background.nut
@@ -3,21 +3,19 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 2,
-			"pg.rf_crossbow": 3,
-			"pg.rf_throwing": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.RangedBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],
 				"pgc.rf_shared_1": [],
-				"pgc.rf_weapon": [
-					"pg.rf_bow"
+				"pgc.rf_weapon": [],
+				"pgc.rf_armor": [
+					"pg.rf_light_armor"
 				],
-				"pgc.rf_armor": [],
-				"pgc.rf_fighting_style": [
-					"pg.rf_ranged"
-				]
+				"pgc.rf_fighting_style": []
 			}
 		});
 	}

--- a/mod_reforged/hooks/skills/backgrounds/raider_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/raider_background.nut
@@ -3,10 +3,14 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 3,
 			"pg.rf_trained": 1.4,
-			"pg.rf_vicious": 2
+			"pg.rf_vicious": 2,
+			"pg.rf_bow": 0,
+			"pg.rf_crossbow": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/raider_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/raider_background.nut
@@ -23,4 +23,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/ratcatcher_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/ratcatcher_background.nut
@@ -27,4 +27,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/ratcatcher_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/ratcatcher_background.nut
@@ -3,12 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 5,
-			"pg.rf_large": 0.8,
-			"pg.rf_resilient": 0.8,
-			"pg.rf_talented": 2,
+			"pg.rf_strong": 0.8,
+			"pg.rf_heavy_armor": 0,
 			"pg.rf_shield": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
@@ -19,10 +20,7 @@
 					"pg.rf_fast"
 				],
 				"pgc.rf_weapon": [],
-				"pgc.rf_armor": [
-					"pg.rf_light_armor",
-					"pg.rf_medium_armor"
-				],
+				"pgc.rf_armor": [],
 				"pgc.rf_fighting_style": [
 					"pg.rf_swift"
 				]

--- a/mod_reforged/hooks/skills/backgrounds/refugee_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/refugee_background.nut
@@ -22,4 +22,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/refugee_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/refugee_background.nut
@@ -3,13 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 0.5,
-			"pg.rf_leadership": 0.5,
-			"pg.rf_resilient": 0.5,
-			"pg.rf_sturdy": 2,
-			"pg.rf_talented": 0.5,
+			"pg.special.rf_leadership": 0.5,
+			"pg.rf_strong": 0.5,
 			"pg.rf_unstoppable": 0.5
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/regent_in_absentia_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/regent_in_absentia_background.nut
@@ -33,4 +33,28 @@
 				return _category.getMin() + 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Has the [Family Pride|Perk+perk_rf_family_pride] perk permanently for free")
+		});
+		return ret;
+	}
+
+	q.onAdded = @(__original) function()
+	{
+		__original();
+		if (this.m.IsNew)
+		{
+			this.getPerkTree().addPerkGroup("pg.rf_noble");
+			this.getSkills().add(::MSU.new("scripts/skills/perks/perk_rf_family_pride", function(o) {
+				o.m.IsRefundable = false;
+			}));
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/regent_in_absentia_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/regent_in_absentia_background.nut
@@ -3,11 +3,20 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			
+			"pg.special.rf_leadership": 20,
+			"pg.rf_tactician": 3,
+			"pg.rf_trained": 5,
+			"pg.rf_heavy_armor": 3
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
-				"pgc.rf_exclusive_1": [],
+				"pgc.rf_exclusive_1": [
+					"pg.rf_noble"
+				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [],

--- a/mod_reforged/hooks/skills/backgrounds/regent_in_absentia_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/regent_in_absentia_background.nut
@@ -24,4 +24,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/retired_soldier_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/retired_soldier_background.nut
@@ -3,18 +3,18 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 0.25,
-			"pg.rf_leadership": 10,
-			"pg.rf_resilient": 0.25,
-			"pg.rf_sturdy": 0.5,
+			"pg.rf_strong": 0.25,
+			"pg.special.rf_leadership": 10,
 			"pg.rf_tactician": 7.5,
-			"pg.rf_light_armor": 0.5,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
-			"pg.rf_ranged": 0,
+			"pg.rf_vigorous": 0.5,
+			"pg.rf_bow": 0,
+			"pg.rf_crossbow": 0,
 
 			 "pg.special.rf_professional": -1
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
@@ -22,7 +22,10 @@
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
-				"pgc.rf_armor": [],
+				"pgc.rf_armor": [
+					"pg.rf_medium_armor",
+					"pg.rf_heavy_armor"
+				],
 				"pgc.rf_fighting_style": []
 			}
 		});

--- a/mod_reforged/hooks/skills/backgrounds/retired_soldier_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/retired_soldier_background.nut
@@ -30,4 +30,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/sellsword_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/sellsword_background.nut
@@ -3,14 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_leadership": 2,
+			"pg.special.rf_leadership": 2,
 			"pg.rf_tactician": 3,
-			"pg.rf_talented": 3,
 			"pg.rf_vicious": 2,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8,
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
@@ -19,10 +18,6 @@
 	                    [30, "pg.rf_raider"],
 	                    [20, "DynamicPerks_NoPerkGroup"]
 	                ]),
-	                ::MSU.Class.WeightedContainer([
-	                    [10, "pg.special.rf_professional"],
-	                    [90, "DynamicPerks_NoPerkGroup"]
-	                ])
 				],
 				"pgc.rf_shared_1": [
 					"pg.rf_trained"

--- a/mod_reforged/hooks/skills/backgrounds/sellsword_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/sellsword_background.nut
@@ -28,4 +28,16 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/servant_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/servant_background.nut
@@ -21,4 +21,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/servant_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/servant_background.nut
@@ -5,11 +5,12 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 1.2,
 			"pg.rf_fast": 1.2,
-			"pg.rf_large": 0.75,
-			"pg.rf_resilient": 0.75,
-			"pg.rf_sturdy": 0.75,
-			"pg.rf_talented": 0.5
+			"pg.rf_strong": 0.75,
+			"pg.rf_vigorous": 0.75
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/servant_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/servant_southern_background.nut
@@ -21,4 +21,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/servant_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/servant_southern_background.nut
@@ -5,11 +5,12 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 1.2,
 			"pg.rf_fast": 1.2,
-			"pg.rf_large": 0.75,
-			"pg.rf_resilient": 0.75,
-			"pg.rf_sturdy": 0.75,
-			"pg.rf_talented": 0.5
+			"pg.rf_strong": 0.75,
+			"pg.rf_vigorous": 0.75
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/shepherd_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/shepherd_background.nut
@@ -3,9 +3,11 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 2,
-			"pg.rf_talented": 0.5
+			"pg.special.rf_leadership": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/shepherd_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/shepherd_background.nut
@@ -29,4 +29,27 @@
 				return _category.getMin() - 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorGreen("+10%") + " chance to hit with slings")
+		});
+		return ret;
+	}
+
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+
+		local weapon = _skill.getItem();
+		if (weapon != null && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(::Const.Items.WeaponType.Sling))
+		{
+			_properties.RangedSkill += 10;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/shepherd_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/shepherd_background.nut
@@ -20,4 +20,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/shepherd_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/shepherd_southern_background.nut
@@ -3,9 +3,11 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 2,
-			"pg.rf_talented": 0.5
+			"pg.special.rf_leadership": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/shepherd_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/shepherd_southern_background.nut
@@ -29,4 +29,27 @@
 				return _category.getMin() - 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorGreen("+10%") + " chance to hit with slings")
+		});
+		return ret;
+	}
+
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		__original(_skill, _targetEntity, _properties);
+
+		local weapon = _skill.getItem();
+		if (weapon != null && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(::Const.Items.WeaponType.Sling))
+		{
+			_properties.RangedSkill += 10;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/shepherd_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/shepherd_southern_background.nut
@@ -20,4 +20,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_fighting_style":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/slave_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/slave_background.nut
@@ -23,4 +23,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/slave_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/slave_background.nut
@@ -5,11 +5,12 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 0.75,
 			"pg.rf_fast": 0.75,
-			"pg.rf_large": 0.25,
-			"pg.rf_leadership": 0.5,
-			"pg.rf_resilient": 0.25,
-			"pg.rf_talented": 0
+			"pg.special.rf_leadership": 0.5,
+			"pg.rf_strong": 0.25
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/slave_barbarian_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/slave_barbarian_background.nut
@@ -23,4 +23,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/slave_barbarian_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/slave_barbarian_background.nut
@@ -5,11 +5,12 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 0.75,
 			"pg.rf_fast": 0.75,
-			"pg.rf_leadership": 0.5,
-			"pg.rf_resilient": 0.25,
-			"pg.rf_sturdy": 1.25,
-			"pg.rf_talented": 0
+			"pg.special.rf_leadership": 0.25,
+			"pg.rf_vigorous": 1.25,
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/slave_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/slave_southern_background.nut
@@ -23,4 +23,14 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/slave_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/slave_southern_background.nut
@@ -5,11 +5,12 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 0.75,
 			"pg.rf_fast": 0.75,
-			"pg.rf_large": 0.25,
-			"pg.rf_leadership": 0.5,
-			"pg.rf_resilient": 0.25,
-			"pg.rf_talented": 0
+			"pg.special.rf_leadership": 0.25
+			"pg.rf_strong": 0.25
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/squire_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/squire_background.nut
@@ -27,4 +27,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() + 2;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/squire_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/squire_background.nut
@@ -3,12 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 10,
-			"pg.rf_tactician": 3,
-			"pg.rf_talented": 3,
-			"pg.rf_spear": 0.75,
-			"pg.rf_sword": 0.8
+			"pg.special.rf_leadership": 10,
+			"pg.rf_tactician": 3
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeSpecialist);
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
@@ -16,10 +17,6 @@
 	                    [50, "pg.rf_soldier"],
 	                    [50, "DynamicPerks_NoPerkGroup"]
 	                ]),
-	                ::MSU.Class.WeightedContainer([
-	                   [30, "pg.special.rf_professional"],
-	                   [70, "DynamicPerks_NoPerkGroup"]
-	                ])
 				],
 				"pgc.rf_shared_1": [
 					"pg.rf_trained"

--- a/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
@@ -41,6 +41,18 @@
 		this.m.ExcludedTalents.push(::Const.Attributes.RangedDefense);
 	}
 
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return 1; // We only want this background to have the Sword perk group
+
+			case "pgc.rf_fighting_style":
+				return _category.getMin() + 1;
+		}
+	}
+
 	q.onAdded = @(__original) function()
 	{
 		if (this.m.IsNew)

--- a/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
@@ -4,18 +4,10 @@
 		__original();
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 0.5,
-			"pg.rf_devious": 0,
 			"pg.rf_fast": 0.5,
-			"pg.rf_large": 0.25,
-			"pg.rf_leadership": 15,
-			"pg.rf_resilient": 1.5,
-			"pg.rf_sturdy": 0.25,
+			"pg.rf_strong": 0.25,
+			"pg.rf_vigorous": 0.25,
 			"pg.rf_tactician": 2,
-			"pg.rf_talented": 0,
-			"pg.rf_bow": 0,
-			"pg.rf_crossbow": 0,
-			"pg.rf_throwing": 0,
-			"pg.rf_ranged": 0
 
             "pg.special.rf_fencer": -1
 		};
@@ -24,20 +16,18 @@
 				"pgc.rf_exclusive_1": [
 					"pg.rf_soldier",
 					"pg.rf_swordmaster",
-					::MSU.Class.WeightedContainer([
-	                    [10, "pg.special.rf_professional"],
-	                    [90, "DynamicPerks_NoPerkGroup"]
-	                ])
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [
 					"pg.rf_sword"
 				],
 				"pgc.rf_armor": [
+					"pg.rf_light_armor",
 					"pg.rf_medium_armor"
 				],
 				"pgc.rf_fighting_style": [
 					"pg.rf_power",
+					"pg.rf_shield",
 					"pg.rf_swift"
 				]
 			}
@@ -55,7 +45,6 @@
 	{
 		if (this.m.IsNew)
 		{
-			this.getContainer().add(::new("scripts/skills/effects/rf_swordmasters_finesse_effect"));
 			this.getContainer().add(::MSU.new("scripts/skills/perks/perk_mastery_sword", function(o) {
 				o.m.IsRefundable = false;
 			}));
@@ -66,7 +55,8 @@
 	q.onBuildPerkTree <- function()
 	{
 		local perkTree = this.getContainer().getActor().getPerkTree();
-		local masteryPerks = [
+		local perksToRemove = [
+			"perk.rf_professional",
 			"perk.mastery.axe",
 			"perk.mastery.bow",
 			"perk.mastery.cleaver",
@@ -79,7 +69,7 @@
 			"perk.mastery.spear",
 			"perk.mastery.throwing",
 		];
-		foreach (perk in masteryPerks)
+		foreach (perk in perksToRemove)
 		{
 			if (perkTree.hasPerk(perk)) perkTree.removePerk(perk);
 		}

--- a/mod_reforged/hooks/skills/backgrounds/tailor_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/tailor_background.nut
@@ -5,11 +5,13 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 1.2,
 			"pg.rf_fast": 1.2,
-			"pg.rf_large": 0.8,
-			"pg.rf_resilient": 0.8,
-			"pg.rf_sturdy": 0.75,
-			"pg.rf_talented": 3
+			"pg.rf_strong": 0.8,
+			"pg.rf_vigorous": 0.75,
+			"pg.special.student": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/tailor_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/tailor_background.nut
@@ -22,4 +22,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/tailor_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/tailor_southern_background.nut
@@ -5,11 +5,13 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 1.2,
 			"pg.rf_fast": 1.2,
-			"pg.rf_large": 0.8,
-			"pg.rf_resilient": 0.8,
-			"pg.rf_sturdy": 0.75,
-			"pg.rf_talented": 3
+			"pg.rf_strong": 0.8,
+			"pg.rf_vigorous": 0.75,
+			"pg.special.student": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],

--- a/mod_reforged/hooks/skills/backgrounds/tailor_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/tailor_southern_background.nut
@@ -22,4 +22,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/thief_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/thief_background.nut
@@ -25,4 +25,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/thief_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/thief_background.nut
@@ -5,16 +5,18 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 3,
 			"pg.rf_fast": 3,
-			"pg.rf_resilient": 1.2,
-			"pg.rf_talented": 2,
-			"pg.rf_dagger": 6
+			"pg.rf_heavy_armor": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
-				"pgc.rf_exclusive_1": [],
-				"pgc.rf_shared_1": [
-					"pg.rf_devious"
+				"pgc.rf_exclusive_1": [
+					"pg.rf_knave"
 				],
+				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [],
 				"pgc.rf_fighting_style": [

--- a/mod_reforged/hooks/skills/backgrounds/thief_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/thief_southern_background.nut
@@ -24,4 +24,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/thief_southern_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/thief_southern_background.nut
@@ -5,16 +5,17 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 3,
 			"pg.rf_fast": 3,
-			"pg.rf_resilient": 1.2,
-			"pg.rf_talented": 2,
-			"pg.rf_dagger": 6
+			"pg.rf_heavy_armor": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
-				"pgc.rf_exclusive_1": [],
-				"pgc.rf_shared_1": [
-					"pg.rf_devious"
+				"pgc.rf_exclusive_1": [
+					"pg.rf_knave"
 				],
+				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
 				"pgc.rf_armor": [],
 				"pgc.rf_fighting_style": [

--- a/mod_reforged/hooks/skills/backgrounds/vagabond_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/vagabond_background.nut
@@ -3,12 +3,14 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 0.66,
-			"pg.rf_leadership": 0.5,
-			"pg.rf_resilient": 0.5,
-			"pg.rf_sturdy": 2,
+			"pg.rf_strong": 0.66,
+			"pg.special.rf_leadership": 0.5,
+			"pg.rf_vigorous": 0.5,
 			"pg.rf_unstoppable": 2
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/vagabond_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/vagabond_background.nut
@@ -23,4 +23,13 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_weapon":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/wildman_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/wildman_background.nut
@@ -5,10 +5,12 @@
 		this.m.PerkTreeMultipliers = {
 			"pg.rf_agile": 0.9,
 			"pg.rf_fast": 0.8,
-			"pg.rf_large": 3,
-			"pg.rf_resilient": 5,
-			"pg.rf_sturdy": 3
+			"pg.rf_strong": 3,
+			"pg.rf_vigorous": 3,
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.MeleeOnly);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [

--- a/mod_reforged/hooks/skills/backgrounds/witchhunter_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/witchhunter_background.nut
@@ -26,4 +26,16 @@
 			}
 		});
 	}
+
+	q.getPerkGroupCollectionMin = @() function( _collection )
+	{
+		switch (_category.getID())
+		{
+			case "pgc.rf_shared_1":
+				return _category.getMin() + 1;
+
+			case "pgc.rf_armor":
+				return _category.getMin() - 1;
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/witchhunter_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/witchhunter_background.nut
@@ -3,13 +3,15 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_leadership": 10,
+			"pg.special.rf_leadership": 10,
 			"pg.rf_tactician": 3,
 			"pg.rf_unstoppable": 2,
 			"pg.rf_vicious": 2,
-			"pg.rf_bow": 2
+			"pg.rf_heavy_armor": 0
 		};
+
+		::MSU.Table.merge(this.m.PerkTreeMultipliers, ::Reforged.Skills.PerkTreeMultipliers.RangedBackground);
+
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [],
@@ -17,9 +19,7 @@
 				"pgc.rf_weapon": [
 					"pg.rf_crossbow"
 				],
-				"pgc.rf_armor": [
-					"pg.rf_light_armor"
-				],
+				"pgc.rf_armor": [],
 				"pgc.rf_fighting_style": [
 					"pg.rf_ranged"
 				]

--- a/mod_reforged/hooks/skills/traits/ailing_trait.nut
+++ b/mod_reforged/hooks/skills/traits/ailing_trait.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_resilient": 0.5
+			"pg.rf_vigorous": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/asthmatic_trait.nut
+++ b/mod_reforged/hooks/skills/traits/asthmatic_trait.nut
@@ -3,7 +3,8 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_sturdy": 0.5
+			"pg.rf_vigorous": 0,
+			"perk.rf_man_of_steel": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/bleeder_trait.nut
+++ b/mod_reforged/hooks/skills/traits/bleeder_trait.nut
@@ -4,7 +4,7 @@
 		__original();
 		this.m.Description = "This character is prone to bleeding and will do so more than most others."; // "more than" as opposed to vanilla "longer than"
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_resilient": 0.5
+			"pg.rf_vigorous": 0
 		};
 	}
 

--- a/mod_reforged/hooks/skills/traits/brave_trait.nut
+++ b/mod_reforged/hooks/skills/traits/brave_trait.nut
@@ -3,8 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 2,
-			"pg.rf_unstoppable": 2
+			"pg.special.rf_leadership": 2
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/bright_trait.nut
+++ b/mod_reforged/hooks/skills/traits/bright_trait.nut
@@ -3,7 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 10
+			"pg.special.rf_discovered_talent": 2,
+			"pg.special.rf_gifted": 2,
+			"pg.special.rf_rising_star": 2,
+			"pg.special.rf_student": 2
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/brute_trait.nut
+++ b/mod_reforged/hooks/skills/traits/brute_trait.nut
@@ -3,14 +3,13 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_trained": 0.5,
+			"pg.rf_trained": 0,
 			"pg.rf_axe": 1.5,
-			"pg.rf_cleaver": 0.66,
 			"pg.rf_flail": 2,
-			"pg.rf_hammer": 0.66,
 			"pg.rf_mace": 1.5,
-			"pg.rf_spear": 0.5,
-			"pg.rf_sword": 0.8
+			"pg.rf_spear": 0,
+			"pg.rf_sword": 0.9,
+			"pg.special.rf_back_to_basics": 0
 		};
 	}
 

--- a/mod_reforged/hooks/skills/traits/clubfooted_trait.nut
+++ b/mod_reforged/hooks/skills/traits/clubfooted_trait.nut
@@ -3,8 +3,8 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 0.5,
-			"pg.rf_fast": 0.5
+			"pg.rf_agile": 0,
+			"pg.rf_fast": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/cocky_trait.nut
+++ b/mod_reforged/hooks/skills/traits/cocky_trait.nut
@@ -3,7 +3,9 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.fast": 1.5
+			"pg.rf_fast": 1.5,
+			"pg.rf_trained": 0.5,
+			"pg.rf_shield": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/craven_trait.nut
+++ b/mod_reforged/hooks/skills/traits/craven_trait.nut
@@ -3,9 +3,8 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 0,
-			"pg.rf_resilient": 0.25,
-			"pg.rf_unstoppable": 0.25
+			"pg.special.rf_leadership": 0,
+			"pg.rf_unstoppable": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/dastard_trait.nut
+++ b/mod_reforged/hooks/skills/traits/dastard_trait.nut
@@ -3,9 +3,8 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 0,
-			"pg.rf_resilient": 0.25,
-			"pg.rf_unstoppable": 0.25
+			"pg.special.rf_leadership": 0,
+			"pg.rf_unstoppable": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/deathwish_trait.nut
+++ b/mod_reforged/hooks/skills/traits/deathwish_trait.nut
@@ -3,8 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_resilient": 2,
-			"pg.rf_unstoppable": 3
+			"pg.rf_unstoppable": -1
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/disloyal_trait.nut
+++ b/mod_reforged/hooks/skills/traits/disloyal_trait.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 2
+			"pg.special.rf_leadership": 0
 		};
 	}
 

--- a/mod_reforged/hooks/skills/traits/drunkard_trait.nut
+++ b/mod_reforged/hooks/skills/traits/drunkard_trait.nut
@@ -3,9 +3,9 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 0.25,
-			"pg.rf_talented": 0.25,
-			"pg.rf_trained": 0.5
+			"pg.special.rf_leadership": 0.25,
+			"pg.rf_trained": 0.5,
+			"pg.special.rf_marksmanship": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/dumb_trait.nut
+++ b/mod_reforged/hooks/skills/traits/dumb_trait.nut
@@ -3,7 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_talented": 0
+			"pg.special.rf_discovered_talent": 0,
+			"pg.special.rf_gifted": 0,
+			"pg.special.rf_rising_star": 0,
+			"pg.special.rf_student": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/eagle_eyes_trait.nut
+++ b/mod_reforged/hooks/skills/traits/eagle_eyes_trait.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"perk.rf_marksmanship": 3
+			"pg.special.rf_marksmanship": 3
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/fainthearted_trait.nut
+++ b/mod_reforged/hooks/skills/traits/fainthearted_trait.nut
@@ -3,8 +3,8 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 0.5,
-			"pg.rf_resilient": 0.5,
+			"pg.special.rf_leadership": 0.5,
+			"pg.rf_vigorous": 0.5,
 			"pg.rf_unstoppable": 0.5
 		};
 	}

--- a/mod_reforged/hooks/skills/traits/fat_trait.nut
+++ b/mod_reforged/hooks/skills/traits/fat_trait.nut
@@ -3,10 +3,9 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 0.5,
-			"pg.rf_fast": 0.5,
-			"pg.rf_large": -1,
-			"pg.rf_sturdy": 0.5
+			"pg.rf_agile": 0,
+			"pg.rf_fast": 0,
+			"pg.rf_strong": 2
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/fearless_trait.nut
+++ b/mod_reforged/hooks/skills/traits/fearless_trait.nut
@@ -3,8 +3,8 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_leadership": 5,
-			"pg.rf_unstoppable": 3
+			"pg.special.rf_leadership": 5,
+			"pg.rf_unstoppable": -1
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/gluttonous_trait.nut
+++ b/mod_reforged/hooks/skills/traits/gluttonous_trait.nut
@@ -3,9 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 0.75,
-			"pg.rf_fast": 0.75,
-			"pg.rf_large": 2
+			"pg.rf_agile": 0.5,
+			"pg.rf_fast": 0.5,
+			"pg.rf_strong": 2,
+			"pg.rf_vigorous": 2
 		};
 	}
 

--- a/mod_reforged/hooks/skills/traits/greedy_trait.nut
+++ b/mod_reforged/hooks/skills/traits/greedy_trait.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 2,
+			"pg.special.rf_leadership": 0.5,
 			"pg.rf_vicious": 2
 		};
 	}

--- a/mod_reforged/hooks/skills/traits/hesitant_trait.nut
+++ b/mod_reforged/hooks/skills/traits/hesitant_trait.nut
@@ -3,8 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 0.5,
-			"pg.rf_fast": 0.5
+			"pg.rf_fast": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/huge_trait.nut
+++ b/mod_reforged/hooks/skills/traits/huge_trait.nut
@@ -3,8 +3,10 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 0.5,
-			"pg.rf_large": -1
+			"pg.rf_agile": 0.5,
+			"pg.rf_fast": 0.5,
+			"pg.rf_strong": 2,
+			"pg.rf_vigorous": 2
 		};
 	}
 	

--- a/mod_reforged/hooks/skills/traits/insecure_trait.nut
+++ b/mod_reforged/hooks/skills/traits/insecure_trait.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
+			"pg.special.rf_leadership": 0,
 			"pg.rf_unstoppable": 0
 		};
 	}

--- a/mod_reforged/hooks/skills/traits/iron_jaw_trait.nut
+++ b/mod_reforged/hooks/skills/traits/iron_jaw_trait.nut
@@ -3,8 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_resilient": -1,
-			"pg.rf_sturdy": 2
+			"pg.rf_vigorous": 2
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/iron_lungs_trait.nut
+++ b/mod_reforged/hooks/skills/traits/iron_lungs_trait.nut
@@ -1,4 +1,4 @@
-::Reforged.HooksMod.hook("scripts/skills/traits/strong_trait", function(q) {
+::Reforged.HooksMod.hook("scripts/skills/traits/iron_lungs_trait", function(q) {
 	q.create = @(__original) function()
 	{
 		__original();

--- a/mod_reforged/hooks/skills/traits/irrational_trait.nut
+++ b/mod_reforged/hooks/skills/traits/irrational_trait.nut
@@ -1,9 +1,8 @@
-::Reforged.HooksMod.hook("scripts/skills/traits/clumsy_trait", function(q) {
+::Reforged.HooksMod.hook("scripts/skills/traits/irrational_trait", function(q) {
 	q.create = @(__original) function()
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_trained": 0,
 			"pg.special.rf_back_to_basics": 0
 		};
 	}

--- a/mod_reforged/hooks/skills/traits/night_blind_trait.nut
+++ b/mod_reforged/hooks/skills/traits/night_blind_trait.nut
@@ -1,4 +1,4 @@
-::Reforged.HooksMod.hook("scripts/skills/traits/short_sighted_trait", function(q) {
+::Reforged.HooksMod.hook("scripts/skills/traits/night_blind_trait", function(q) {
 	q.create = @(__original) function()
 	{
 		__original();

--- a/mod_reforged/hooks/skills/traits/optimist_trait.nut
+++ b/mod_reforged/hooks/skills/traits/optimist_trait.nut
@@ -3,6 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
+			"pg.special.rf_leadership": 2,
 			"pg.rf_unstoppable": 2
 		};
 	}

--- a/mod_reforged/hooks/skills/traits/paranoid_trait.nut
+++ b/mod_reforged/hooks/skills/traits/paranoid_trait.nut
@@ -3,9 +3,9 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 0.25,
-			"pg.rf_fast": 0.25,
-			"pg.rf_tactician": 0
+			"pg.special.rf_leadership": 0,
+			"pg.rf_tactician": 0,
+			"pg.rf_unstoppable": 0
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/quick_trait.nut
+++ b/mod_reforged/hooks/skills/traits/quick_trait.nut
@@ -3,8 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_agile": 2,
-			"pg.rf_fast": 2
+			"pg.rf_fast": -1
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/spartan_trait.nut
+++ b/mod_reforged/hooks/skills/traits/spartan_trait.nut
@@ -3,7 +3,8 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_resilient": 0.5
+			"pg.rf_strong": 0.5,
+			"pg.rf_vigorous": 0.5
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/superstitious_trait.nut
+++ b/mod_reforged/hooks/skills/traits/superstitious_trait.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_resilient": 0.5
+			"pg.rf_vigorous": 0.5
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/survivor_trait.nut
+++ b/mod_reforged/hooks/skills/traits/survivor_trait.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_resilient": -1
+			"pg.rf_vigorous": -1
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/tiny_trait.nut
+++ b/mod_reforged/hooks/skills/traits/tiny_trait.nut
@@ -3,8 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 2,
-			"pg.rf_large": 0
+			"pg.rf_strong": 0
 		};
 	}
 

--- a/mod_reforged/hooks/skills/traits/tough_trait.nut
+++ b/mod_reforged/hooks/skills/traits/tough_trait.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_large": 2
+			"pg.rf_strong": -1
 		};
 	}
 });

--- a/mod_reforged/hooks/skills/traits/weasel_trait.nut
+++ b/mod_reforged/hooks/skills/traits/weasel_trait.nut
@@ -1,9 +1,9 @@
-::Reforged.HooksMod.hook("scripts/skills/traits/fragile_trait", function(q) {
+::Reforged.HooksMod.hook("scripts/skills/traits/weasel_trait", function(q) {
 	q.create = @(__original) function()
 	{
 		__original();
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_strong": 0
+			"pg.rf_agile": -1
 		};
 	}
 });

--- a/scripts/mods/mod_reforged/perk_group_collections/pgc_rf_shared_1.nut
+++ b/scripts/mods/mod_reforged/perk_group_collections/pgc_rf_shared_1.nut
@@ -12,7 +12,7 @@ this.pgc_rf_shared_1 <- ::inherit(::DynamicPerks.Class.PerkGroupCollection, {
 			"pg.rf_devious",
 			"pg.rf_fast",
 			"pg.rf_large",
-			"pg.rf_leadership",
+			"pg.special.rf_leadership",
 			"pg.rf_resilient",
 			"pg.rf_sturdy",
 			"pg.rf_tactician",

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_crossbow.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_crossbow.nut
@@ -20,4 +20,9 @@ this.pg_rf_crossbow <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 			]
 		};
 	}
+
+	function getSelfMultiplier( _perkTree )
+	{
+		return 0.5;
+	}
 });

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_heavy_armor.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_heavy_armor.nut
@@ -23,6 +23,6 @@ this.pg_rf_heavy_armor <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 
 	function getSelfMultiplier( _perkTree )
 	{
-		return 0.5;
+		return 0.33;
 	}
 });

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_laborer.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_laborer.nut
@@ -20,5 +20,9 @@ this.pg_rf_laborer <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 				[]
 			]
 		};
+		this.m.PerkTreeMultipliers = {
+			"pg.rf_strong": 1.5,
+			"pg.rf_vigorous": 1.5
+		};
 	}
 });

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_noble.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_noble.nut
@@ -22,6 +22,7 @@ this.pg_rf_noble <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 			]
 		};
 		this.m.PerkTreeMultipliers = {
+			"pg.rf_tactician": 2,
 			"pg.rf_trained": 1.5
 		};
 	}

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_pauper.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_pauper.nut
@@ -22,8 +22,10 @@ this.pg_rf_pauper <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 			]
 		};
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 1.5,
-			"pg.rf_talented": 0
+			"pg.special.rf_discovered_talent": 0,
+			"pg.special.rf_gifted": 0,
+			"pg.special.rf_rising_star": 0,
+			"pg.special.rf_student": 0
 		};
 	}
 });

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_soldier.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_soldier.nut
@@ -22,7 +22,9 @@ this.pg_rf_soldier <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 			]
 		};
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_trained": -1
+			"pg.rf_trained": -1,
+			"pg.special.rf_back_to_basics": 2.5,
+			"pg.special.rf_professional": -1
 		};
 	}
 });

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_spear.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_spear.nut
@@ -23,6 +23,6 @@ this.pg_rf_spear <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 
 	function getSelfMultiplier( _perkTree )
 	{
-		return 1.33;
+		return 1.2;
 	}
 });

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_sword.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_sword.nut
@@ -23,6 +23,6 @@ this.pg_rf_sword <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 
 	function getSelfMultiplier( _perkTree )
 	{
-		return 1.2;
+		return 1.1;
 	}
 });

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_trained.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_trained.nut
@@ -30,6 +30,6 @@ this.pg_rf_trained <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 
 	function getSelfMultiplier( _perkTree )
 	{
-		return 0.75;
+		return 0.5;
 	}
 });

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_wildling.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_wildling.nut
@@ -22,18 +22,20 @@ this.pg_rf_wildling <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 			]
 		};
 		this.m.PerkTreeMultipliers = {
-			"pg.rf_devious": 0,
-			"pg.rf_leadership": 0,
+			"pg.special.rf_leadership": 0,
 			"pg.rf_tactician": 0,
-			"pg.rf_talented": 0,
 			"pg.rf_trained": 0,
 			"pg.rf_bow": 0,
 			"pg.rf_crossbow": 0,
 			"pg.rf_dagger": 0,
-			"pg.rf_spear": 0,
-			"pg.rf_sword": 0,
+			"pg.rf_spear": 0.8,
+			"pg.rf_sword": 0.9,
 			"pg.rf_ranged": 0,
-			"pg.rf_shield": 0
+			"pg.rf_shield": 0,
+			"pg.special.rf_back_to_basics": 0,
+			"pg.special.rf_discovered_talent": 0,
+			"pg.special.rf_gifted": 0,
+			"pg.special.rf_student": 0
 		};
 	}
 });

--- a/scripts/mods/mod_reforged/perk_groups/special/pg_special_rf_man_of_steel.nut
+++ b/scripts/mods/mod_reforged/perk_groups/special/pg_special_rf_man_of_steel.nut
@@ -9,7 +9,7 @@ this.pg_special_rf_man_of_steel <- ::inherit(::DynamicPerks.Class.SpecialPerkGro
 		this.m.FlavorText = [
 			"Is tough as if made of steel!"
 		];
-		this.m.Chance = 25;
+		this.m.Chance = 10;
 		this.m.Trees = {
 			"default": [
 				[],

--- a/scripts/mods/mod_reforged/perk_groups/special/pg_special_rf_marksmanship.nut
+++ b/scripts/mods/mod_reforged/perk_groups/special/pg_special_rf_marksmanship.nut
@@ -30,6 +30,6 @@ this.pg_special_rf_marksmanship <- ::inherit(::DynamicPerks.Class.SpecialPerkGro
 
 		local talents = _perkTree.getActor().getTalents();
 
-		return talents.len() == 0 || talents[::Const.Attributes.RangedSkill] < 2 ? 0 : talents[::Const.Attributes.RangedSkill];
+		return talents.len() == 0 ? 0 : talents[::Const.Attributes.RangedSkill];
 	}
 });


### PR DESCRIPTION
Requires find and replace for strong and vigorous groups if we change the names of those. 
Also requires code to make use of isMeleeOnly, isMeleeSpecialist, isMeleeBackground and isRangedBackground templates. We can find and replace those keywords depending on how the system gets implemented.

Not calling for review from Darxo at this point until these things are sorted.