### PR TITLE
fix: remove IsAttack being set to true in hook shield

### DIFF
--- a/scripts/skills/actives/rf_hook_shield_skill.nut
+++ b/scripts/skills/actives/rf_hook_shield_skill.nut
@@ -37,7 +37,6 @@ this.rf_hook_shield_skill <- ::inherit("scripts/skills/skill", {
 		this.m.IsActive = true;
 		this.m.IsTargeted = true;
 		this.m.IsStacking = false;
-		this.m.IsAttack = true;
 		this.m.IsUsingHitchance = true;
 		this.m.IsIgnoredAsAOO = true;
 		this.m.IsWeaponSkill = true;


### PR DESCRIPTION
Because we don't want this skill to be considered an attack for the purposes of being a valid skill in other perks.

This fixes the issue currently where in the Dismemberment perk the `_hitInfo.Injuries` is null. However, this is not a permanent long-term solution because it will still trigger `onBeforeTargetHit` and similar functions on the target because it uses `this.attackEntity` in its `onUse` function. So a null `hitInfo.Injuries` will be passed. I do not know for sure if `hitInfo.Injuries` is ever expected to be null in these functions (probably it isn't), so we should try to find a solution for this issue by rethinking how to make the code of this skill work. Have opened a separate issue for that #393 