### PR TITLE
Fix pass correct killer to msu ondeath events

### DIFF
--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -207,13 +207,20 @@
 		// Store the real killer here before switching _killer for loot purposes. This is used to fix MSU onDeathWithInfo and onOtherActorDeath functions to have the correct killer
 		this.m.RF_RealKiller = _killer;
 
-		if (_killer != null && _killer.getFaction() != ::Const.Faction.Player && (::Const.Faction.Player in this.m.RF_DamageReceived) && this.m.RF_DamageReceived[::Const.Faction.Player].Total / this.m.RF_DamageReceived.Total >= 0.5)
+		if (_killer != null && _killer.getFaction() != ::Const.Faction.Player && _killer.getFaction() != ::Const.Faction.PlayerAnimals)
 		{
-			// If _killer isn't already a player character AND the player faction did at least 50% of total damage to this actor,
-			// we set the _killer to null to ensure that the loot properly drops from this actor.
+			local playerRelevantDamage = 0.0;
+			if (::Const.Faction.Player in this.m.RF_DamageReceived)
+				playerRelevantDamage += this.m.RF_DamageReceived[::Const.Faction.Player].Total;
+			if (::Const.Faction.PlayerAnimals in this.m.RF_DamageReceived)
+				playerRelevantDamage +=  this.m.RF_DamageReceived[::Const.Faction.PlayerAnimals].Total;
+
+			// If _killer isn't already a player character or player animal AND the player + player animals did at least 50%
+			// of total damage to this actor, we set the _killer to null to ensure that the loot properly drops from this actor.
 			// This is because vanilla drops loot if _killer is null or belongs to Player or PlayerAnimals faction
 			// Warning: This will break any mod that hooks the original onDeath and expects _killer to represent the actual killer
-			_killer = null;
+			if (playerRelevantDamage / this.m.RF_DamageReceived.Total >= 0.5)
+				_killer = null;
 		}
 
 		__original(_killer, _skill, _tile, _fatalityType);

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -207,7 +207,7 @@
 		// Store the real killer here before switching _killer for loot purposes. This is used to fix MSU onDeathWithInfo and onOtherActorDeath functions to have the correct killer
 		this.m.RF_RealKiller = _killer;
 
-		if ((::Const.Faction.Player in this.m.RF_DamageReceived) && this.m.RF_DamageReceived[::Const.Faction.Player].Total / this.m.RF_DamageReceived.Total >= 0.5)
+		if (_killer != null && _killer.getFaction() != ::Const.Faction.Player && (::Const.Faction.Player in this.m.RF_DamageReceived) && this.m.RF_DamageReceived[::Const.Faction.Player].Total / this.m.RF_DamageReceived.Total >= 0.5)
 		{
 			// If player faction did at least 50% of total damage to this actor,
 			// we award the kill to the bro who did the most damage (for the purposes of loot drop)

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -209,26 +209,11 @@
 
 		if (_killer != null && _killer.getFaction() != ::Const.Faction.Player && (::Const.Faction.Player in this.m.RF_DamageReceived) && this.m.RF_DamageReceived[::Const.Faction.Player].Total / this.m.RF_DamageReceived.Total >= 0.5)
 		{
-			// If player faction did at least 50% of total damage to this actor,
-			// we award the kill to the bro who did the most damage (for the purposes of loot drop)
-			// Note: This may have unintended consequences if someone expects `_killer` to be the actual killer.
-			local max = 0;
-			local killer;
-			foreach (broID, damage in this.m.RF_DamageReceived[::Const.Faction.Player])
-			{
-				if (broID == "Total") continue;
-				if (damage > max)
-				{
-					local entity = ::Tactical.getEntityByID(broID);
-					if (entity != null && entity.isAlive())
-					{
-						max = damage;
-						killer = entity;
-					}
-				}
-			}
-			if (killer != null)
-				_killer = killer;
+			// If _killer isn't already a player character AND the player faction did at least 50% of total damage to this actor,
+			// we set the _killer to null to ensure that the loot properly drops from this actor.
+			// This is because vanilla drops loot if _killer is null or belongs to Player or PlayerAnimals faction
+			// Warning: This will break any mod that hooks the original onDeath and expects _killer to represent the actual killer
+			_killer = null;
 		}
 
 		__original(_killer, _skill, _tile, _fatalityType);

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -2,6 +2,7 @@
 	q.m.IsPerformingAttackOfOpportunity <- false;
 	q.m.IsWaitingTurn <- false;		// Is only set true when using the new Wait-All button. While true this entity will try to use Wait when its their turn
 	q.m.RF_DamageReceived <- null; // Table with faction number as key and tables as values. These tables have actor ID as key and the damage dealt as their value. Is populated during skill_container.onDamageReceived
+	q.m.RF_RealKiller <- null; // Store the real killer here before switching _killer in onDeath for loot purposes. This is used to fix MSU onDeathWithInfo and onOtherActorDeath functions to have the correct killer
 
 	q.isDisarmed <- function()
 	{
@@ -203,6 +204,9 @@
 
 	q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )
 	{
+		// Store the real killer here before switching _killer for loot purposes. This is used to fix MSU onDeathWithInfo and onOtherActorDeath functions to have the correct killer
+		this.m.RF_RealKiller = _killer;
+
 		if ((::Const.Faction.Player in this.m.RF_DamageReceived) && this.m.RF_DamageReceived[::Const.Faction.Player].Total / this.m.RF_DamageReceived.Total >= 0.5)
 		{
 			// If player faction did at least 50% of total damage to this actor,
@@ -228,6 +232,8 @@
 		}
 
 		__original(_killer, _skill, _tile, _fatalityType);
+
+		this.m.RF_RealKiller = null;
 
 		// The following is an override of the XP gain system. We award XP based on ratio of total damage dealt to an entity.
 

--- a/mod_reforged/hooks/skills/skill_container.nut
+++ b/mod_reforged/hooks/skills/skill_container.nut
@@ -1,4 +1,14 @@
 ::Reforged.HooksMod.hook("scripts/skills/skill_container", function(q) {
+	q.onDeathWithInfo = @(__original) function( _killer, _skill, _deathTile, _corpseTile, _fatalityType )
+	{
+		__original(this.getActor().m.RF_RealKiller, _skill, _deathTile, _corpseTile, _fatalityType);
+	}
+
+	q.onOtherActorDeath = @(__original) function( _killer, _victim, _skill, _deathTile, _corpseTile, _fatalityType )
+	{
+		__original(this.getActor().m.RF_RealKiller, _victim, _skill, _deathTile, _corpseTile, _fatalityType);
+	}
+
 	q.onDamageReceived = @(__original) function( _attacker, _damageHitpoints, _damageArmor )
 	{
 		local damage = _damageArmor + ::Math.min(_damageHitpoints, this.getActor().getHitpoints());


### PR DESCRIPTION
- Fix the issue where we switch the `_killer` in our hook on actor `onDeath` function causing MSU hook on `onDeath` to receive this wrong killer.
- Clean up the switching of the `_killer` by setting it to `null` instead of to a bro, because this is enough to drop loot for the player.