### PR TITLE
fix: set IsSpecializedInShields for zombie knight bodyguards to false

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/zombie_knight_bodyguard.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/zombie_knight_bodyguard.nut
@@ -2,8 +2,8 @@
 	q.onInit = @() function()
 	{
 	    this.zombie_knight.onInit();
-		// local b = this.m.BaseProperties;
-		// b.IsSpecializedInShields = true;
+		local b = this.m.BaseProperties;
+		b.IsSpecializedInShields = false;	// this is the only enemy where this property in vanilla is hard-coded to true
 
 		// Reforged
 		this.m.Skills.add(::new("scripts/skills/perks/perk_shield_expert"));


### PR DESCRIPTION
zombie knight bodyguards are the only vanilla entity where this flag is hard-codedly set to true in the base properties.
Currently this is redundant and I dislike the idea that in the future they secretly have some shield expert abilities without anything saying that in the tooltips.

So I find it consistent to once and for all reset that flag to the default value `false`