### PR TITLE
balance: reduce base melee skill and defense of conscript

### DIFF
--- a/mod_reforged/hooks/config/faction_southern.nut
+++ b/mod_reforged/hooks/config/faction_southern.nut
@@ -1,4 +1,6 @@
 ::MSU.Table.merge(::Const.Tactical.Actor.Conscript, {
+	MeleeSkill = 60, // Vanilla is 70
+	MeleeDefense = 0, // Vanilla is 10
 	RangedDefense = 0
 });
 ::MSU.Table.merge(::Const.Tactical.Actor.Officer, {


### PR DESCRIPTION
- Drop base Melee Defense because they have Phalanx in Reforged which gives them additional Reach and permanent Shieldwall next to an allied Shieldwall. 
- Drop base Melee Skill because they have Backstabber in Reforged.