### PR TITLE
refactor: round debuff multiplier in bleed effect tooltip

### DIFF
--- a/mod_reforged/hooks/skills/effects/bleeding_effect.nut
+++ b/mod_reforged/hooks/skills/effects/bleeding_effect.nut
@@ -32,7 +32,7 @@
 		}
 		else
 		{
-			local malusMult = this.getMalusMult();
+			local malusMult = ::Math.round(this.getMalusMult() * 100) / 100.0;
 			ret.push({
 				id = 11,
 				type = "text",


### PR DESCRIPTION
Currently the description shows like 4 decimal places for certain hp values