### PR TITLE
refactor: rework shield durability and weapons shield damage

### DIFF
--- a/mod_reforged/hooks/items/shields/ancient/auxiliary_shield.nut
+++ b/mod_reforged/hooks/items/shields/ancient/auxiliary_shield.nut
@@ -1,0 +1,8 @@
+::Reforged.HooksMod.hook("scripts/items/shields/ancient/auxiliary_shield", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.Condition = 32;
+		this.m.ConditionMax = 32;
+	}
+});

--- a/mod_reforged/hooks/items/shields/ancient/coffin_shield.nut
+++ b/mod_reforged/hooks/items/shields/ancient/coffin_shield.nut
@@ -2,8 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 24;
-		this.m.ConditionMax = 24;
+		this.m.Condition = 40;
+		this.m.ConditionMax = 40;
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/ancient/tower_shield.nut
+++ b/mod_reforged/hooks/items/shields/ancient/tower_shield.nut
@@ -2,6 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
+		this.m.Condition = 48;
+		this.m.ConditionMax = 48;
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/buckler_shield.nut
+++ b/mod_reforged/hooks/items/shields/buckler_shield.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.ReachIgnore = 1;
-		this.m.Condition = 50;
-		this.m.ConditionMax = 50;
+		this.m.Condition = 40;
+		this.m.ConditionMax = 40;
 	}
 });

--- a/mod_reforged/hooks/items/shields/faction_heater_shield.nut
+++ b/mod_reforged/hooks/items/shields/faction_heater_shield.nut
@@ -2,8 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 170;
-		this.m.ConditionMax = 170;
+		this.m.Condition = 150;
+		this.m.ConditionMax = 150;
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/faction_kite_shield.nut
+++ b/mod_reforged/hooks/items/shields/faction_kite_shield.nut
@@ -2,8 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 220;
-		this.m.ConditionMax = 220;
+		this.m.Condition = 200;
+		this.m.ConditionMax = 200;
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/faction_wooden_shield.nut
+++ b/mod_reforged/hooks/items/shields/faction_wooden_shield.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 130;
-		this.m.ConditionMax = 130;
+		this.m.Condition = 100;
+		this.m.ConditionMax = 100;
 	}
 });

--- a/mod_reforged/hooks/items/shields/greenskins/goblin_light_shield.nut
+++ b/mod_reforged/hooks/items/shields/greenskins/goblin_light_shield.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 30;
-		this.m.ConditionMax = 30;
+		this.m.Condition = 24;
+		this.m.ConditionMax = 24;
 	}
 });

--- a/mod_reforged/hooks/items/shields/greenskins/orc_heavy_shield.nut
+++ b/mod_reforged/hooks/items/shields/greenskins/orc_heavy_shield.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 280;
-		this.m.ConditionMax = 280;
+		this.m.Condition = 300;
+		this.m.ConditionMax = 300;
 	}
 });

--- a/mod_reforged/hooks/items/shields/heater_shield.nut
+++ b/mod_reforged/hooks/items/shields/heater_shield.nut
@@ -2,8 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 170;
-		this.m.ConditionMax = 170;
+		this.m.Condition = 150;
+		this.m.ConditionMax = 150;
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/kite_shield.nut
+++ b/mod_reforged/hooks/items/shields/kite_shield.nut
@@ -2,8 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 220;
-		this.m.ConditionMax = 220;
+		this.m.Condition = 200;
+		this.m.ConditionMax = 200;
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/oriental/metal_round_shield.nut
+++ b/mod_reforged/hooks/items/shields/oriental/metal_round_shield.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 280;
-		this.m.ConditionMax = 280;
+		this.m.Condition = 300;
+		this.m.ConditionMax = 300;
 	}
 });

--- a/mod_reforged/hooks/items/shields/oriental/southern_light_shield.nut
+++ b/mod_reforged/hooks/items/shields/oriental/southern_light_shield.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 100;
-		this.m.ConditionMax = 100;
+		this.m.Condition = 80;
+		this.m.ConditionMax = 80;
 	}
 });

--- a/mod_reforged/hooks/items/shields/special/craftable_lindwurm_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_lindwurm_shield.nut
@@ -2,8 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 280;
-		this.m.ConditionMax = 280;
+		this.m.Condition = 250;
+		this.m.ConditionMax = 250;
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 170;
-		this.m.ConditionMax = 170;
+		this.m.Condition = 150;
+		this.m.ConditionMax = 150;
 	}
 });

--- a/mod_reforged/hooks/items/shields/wooden_shield.nut
+++ b/mod_reforged/hooks/items/shields/wooden_shield.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 130;
-		this.m.ConditionMax = 130;
+		this.m.Condition = 100;
+		this.m.ConditionMax = 100;
 	}
 });

--- a/mod_reforged/hooks/items/shields/wooden_shield_old.nut
+++ b/mod_reforged/hooks/items/shields/wooden_shield_old.nut
@@ -1,4 +1,4 @@
-::Reforged.HooksMod.hook("scripts/items/shields/greenskins/goblin_heavy_shield", function(q) {
+::Reforged.HooksMod.hook("scripts/items/shields/wooden_shield_old", function(q) {
 	q.create = @(__original) function()
 	{
 		__original();

--- a/mod_reforged/hooks/items/shields/worn_heater_shield.nut
+++ b/mod_reforged/hooks/items/shields/worn_heater_shield.nut
@@ -2,6 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
+		this.m.Condition = 48;
+		this.m.ConditionMax = 48;
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/worn_kite_shield.nut
+++ b/mod_reforged/hooks/items/shields/worn_kite_shield.nut
@@ -2,8 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 30;
-		this.m.ConditionMax = 30;
+		this.m.Condition = 80;
+		this.m.ConditionMax = 80;
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/weapons/ancient/crypt_cleaver.nut
+++ b/mod_reforged/hooks/items/weapons/ancient/crypt_cleaver.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 18;
 		this.m.DirectDamageAdd = 0.05; // Brings the total to 30%
 	}
 

--- a/mod_reforged/hooks/items/weapons/barbarians/axehammer.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/axehammer.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 12;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/barbarians/crude_axe.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/crude_axe.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 16;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/barbarians/heavy_rusty_axe.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/heavy_rusty_axe.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 40;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/barbarians/rusty_warblade.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/rusty_warblade.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 26;
 		this.m.ArmorDamageMult = 1.3;
 		this.m.RegularDamage = 70;
 		this.m.RegularDamageMax = 90;

--- a/mod_reforged/hooks/items/weapons/barbarians/skull_hammer.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/skull_hammer.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 4;
-		this.m.ShieldDamage = 30;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/barbarians/two_handed_spiked_mace.nut
+++ b/mod_reforged/hooks/items/weapons/barbarians/two_handed_spiked_mace.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 22;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/bardiche.nut
+++ b/mod_reforged/hooks/items/weapons/bardiche.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 6;
-		this.m.ShieldDamage = 32;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/fighting_axe.nut
+++ b/mod_reforged/hooks/items/weapons/fighting_axe.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 18;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/greataxe.nut
+++ b/mod_reforged/hooks/items/weapons/greataxe.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 40;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/greatsword.nut
+++ b/mod_reforged/hooks/items/weapons/greatsword.nut
@@ -4,7 +4,6 @@
 		__original();
 		this.m.Name = "Zweihander";
 		this.m.Reach = 7;
-		this.m.ShieldDamage = 24;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/greenskins/orc_axe.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/orc_axe.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 22;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/greenskins/orc_axe_2h.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/orc_axe_2h.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 54;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/hand_axe.nut
+++ b/mod_reforged/hooks/items/weapons/hand_axe.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 3;
-		this.m.ShieldDamage = 12;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/hatchet.nut
+++ b/mod_reforged/hooks/items/weapons/hatchet.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 2;
-		this.m.ShieldDamage = 10;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/longaxe.nut
+++ b/mod_reforged/hooks/items/weapons/longaxe.nut
@@ -3,6 +3,5 @@
 	{
 		__original();
 		this.m.Reach = 6;
-		this.m.ShieldDamage = 32;
 	}
 });

--- a/mod_reforged/hooks/items/weapons/oriental/two_handed_scimitar.nut
+++ b/mod_reforged/hooks/items/weapons/oriental/two_handed_scimitar.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 16;
 		this.m.ItemType = this.m.ItemType | ::Const.Items.ItemType.RF_Southern;
 	}
 

--- a/mod_reforged/hooks/items/weapons/two_handed_flanged_mace.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_flanged_mace.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 32;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/two_handed_hammer.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_hammer.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 4;
-		this.m.ShieldDamage = 36;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/two_handed_mace.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_mace.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 5;
-		this.m.ShieldDamage = 22;
 	}
 
 	q.onEquip = @() function()

--- a/mod_reforged/hooks/items/weapons/two_handed_wooden_hammer.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_wooden_hammer.nut
@@ -3,7 +3,6 @@
 	{
 		__original();
 		this.m.Reach = 4;
-		this.m.ShieldDamage = 22;
 	}
 
 	q.onEquip = @() function()

--- a/scripts/items/weapons/rf_greatsword.nut
+++ b/scripts/items/weapons/rf_greatsword.nut
@@ -21,7 +21,7 @@ this.rf_greatsword <- ::inherit("scripts/items/weapons/weapon", {
 		this.m.ShowArmamentIcon = true;
 		this.m.ArmamentIcon = "icon_sword_two_handed_01";
 		this.m.Value = 2400;
-		this.m.ShieldDamage = 18;
+		this.m.ShieldDamage = 16;
 		this.m.Condition = 60.0;
 		this.m.ConditionMax = 60.0;
 		this.m.StaminaModifier = -10;


### PR DESCRIPTION
- Instead of changing weapons shield damage across the board, we mostly revert that to their vanilla state.
- We change the durability of shields across the board to achieve a design of mostly unbreakable shields, with certain shields being still breakable (e.g. undead ones).