### PR TITLE
refactor: remove legendary difficulty setting

### DIFF
--- a/mod_reforged/config/config.nut
+++ b/mod_reforged/config/config.nut
@@ -1,5 +1,4 @@
 ::Reforged.Config <- {
-	IsLegendaryDifficulty = true,
 	HiringCostVariance = 0.2,	// Hiring cost for recruits after gear is randomized +- this value. 0.0 = no variance. 0.2 = it varies between 80% and 120% of its original cost
 	HiringCostLuck = 200,	// Luck for rerolling hiring cost. Every 100 luck = 1 reroll. With multiple rerolls present only the closest to the original hiring cost is taken. 0 luck = to linear distribution between min and max,
 	XPOverride = false, // Is set to true during actor.onActorKilled to prevent any xp gain via player.getXP function. Then set to false afterwards. This is to do our own override of XP gain system based on damage dealt ratios.

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -1,10 +1,3 @@
-local generalPage = ::Reforged.Mod.ModSettings.addPage("General");
-local legendaryDifficulty = generalPage.addBooleanSetting("LegendaryDifficulty", true, "Legendary Difficulty");
-legendaryDifficulty.getData().NewCampaign <- true;
-legendaryDifficulty.addAfterChangeCallback(function( _oldValue ) {
-	::Reforged.Config.IsLegendaryDifficulty = this.getValue();
-});
-
 local tacticalTooltipPage = ::Reforged.Mod.ModSettings.addPage("Tactical Tooltips");
 
 tacticalTooltipPage.addEnumSetting("TacticalTooltip_Attributes", "All", ["All", "AI Only", "Player Only", "None"], "Show Attributes", "Show attributes such as Melee Skill, Melee Defense etc. for entities in the Tactical Tooltip.");


### PR DESCRIPTION
Should be merged after #362 because that PR removes the application of legendary difficulty from enemies.