### PR TITLE
fix: properly revert the changes to morale check bravery fields

### DIFF
--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -108,13 +108,15 @@
 	{
 		if (_change < 0)
 		{
-			this.getCurrentProperties().MoraleCheckBravery[_type] += this.getCurrentProperties().NegativeMoraleCheckBravery[_type];
-			this.getCurrentProperties().MoraleCheckBraveryMult[_type] *= this.getCurrentProperties().NegativeMoraleCheckBraveryMult[_type];
+			local p = this.getCurrentProperties();
+			p.MoraleCheckBravery[_type] += p.NegativeMoraleCheckBravery[_type];
+			p.MoraleCheckBraveryMult[_type] *= p.NegativeMoraleCheckBraveryMult[_type];
 		}
 		else if (_change > 0)
 		{
-			this.getCurrentProperties().MoraleCheckBravery[_type] += this.getCurrentProperties().PositiveMoraleCheckBravery[_type];
-			this.getCurrentProperties().MoraleCheckBraveryMult[_type] *= this.getCurrentProperties().PositiveMoraleCheckBraveryMult[_type];
+			local p = this.getCurrentProperties();
+			p.MoraleCheckBravery[_type] += p.PositiveMoraleCheckBravery[_type];
+			p.MoraleCheckBraveryMult[_type] *= p.PositiveMoraleCheckBraveryMult[_type];
 		}
 
 		local ret = __original(_change, _difficulty, _type, _showIconBeforeMoraleIcon, _noNewLine);

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -117,7 +117,13 @@
 			this.getCurrentProperties().MoraleCheckBraveryMult[_type] *= this.getCurrentProperties().PositiveMoraleCheckBraveryMult[_type];
 		}
 
-		return __original(_change, _difficulty, _type, _showIconBeforeMoraleIcon, _noNewLine);
+		local ret = __original(_change, _difficulty, _type, _showIconBeforeMoraleIcon, _noNewLine);
+
+		// This is the most secure way to revert the changes to MoraleCheckBravery and MoraleCheckBraveryMult.
+		// Reverting them manually has edge cases where you may or may not want to revert them depending on whether an update already happened.
+		this.m.Skills.update();
+
+		return ret;
 	}
 
 	q.getSurroundedCount = @(__original) function()


### PR DESCRIPTION
The changes from the Reforged-added positive and negative morale check related fields were being added to the CurrentProperties before the morale check, but were not being reverted after the morale check.