### PR TITLE
Safer changing of killer in actor on death

### DIFF
--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -237,22 +237,6 @@
 
 	q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )
 	{
-		if (_killer != null && _killer.getFaction() != ::Const.Faction.Player && _killer.getFaction() != ::Const.Faction.PlayerAnimals)
-		{
-			local playerRelevantDamage = 0.0;
-			if (::Const.Faction.Player in this.m.RF_DamageReceived)
-				playerRelevantDamage += this.m.RF_DamageReceived[::Const.Faction.Player].Total;
-			if (::Const.Faction.PlayerAnimals in this.m.RF_DamageReceived)
-				playerRelevantDamage +=  this.m.RF_DamageReceived[::Const.Faction.PlayerAnimals].Total;
-
-			// If _killer isn't already a player character or player animal AND the player + player animals did at least 50%
-			// of total damage to this actor, we set the _killer to null to ensure that the loot properly drops from this actor.
-			// This is because vanilla drops loot if _killer is null or belongs to Player or PlayerAnimals faction
-			// Warning: This will break any mod that hooks the original onDeath and expects _killer to represent the actual killer
-			if (playerRelevantDamage / this.m.RF_DamageReceived.Total >= 0.5)
-				_killer = null;
-		}
-
 		__original(_killer, _skill, _tile, _fatalityType);
 
 		// The following is an override of the XP gain system. We award XP based on ratio of total damage dealt to an entity.

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -1,7 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/entity/tactical/actor", function(q) {
 	q.m.IsWaitingTurn <- false;		// Is only set true when using the new Wait-All button. While true this entity will try to use Wait when its their turn
 	q.m.RF_DamageReceived <- null; // Table with faction number as key and tables as values. These tables have actor ID as key and the damage dealt as their value. Is populated during skill_container.onDamageReceived
-	q.m.RF_RealKiller <- null; // Store the real killer here before switching _killer in onDeath for loot purposes. This is used to fix MSU onDeathWithInfo and onOtherActorDeath functions to have the correct killer
 
 	q.isDisarmed <- function()
 	{
@@ -238,9 +237,6 @@
 
 	q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )
 	{
-		// Store the real killer here before switching _killer for loot purposes. This is used to fix MSU onDeathWithInfo and onOtherActorDeath functions to have the correct killer
-		this.m.RF_RealKiller = _killer;
-
 		if (_killer != null && _killer.getFaction() != ::Const.Faction.Player && _killer.getFaction() != ::Const.Faction.PlayerAnimals)
 		{
 			local playerRelevantDamage = 0.0;
@@ -258,8 +254,6 @@
 		}
 
 		__original(_killer, _skill, _tile, _fatalityType);
-
-		this.m.RF_RealKiller = null;
 
 		// The following is an override of the XP gain system. We award XP based on ratio of total damage dealt to an entity.
 

--- a/mod_reforged/hooks/skills/skill_container.nut
+++ b/mod_reforged/hooks/skills/skill_container.nut
@@ -1,14 +1,4 @@
 ::Reforged.HooksMod.hook("scripts/skills/skill_container", function(q) {
-	q.onDeathWithInfo = @(__original) function( _killer, _skill, _deathTile, _corpseTile, _fatalityType )
-	{
-		__original(this.getActor().m.RF_RealKiller, _skill, _deathTile, _corpseTile, _fatalityType);
-	}
-
-	q.onOtherActorDeath = @(__original) function( _killer, _victim, _skill, _deathTile, _corpseTile, _fatalityType )
-	{
-		__original(this.getActor().m.RF_RealKiller, _victim, _skill, _deathTile, _corpseTile, _fatalityType);
-	}
-
 	q.onDamageReceived = @(__original) function( _attacker, _damageHitpoints, _damageArmor )
 	{
 		local damage = _damageArmor + ::Math.min(_damageHitpoints, this.getActor().getHitpoints());

--- a/scripts/!mods_preload/mod_reforged.nut
+++ b/scripts/!mods_preload/mod_reforged.nut
@@ -44,21 +44,17 @@ foreach (requirement in requiredMods)
 	::Reforged.HooksMod.hookTree("scripts/entity/tactical/actor", function(q) {
 		q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )
 		{
-			if (_killer != null && _killer.getFaction() != ::Const.Faction.Player && _killer.getFaction() != ::Const.Faction.PlayerAnimals)
-			{
-				local playerRelevantDamage = 0.0;
-				if (::Const.Faction.Player in this.m.RF_DamageReceived)
-					playerRelevantDamage += this.m.RF_DamageReceived[::Const.Faction.Player].Total;
-				if (::Const.Faction.PlayerAnimals in this.m.RF_DamageReceived)
-					playerRelevantDamage +=  this.m.RF_DamageReceived[::Const.Faction.PlayerAnimals].Total;
+			local playerRelevantDamage = 0.0;
+			if (::Const.Faction.Player in this.m.RF_DamageReceived)
+				playerRelevantDamage += this.m.RF_DamageReceived[::Const.Faction.Player].Total;
+			if (::Const.Faction.PlayerAnimals in this.m.RF_DamageReceived)
+				playerRelevantDamage +=  this.m.RF_DamageReceived[::Const.Faction.PlayerAnimals].Total;
 
-				// If _killer isn't already a player character or player animal AND the player + player animals did at least 50%
-				// of total damage to this actor, we set the _killer to null to ensure that the loot properly drops from this actor.
-				// This is because vanilla drops loot if _killer is null or belongs to Player or PlayerAnimals faction
-				// Warning: This will break any mod that hooks the original onDeath and expects _killer to represent the actual killer
-				if (playerRelevantDamage / this.m.RF_DamageReceived.Total >= 0.5)
-					_killer = null;
-			}
+			// If player + player animals did at least 50% of total damage to this actor, we set the _killer to null to ensure that the loot properly drops from this actor.
+			// This is because vanilla drops loot if _killer is null or belongs to Player or PlayerAnimals faction.
+			// Warning: This will break any mod that hooks the original onDeath and expects _killer to represent the actual killer
+			if (playerRelevantDamage / this.m.RF_DamageReceived.Total >= 0.5)
+				_killer = null;
 
 			__original(_killer, _skill, _tile, _fatalityType);
 		}

--- a/scripts/!mods_preload/mod_reforged.nut
+++ b/scripts/!mods_preload/mod_reforged.nut
@@ -54,7 +54,14 @@ foreach (requirement in requiredMods)
 			// This is because vanilla drops loot if _killer is null or belongs to Player or PlayerAnimals faction.
 			// Warning: This will break any mod that hooks the original onDeath and expects _killer to represent the actual killer
 			if (playerRelevantDamage / this.m.RF_DamageReceived.Total >= 0.5)
+			{
 				_killer = null;
+			}
+			// Otherwise set the killer to the dying entity itself, so loot doesn't spawn for the player
+			else if (_killer == null || _killer.getFaction() == ::Const.Faction.Player || _killer.getFaction() == ::Const.Faction.PlayerAnimals)
+			{
+				_killer = this;
+			}
 
 			__original(_killer, _skill, _tile, _fatalityType);
 		}

--- a/scripts/!mods_preload/mod_reforged.nut
+++ b/scripts/!mods_preload/mod_reforged.nut
@@ -39,6 +39,32 @@ foreach (requirement in requiredMods)
 	queueLoadOrder.push(">" + (idx == null ? requirement : requirement.slice(0, idx)));
 }
 
+// TODO: Establish a cleaner way to organize "Early" bucket hooks on a per-file basis
+::Reforged.HooksMod.queue(queueLoadOrder, function() {
+	::Reforged.HooksMod.hookTree("scripts/entity/tactical/actor", function(q) {
+		q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )
+		{
+			if (_killer != null && _killer.getFaction() != ::Const.Faction.Player && _killer.getFaction() != ::Const.Faction.PlayerAnimals)
+			{
+				local playerRelevantDamage = 0.0;
+				if (::Const.Faction.Player in this.m.RF_DamageReceived)
+					playerRelevantDamage += this.m.RF_DamageReceived[::Const.Faction.Player].Total;
+				if (::Const.Faction.PlayerAnimals in this.m.RF_DamageReceived)
+					playerRelevantDamage +=  this.m.RF_DamageReceived[::Const.Faction.PlayerAnimals].Total;
+
+				// If _killer isn't already a player character or player animal AND the player + player animals did at least 50%
+				// of total damage to this actor, we set the _killer to null to ensure that the loot properly drops from this actor.
+				// This is because vanilla drops loot if _killer is null or belongs to Player or PlayerAnimals faction
+				// Warning: This will break any mod that hooks the original onDeath and expects _killer to represent the actual killer
+				if (playerRelevantDamage / this.m.RF_DamageReceived.Total >= 0.5)
+					_killer = null;
+			}
+
+			__original(_killer, _skill, _tile, _fatalityType);
+		}
+	});
+}, ::Hooks.QueueBucket.Early);
+
 ::Reforged.HooksMod.queue(queueLoadOrder, function() {
 	::Reforged.Mod <- ::MSU.Class.Mod(::Reforged.ID, ::Reforged.Version, ::Reforged.Name);	
 


### PR DESCRIPTION
After having merged #369 I realized that the part about passing the correct killer to MSU `skill_container` functions was unnecessary because MSU hooks the actor `onDeath` function _after_ Reforged. So I'm reverting that. But this also gave me the idea that we should do this changing of `_killer` as early as possible i.e. before most other mods would `hookTree` the `onDeath` of actor, so I have moved it to an Early bucket hook. This should make most mods safe from breaking due to our modification of `_killer`.

We don't have a clean setup for Early bucket hooks right now. The "proper" way would be to load all our files in the `First` bucket and then within each file we `push` the function to our custom buckets arrays and then queue them e.g. like we do currently with `FirstWorldInit` and `Late` buckets. But this requires a major refactor of every hook in the codebase so I've not done it in this PR.