### PR TITLE
Rework duelist validity

### DIFF
--- a/mod_reforged/config/items.nut
+++ b/mod_reforged/config/items.nut
@@ -1,0 +1,27 @@
+::Reforged.Items <- {
+	function isDuelistValid( _weapon )
+	{
+		if (_weapon.isEquipped())
+			return _weapon.getContainer().getActor().getSkills().getAttackOfOpportunity().isDuelistValid();
+
+		local copy = ::new(::IO.scriptFilenameByHash(_weapon.ClassNameHash));
+		local player = ::MSU.getDummyPlayer();
+		player.equip(copy);
+		local ret = player.getSkills().getAttackOfOpportunity().isDuelistValid();
+		player.unequip(copy);
+		return ret;
+	}
+
+	function getSkills( _item )
+	{
+		if (_item.isEquipped())
+			return _item.getSkills();
+
+		local copy = ::new(::IO.scriptFilenameByHash(_item.ClassNameHash));
+		local player = ::MSU.getDummyPlayer();
+		player.equip(copy);
+		local ret = copy.getSkills();
+		player.unequip(copy);
+		return ret;
+	}
+};

--- a/mod_reforged/config/items.nut
+++ b/mod_reforged/config/items.nut
@@ -1,13 +1,18 @@
 ::Reforged.Items <- {
 	function isDuelistValid( _weapon )
 	{
+		local function isSkillValid( _skill )
+		{
+			return _skill.getBaseValue("ActionPointCost") <= 4 && _skill.isDuelistValid();
+		}
+
 		if (_weapon.isEquipped())
-			return _weapon.getContainer().getActor().getSkills().getAttackOfOpportunity().isDuelistValid();
+			return isSkillValid(_weapon.getContainer().getActor().getSkills().getAttackOfOpportunity());
 
 		local copy = ::new(::IO.scriptFilenameByHash(_weapon.ClassNameHash));
 		local player = ::MSU.getDummyPlayer();
 		player.equip(copy);
-		local ret = player.getSkills().getAttackOfOpportunity().isDuelistValid();
+		local ret = isSkillValid(player.getSkills().getAttackOfOpportunity());
 		player.unequip(copy);
 		return ret;
 	}

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -387,7 +387,7 @@ local vanillaDescriptions = [
 		Key = "Duelist",
 		Description = ::UPD.getDescription({
 	 		Fluff = "Become one with your weapon and go for the weak spots!",
-	 		Requirement = "Melee Attack",
+	 		Requirement = "Weapon whose primary melee attack has a Base [Action Point|Concept.ActionPoints] cost of 4 or less",
 	 		Effects = [{
  				Type = ::UPD.EffectType.Passive,
  				Description = [
@@ -396,7 +396,7 @@ local vanillaDescriptions = [
  					"Shields now also negate the [Reach Advantage|Concept.ReachAdvantage] of the target when attacking."
  				]
  			}],
- 			Footer = ::MSU.Text.colorRed("This perk ONLY works with melee attacks with a [Base|Concept.BaseAttribute] [Action Point|Concept.ActionPoints] cost of 4 or less that are either [Lunge|Skill+lunge_skill] or have a Base Maximum Range of 1 tile.")
+ 			Footer = ::MSU.Text.colorRed("This perk ONLY works with melee attacks that have a Base Maximum Range of 1 tile, with the exception of [Lunge|Skill+lunge_skill].")
 	 	})
 	},
 	{

--- a/mod_reforged/hooks/skills/perks/perk_duelist.nut
+++ b/mod_reforged/hooks/skills/perks/perk_duelist.nut
@@ -22,13 +22,16 @@
 		return aoo != null && aoo.isDuelistValid();
 	}
 
-	q.onAnySkillUsed <- function( _skill, _targetEntity, _properties )
+	q.onAnySkillUsed = @() function( _skill, _targetEntity, _properties )
 	{
 		if (!_skill.isDuelistValid())
 			return;
 
-		local weapon = this.getContainer().getActor().getMainhandItem();
-		if (weapon == null || weapon.isItemType((::Const.Items.ItemType.OneHanded)))
+		local weapon = _skill.getItem();
+		if (weapon == null || !weapon.isItemType(::Const.Items.ItemType.Weapon) || !::Reforged.Items.isDuelistValid(weapon))
+			return;
+
+		if (weapon.isItemType(::Const.Items.ItemType.OneHanded))
 		{
 			_properties.DamageDirectAdd += 0.25;
 			if (this.getContainer().getActor().isArmedWithShield())

--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -1,7 +1,7 @@
 ::Reforged.HooksMod.hook("scripts/skills/skill", function(q) {
 	q.isDuelistValid <- function()
 	{
-		return this.isAttack() && !this.isRanged() && this.getBaseValue("ActionPointCost") <= 4 && this.getBaseValue("MaxRange") == 1;
+		return this.isAttack() && !this.isRanged() && this.getBaseValue("MaxRange") == 1;
 	}
 
 	q.getHitFactors = @(__original) function( _targetTile )


### PR DESCRIPTION
- Remove requirement for base AP cost of skill to be <= 4.
- Add requirement for being the skill of a weapon whose primary attack has a Base AP cost of <=4 (this means it no longer work with unarmed attacks - this is acceptable imo because this keeps the code a lot cleaner).
- Still requires the skill to be melee with a base maximum range of 1 tile.