### PR TITLE
fix: resource usage and cost calculation for units with subparties

### DIFF
--- a/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
@@ -43,30 +43,30 @@ local units = [
 	{
 		ID = "Unit.RF.BarbarianBeastmasterU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 15 + 55,
+		Cost = 15,
 		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
-		SubPartyDef = {BaseID = "OneUnhold"}
+		SubPartyDef = {BaseID = "OneUnhold", IsUsingTopPartyResources = false }
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterUU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 15 + 55 + 55,
+		Cost = 15,
 		StartingResourceMin = 400, // In Vanilla they appear in a group of 400 cost
-		SubPartyDef = {BaseID = "TwoUnhold"}
+		SubPartyDef = {BaseID = "TwoUnhold", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 15 + 75,
+		Cost = 15,
 		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
-		SubPartyDef = {BaseID = "OneFrostUnhold"}
+		SubPartyDef = {BaseID = "OneFrostUnhold", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterFF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 15 + 75 + 75,
+		Cost = 15,
 		StartingResourceMin = 430, // In Vanilla they appear in a group of 430 cost
-		SubPartyDef = {BaseID = "TwoFrostUnhold"}
+		SubPartyDef = {BaseID = "TwoFrostUnhold", IsUsingTopPartyResources = false}
 	}
 ]
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/beast_units.nut
@@ -110,29 +110,29 @@ local units = [
 		ID = "Unit.RF.HexeOneSpider",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
-		Cost = 50 + 12,
-		SubPartyDef = {BaseID = "SpiderBodyguards", HardMin = 1, HardMax = 1}
+		Cost = 50,
+		SubPartyDef = {BaseID = "SpiderBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.HexeTwoSpider",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
-		Cost = 50 + 12 + 12,
-		SubPartyDef = {BaseID = "SpiderBodyguards", HardMin = 2, HardMax = 2}
+		Cost = 50,
+		SubPartyDef = {BaseID = "SpiderBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.HexeOneDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
-		Cost = 50 + 25,
-		SubPartyDef = {BaseID = "DirewolfBodyguards", HardMin = 1, HardMax = 1}
+		Cost = 50,
+		SubPartyDef = {BaseID = "DirewolfBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.HexeTwoDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
-		Cost = 50 + 25 + 25,
-		SubPartyDef = {BaseID = "DirewolfBodyguards", HardMin = 2, HardMax = 2}
+		Cost = 50,
+		SubPartyDef = {BaseID = "DirewolfBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false}
 	},
 
 	// Bodyguards

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
@@ -26,7 +26,7 @@ local units = [
 		ID = "Unit.RF.Mortar",
 		Troop = "Mortar",
 		StartingResourceMin = 340, // In Vanilla they appear in a group of 340 cost
-		SubPartyDef = {BaseID = "MortarEngineers"}
+		SubPartyDef = {BaseID = "MortarEngineers", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.Assassin",

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/undead_units.nut
@@ -108,32 +108,32 @@ local units = [
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 300,
-		Cost = 40 + 40,
-		SubPartyDef = {BaseID = "SubPartyPrae"}
+		Cost = 40,
+		SubPartyDef = {BaseID = "SubPartyPrae", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.SkeletonPriestPP",
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 325,
-		Cost = 40 + 40 + 40,
-		SubPartyDef = {BaseID = "SubPartyPrae2"}
+		Cost = 40,
+		SubPartyDef = {BaseID = "SubPartyPrae2", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.SkeletonPriestPH",
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 350,
-		Cost = 40 + 40 + 50,
-		SubPartyDef = {BaseID = "SubPartyPraeHonor"}
+		Cost = 40,
+		SubPartyDef = {BaseID = "SubPartyPraeHonor", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.SkeletonPriestHH",
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 375,
-		Cost = 40 + 50 + 50,
-		SubPartyDef = {BaseID = "SubPartyHonor2"}
+		Cost = 40,
+		SubPartyDef = {BaseID = "SubPartyHonor2", IsUsingTopPartyResources = false}
 	},
 ];
 

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/zombie_units.nut
@@ -34,32 +34,32 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 100, // In Vanilla they appear in a group of 100 cost
-		Cost = 30 + 12,
-		SubPartyDef = {BaseID = "SubPartyYeoman"}
+		Cost = 30,
+		SubPartyDef = {BaseID = "SubPartyYeoman", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.NecromancerK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 320, // In Vanilla they appear in a group of 320 cost
-		Cost = 30 + 24,
-		SubPartyDef = {BaseID = "SubPartyKnight"}
+		Cost = 30,
+		SubPartyDef = {BaseID = "SubPartyKnight", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.NecromancerYK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 360, // In Vanilla they appear in a group of 415 cost
-		Cost = 30 + 12 + 24,
-		SubPartyDef = {BaseID = "SubPartyYeomanKnight"}
+		Cost = 30,
+		SubPartyDef = {BaseID = "SubPartyYeomanKnight", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.NecromancerKK",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 420, // In Vanilla they appear in a group of 415 cost
-		Cost = 30 + 24 + 24,
-		SubPartyDef = {BaseID = "SubPartyKnightKnight"}
+		Cost = 30,
+		SubPartyDef = {BaseID = "SubPartyKnightKnight", IsUsingTopPartyResources = false}
 	},
 
 // Necromancer with Nomad Bodyguards
@@ -68,24 +68,24 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 110,
-		Cost = 30 + 12,
-		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1 }
+		Cost = 30,
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false }
 	},
 	{
 		ID = "Unit.RF.NecromancerNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 130,
-		Cost = 30 + 12 + 12,
-		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2 }
+		Cost = 30,
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false }
 	},
 	{
 		ID = "Unit.RF.NecromancerNNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 170,
-		Cost = 30 + 12 + 12 + 12,
-		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3 }
+		Cost = 30,
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3, IsUsingTopPartyResources = false }
 	}
 
 // Bodyguards for Necromancer


### PR DESCRIPTION
Dynamic Spawns Framework 0.3.0 adds the cost of the spawned party into the cost of the unit when subtracting its worth from the top party's resources. So we add a check to not use resources from the top party, and remove the manual addition of the extra cost from the unit with the subparty.