### PR TITLE
Feat more named names

### DIFF
--- a/mod_reforged/config/item_names.nut
+++ b/mod_reforged/config/item_names.nut
@@ -1,3 +1,69 @@
+// Vanilla Adjustments
+::MSU.Array.removeValues(::Const.Strings.CrossbowNames, [
+	"Betrayer"		// moved over to dagger names
+]);
+::Const.Strings.CrossbowNames.extend([
+	"Scorpion",
+	"Ironsight",
+	"Thunderbolt",
+	"Ravenshrike",
+	"Bloodbolt",
+	"Grimshot",
+	"Wyrmfang",
+	"Blackthorn",
+	"Stormbreaker",
+	"Steelwind"
+]);
+
+::MSU.Array.removeValues(::Const.Strings.DaggerNames, [
+	"Estoc"		// We have our own actual Estoc item
+]);
+::Const.Strings.DaggerNames.extend([
+	"Betrayer"		// formerly a crossbow name
+]);
+
+::Const.Strings.HandgonneNames.extend([
+	"Deafener",
+	"Eisenknall",
+	"Volcano",
+	"Ironspark",
+	"Thundermuzzle",
+	"Stormfire",
+	"Inferno",
+	"Blazeburst"
+]);
+
+::Const.Strings.LongaxeNames.extend([
+	"Culler"
+]);
+
+::Const.Strings.SwordlanceNames.extend([	// In Vanilla this has only 2 entries
+	"Bloodmoon",
+	"Ghoul\'s Bane",
+	"Soulstrike",
+	"Shadowreaper",
+	"Death\'s Hand",
+	"Grimharvest",
+	"Bloodstorm",
+	"Warbringer",
+	"Deathwind"
+]);
+
+::MSU.Array.removeValues(::Const.Strings.WarbrandNames, [
+	"Kriegsmesser",	// We have our own actual Kriegsmesser item
+]);
+
+::Const.Strings.WhipNames.extend([
+	"Slavedriver",
+	"Tendril",
+	"Vine",
+	"Bloodletter",
+	"Spikelash",
+	"Thornwhip",
+	"Bloodlash"
+]);
+
+// Reforged Lists
 ::Const.Strings.RF_KriegsmesserNames <- [
 	"Kriegsmesser",
 	"Ripper",
@@ -58,6 +124,3 @@
 	"Honor",
 	"Vanquisher"
 ];
-
-// Remove Kriegsmesser from Warbrand names because we have our own actual Kriegsmesser item
-::MSU.Array.removeByValue(::Const.Strings.WarbrandNames, "Kriegsmesser");

--- a/mod_reforged/hooks/msu.nut
+++ b/mod_reforged/hooks/msu.nut
@@ -320,4 +320,16 @@
 	}
 });
 
+::logInfo("Reforged::MSU -- adding ::MSU.Array.removeValues");
+::MSU.Array.removeValues <- function( _array, _values )
+{
+	for (local i = _array.len() - 1; i > 0; i--)
+	{
+		if (_values.find(_array[i]) != null)
+		{
+			_array.remove(i);
+		}
+	}
+}
+
 ::logWarning("------ Reforged modifications to MSU Finished------");


### PR DESCRIPTION
This PR was a spontaneous idea of mine when I saw that vanilla only has two famed swordlance names. So I went and added a few names here and there.

It also includes a proposal for a new `::MSU.Array.removeValues` function. The singular removeValue function of MSU is not very performant if we want to remove a list of names as it would iterative several times over the same array.