### PR TITLE
refactor: rework whirling death perk

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -2242,12 +2242,15 @@ foreach (vanillaDesc in vanillaDescriptions)
 		}]
  	}),
 	RF_WhirlingDeath = ::UPD.getDescription({
- 		Fluff = "Use the arc of your flailhead to target weak spots in your opponents' armor!",
+ 		Fluff = "Create a whirlwind of death with the spinning head of your flail!",
  		Requirement = "Flail",
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"An additional random " + ::MSU.Text.colorGreen("0-25%") + " of damage ignores armor."
+				"Every attack with flails increases your current [Reach|Concept.Reach] by " + ::MSU.Text.colorGreen("+1") + " until your next turn.",
+				"With two-handed flails, when attacking a target who has lower current [Reach|Concept.Reach] than you, gain " + ::MSU.Text.colorGreen("+10%") + " chance to hit the head per difference in current [Reach|Concept.Reach] between you and the target.",
+				"During your [turn|Concept.Reach], when attacking with one-handed flails, perform a free extra attack with " + ::MSU.Text.colorRed("50%") + " less damage against a different adjacent enemy who has lower current [Reach|Concept.Reach] than you.",
+				"Does not take into account abilities which ignore or modify [Reach|Concept.Reach] during an attack."
 			]
 		}]
  	}),

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -2249,7 +2249,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Description = [
 				"Every attack with flails increases your current [Reach|Concept.Reach] by " + ::MSU.Text.colorGreen("+1") + " until your next [turn|Concept.Turn].",
 				"With two-handed flails, when attacking a target who has lower current [Reach|Concept.Reach] than you, gain " + ::MSU.Text.colorGreen("+10%") + " chance to hit the head per difference in current [Reach|Concept.Reach] between you and the target.",
-				"During your [turn|Concept.Reach], when attacking with one-handed flails, perform a free extra attack with " + ::MSU.Text.colorRed("50%") + " less damage against a different adjacent enemy who has lower current [Reach|Concept.Reach] than you.",
+				"During your [turn|Concept.Turn], when attacking with one-handed flails, perform a free extra attack with " + ::MSU.Text.colorRed("50%") + " less damage against a different adjacent enemy who has lower current [Reach|Concept.Reach] than you. This extra attack does not increase your [Reach|Concept.Reach].",
 				"Does not take into account abilities which ignore or modify [Reach|Concept.Reach] during an attack."
 			]
 		}]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -2247,7 +2247,7 @@ foreach (vanillaDesc in vanillaDescriptions)
  		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Every attack with flails increases your current [Reach|Concept.Reach] by " + ::MSU.Text.colorGreen("+1") + " until your next turn.",
+				"Every attack with flails increases your current [Reach|Concept.Reach] by " + ::MSU.Text.colorGreen("+1") + " until your next [turn|Concept.Turn].",
 				"With two-handed flails, when attacking a target who has lower current [Reach|Concept.Reach] than you, gain " + ::MSU.Text.colorGreen("+10%") + " chance to hit the head per difference in current [Reach|Concept.Reach] between you and the target.",
 				"During your [turn|Concept.Reach], when attacking with one-handed flails, perform a free extra attack with " + ::MSU.Text.colorRed("50%") + " less damage against a different adjacent enemy who has lower current [Reach|Concept.Reach] than you.",
 				"Does not take into account abilities which ignore or modify [Reach|Concept.Reach] during an attack."

--- a/scripts/skills/perks/perk_rf_whirling_death.nut
+++ b/scripts/skills/perks/perk_rf_whirling_death.nut
@@ -1,46 +1,169 @@
 this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 	m = {
-		IsForceEnabled = false,
-		MinBonus = 0,
-		MaxBonus = 25
+		RequiredWeaponType = ::Const.Items.WeaponType.Flail,
+		Stacks = 0,
+		IsPerformingExtraAttack = false, // Is flipped during the extra attack to reduce its damage using onAnySkillUsed
+		DamageTotalMult = 0.5, // Multiplier for the damage dealt during the extra attack
+		ChanceToHitHeadPerReachDiff = 10 // Is used for two-handed flails
 	},
 	function create()
 	{
 		this.m.ID = "perk.rf_whirling_death";
 		this.m.Name = ::Const.Strings.PerkName.RF_WhirlingDeath;
-		this.m.Description = ::Const.Strings.PerkDescription.RF_WhirlingDeath;
+		this.m.Description = "This character\'s attacks are like a whirlwind, making it very dangerous to be near them.";
 		this.m.Icon = "ui/perks/rf_whirling_death.png";
-		this.m.Type = ::Const.SkillType.Perk;
+		this.m.Type = ::Const.SkillType.Perk | ::Const.SkillType.StatusEffect;
 		this.m.Order = ::Const.SkillOrder.Perk;
-		this.m.IsActive = false;
-		this.m.IsStacking = false;
-		this.m.IsHidden = false;
 	}
 
-	function isEnabled()
+	function isHidden()
 	{
-		if (this.m.IsForceEnabled)
-		{
-			return true;
-		}
-
-		if (this.getContainer().getActor().isDisarmed()) return false;
-
-		local weapon = this.getContainer().getActor().getMainhandItem();		
-		if (weapon == null || !weapon.isWeaponType(::Const.Items.WeaponType.Flail))
-		{
-			return false;
-		}
-
-		return true;
+		return this.m.Stacks == 0;
 	}
-	
+
+	function getTooltip()
+	{
+		local ret = this.skill.getTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/reach.png",
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.Stacks) + " [Reach|Concept.Reach]")
+		});
+		ret.push({
+			id = 20,
+			type = "text",
+			icon = "ui/tooltips/warning.png",
+			text = "Will expire upon swapping your weapon!"
+		});
+		return ret;
+	}
+
+	function onUpdate( _properties )
+	{
+		_properties.Reach += this.m.Stacks;
+	}
+
 	function onAnySkillUsed( _skill, _targetEntity, _properties )
 	{
-		if (this.isEnabled() && (this.m.IsForceEnabled || (_skill.getItem() != null && _skill.getItem().getID() == this.getContainer().getActor().getMainhandItem().getID())))
+		if (this.m.IsPerformingExtraAttack)
+			_properties.DamageTotalMult *= this.m.DamageTotalMult;
+
+		local weapon = _skill.getItem();
+		if (weapon != null && weapon.isItemType(::Const.Items.ItemType.TwoHanded))
 		{
-			_properties.DamageDirectAdd += 0.01 * (_targetEntity == null ? this.m.MaxBonus : ::Math.rand(this.m.MinBonus, this.m.MaxBonus));
+			local reachDiff = this.getContainer().getActor().getCurrentProperties().getReach() - _targetEntity.getCurrentProperties().getReach();
+			if (reachDiff > 0)
+				_properties.HitChance[::Const.BodyPart.Head] += reachDiff * this.m.ChanceToHitHeadPerReachDiff;
 		}
+	}
+
+	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
+	{
+		if (this.isSkillValid(_skill) && !this.m.IsPerformingExtraAttack)
+		{
+			this.m.Stacks++;
+
+			if (::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()))
+				this.doExtraAttack(_skill, _targetTile);
+		}
+	}
+
+	function onTurnStart()
+	{
+		this.m.Stacks = 0;
+	}
+
+	function onCombatFinished()
+	{
+		this.skill.onCombatFinished();
+		this.m.Stacks = 0;
+	}
+
+	function onPayForItemAction( _skill, _items )
+	{
+		foreach (item in _items)
+		{
+			if (_item != null && _item.getSlotType() == ::Const.ItemSlot.Mainhand)
+			{
+				this.m.Stacks = 0;
+				return;
+			}
+		}
+	}
+
+	function doExtraAttack( _skill, _primaryTargetTile )
+	{
+		local user = this.getContainer().getActor();
+		local myTile = user.getTile();
+
+		local targets = [];
+		for (local i = 0; i < 6; i++)
+		{
+			if (!myTile.hasNextTile(i))
+				continue;
+
+			local nextTile = myTile.getNextTile(i);
+			if (!nextTile.IsOccupiedByActor || nextTile.isSameTileAs(_primaryTargetTile))
+				continue;
+
+			local entity = nextTile.getEntity();
+			if (!entity.isAlliedWith(user) && entity.getCurrentProperties().getReach() < user.getCurrentProperties().getReach() && _skill.onVerifyTarget(myTile, nextTile))
+			{
+				targets.push(entity)
+			}
+		}
+
+		if (targets.len() == 0)
+			return;
+
+		local target = ::MSU.Array.rand(targets);
+		local targetTile = target.getTile();
+
+		if (!user.isHiddenToPlayer() || targetTile.IsVisibleForPlayer)
+		{
+			this.getContainer().setBusy(true);
+			::Time.scheduleEvent(::TimeUnit.Virtual, 100, function ( _perk )
+			{
+				if (target.isAlive())
+				{
+					this.logDebug("[" + user.getName() + "] is attacking [" + target.getName() + "] with skill [" + _skill.getName() + "] due to " + _perk.m.Name);
+					if (!user.isHiddenToPlayer() && targetTile.IsVisibleForPlayer)
+					{
+						::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(user) + " has " + _perk.m.Name);
+					}
+
+					this.m.IsPerformingExtraAttack = true;
+					_skill.useForFree(targetTile);
+					this.m.IsPerformingExtraAttack = false;
+				}
+				this.getContainer().setBusy(false);
+
+			}.bindenv(this), this);
+		}
+		else
+		{
+			if (target.isAlive())
+			{
+				this.logDebug("[" + user.getName() + "] is attacking [" + target.getName() + "] with skill [" + _skill.getName() + "] due to " + this.m.Name);
+
+				this.m.IsPerformingExtraAttack = true;
+				_skill.useForFree(targetTile);
+				this.m.IsPerformingExtraAttack = false;
+			}
+		}
+	}
+
+	function isSkillValid( _skill )
+	{
+		if (!_skill.isAttack() || _skill.isRanged())
+			return false;
+
+		if (this.m.RequiredWeaponType == null)
+			return true;
+
+		local weapon = _skill.getItem();
+		return !::MSU.isNull(weapon) && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(::Const.Items.WeaponType.Flail);
 	}
 });
 

--- a/scripts/skills/perks/perk_rf_whirling_death.nut
+++ b/scripts/skills/perks/perk_rf_whirling_death.nut
@@ -47,7 +47,15 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 	function onAnySkillUsed( _skill, _targetEntity, _properties )
 	{
 		if (this.m.IsPerformingExtraAttack)
-			_properties.DamageTotalMult *= this.m.DamageTotalMult;
+		{
+			// We don't apply our damage reduction for the extra attack during the Flail Spinner attack. This solves the issue of double-dipping
+			// damage reduction for when both this perk and Flail Spinner trigger during an attack for entities not visible to the player
+			local flailSpinner = this.getContainer().getSkillByID("perk.rf_flail_spinner")
+			if (flailSpinner == null || !flailSpinner.m.IsSpinningFlail)
+			{
+				_properties.DamageTotalMult *= this.m.DamageTotalMult;
+			}
+		}
 
 		local weapon = _skill.getItem();
 		if (weapon != null && weapon.isItemType(::Const.Items.ItemType.TwoHanded) && this.isSkillValid(_skill))

--- a/scripts/skills/perks/perk_rf_whirling_death.nut
+++ b/scripts/skills/perks/perk_rf_whirling_death.nut
@@ -127,7 +127,7 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 			{
 				if (target.isAlive())
 				{
-					this.logDebug("[" + user.getName() + "] is attacking [" + target.getName() + "] with skill [" + _skill.getName() + "] due to " + _perk.m.Name);
+					::logDebug("[" + user.getName() + "] is attacking [" + target.getName() + "] with skill [" + _skill.getName() + "] due to " + _perk.m.Name);
 					if (!user.isHiddenToPlayer() && targetTile.IsVisibleForPlayer)
 					{
 						::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(user) + " has " + _perk.m.Name);
@@ -145,7 +145,7 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 		{
 			if (target.isAlive())
 			{
-				this.logDebug("[" + user.getName() + "] is attacking [" + target.getName() + "] with skill [" + _skill.getName() + "] due to " + this.m.Name);
+				::logDebug("[" + user.getName() + "] is attacking [" + target.getName() + "] with skill [" + _skill.getName() + "] due to " + this.m.Name);
 
 				this.m.IsPerformingExtraAttack = true;
 				_skill.useForFree(targetTile);
@@ -163,6 +163,6 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 			return true;
 
 		local weapon = _skill.getItem();
-		return !::MSU.isNull(weapon) && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(::Const.Items.WeaponType.Flail);
+		return !::MSU.isNull(weapon) && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(this.m.RequiredWeaponType);
 	}
 });

--- a/scripts/skills/perks/perk_rf_whirling_death.nut
+++ b/scripts/skills/perks/perk_rf_whirling_death.nut
@@ -166,4 +166,3 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 		return !::MSU.isNull(weapon) && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(::Const.Items.WeaponType.Flail);
 	}
 });
-

--- a/scripts/skills/perks/perk_rf_whirling_death.nut
+++ b/scripts/skills/perks/perk_rf_whirling_death.nut
@@ -50,7 +50,7 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 			_properties.DamageTotalMult *= this.m.DamageTotalMult;
 
 		local weapon = _skill.getItem();
-		if (weapon != null && weapon.isItemType(::Const.Items.ItemType.TwoHanded))
+		if (weapon != null && weapon.isItemType(::Const.Items.ItemType.TwoHanded) && this.isSkillValid(_skill))
 		{
 			local reachDiff = this.getContainer().getActor().getCurrentProperties().getReach() - _targetEntity.getCurrentProperties().getReach();
 			if (reachDiff > 0)


### PR DESCRIPTION
- Gain +1 reach with every attack for one turn.
- For 1-handed flails perform a free attack against an adjacent enemy with lower current Reach than you, but with 50% less damage.
- For 2-handed flails gain +10% chance to hit the head per current Reach difference between you and the target, if you have higher Reach.