### PR TITLE
feat: add keybind support for wait round action

### DIFF
--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -13,3 +13,16 @@ tacticalTooltipPage.addRangeSetting("CollapseActivesWhenX", 5, 0, 20, 1, "Collap
 tacticalTooltipPage.addBooleanSetting("TacticalTooltip_CollapseAsText", false, "Collapse as Text", "If enabled, then skills collapse using their names as text, otherwise they collapse using their icons.");
 tacticalTooltipPage.addBooleanSetting("ShowStatusPerkAndEffect", true, "Show Status Perk And Effect", "Some Perks are also Status Effects. Usually their Effect is hidden until some condition is fulfilled. When this setting is enabled, these perks show up in the Perks category even when they show up under Effects (e.g. when their effect is active). When disabled, when they appear under Effects, they will be hidden from the Perks category. This can help save space on the tooltip.");
 tacticalTooltipPage.addBooleanSetting("HeaderForEmptyCategories", false, "Show Header for empty categories");
+
+::Reforged.Mod.Keybinds.addSQKeybind("Tactical_WaitRound", "h", ::MSU.Key.State.Tactical, function()
+{
+	if (this.m.MenuStack.hasBacksteps() || this.isInputLocked() || this.isInCharacterScreen())
+	{
+		return false;
+	}
+	else
+	{
+		::Tactical.TurnSequenceBar.onWaitTurnAllButtonPressed();
+		return true;
+	}
+}, "Wait Turn with all Characters");

--- a/mod_reforged/msu_systems/tooltips.nut
+++ b/mod_reforged/msu_systems/tooltips.nut
@@ -25,7 +25,20 @@
 	},
 	Tactical = {
 		Button = {
-			WaitTurnAllButton = ::MSU.Class.BasicTooltip("Wait Round", "Have all your characters use \'Wait\' on their turn.")
+			WaitTurnAllButton = ::MSU.Class.CustomTooltip(function( _ ) {
+				return [
+					{
+						id = 1,
+						type = "title",
+						text = format("Wait Round (%s)", ::MSU.System.Keybinds.KeybindsByMod["mod_reforged"]["Tactical_WaitRound"].getKeyCombinations())
+					},
+					{
+						id = 2,
+						type = "description",
+						text = "Have all your characters use \'Wait\' on their turn."
+					}
+				];
+			})
 		}
 	}
 });

--- a/mod_reforged/msu_systems/tooltips.nut
+++ b/mod_reforged/msu_systems/tooltips.nut
@@ -35,7 +35,7 @@
 					{
 						id = 2,
 						type = "description",
-						text = "Have all your characters use \'Wait\' on their turn."
+						text = ::Reforged.Mod.Tooltips.parseString("Have all your characters use [Wait|Concept.Wait] on their [turn|Concept.Turn].")
 					}
 				];
 			})


### PR DESCRIPTION
The default Hotkey is CTRL + Spacebar
Reminder that normal Wait hotkey is Spacebar

![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/2a3dac7f-4a69-4457-bcff-83cc9b508a16)

End Turn for all Characters (vanilla) has the hotkey **R**. I prefer a single button hotkey but there are not so many options left. And honestly you probably use **Wait Round** a bit less than **End Round**.