### PR TITLE
fix: puncture being affected by reforged reworked double grip

### DIFF
--- a/mod_reforged/hooks/skills/actives/puncture.nut
+++ b/mod_reforged/hooks/skills/actives/puncture.nut
@@ -4,4 +4,14 @@
 		__original();
 		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.Puncture;
 	}
+
+	// Revert the modification to DamageTotalMult in vanilla which they did as a compensation to revert
+	// the damage bonus from Double Grip. Instead, we prevent puncture from using Double Grip directly within
+	// double_grip.nut, because we have a custom implementation of double grip bonus for daggers.
+	q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+	{
+		local old_DamageTotalMult = _properties.DamageTotalMult;
+		__original(_skill, _targetEntity, _properties);
+		_properties.DamageTotalMult = old_DamageTotalMult;
+	}
 });

--- a/mod_reforged/hooks/skills/special/double_grip.nut
+++ b/mod_reforged/hooks/skills/special/double_grip.nut
@@ -2,6 +2,7 @@
 	// Is set during onUpdate so that hybrid weapons are properly dealt with in functions other than onUpdate
 	// because we go through weapon types alphabetically and choose the first applicable type
 	q.m.CurrWeaponType <- null;
+	q.m.MeleeDamageMult_Dagger <- 1.2;
 
 	q.create = @(__original) function()
 	{
@@ -38,6 +39,10 @@
 
 			case ::Const.Items.WeaponType.Cleaver:
 				_properties.MeleeDamageMult *= 1.3;
+				break;
+
+			case ::Const.Items.WeaponType.Dagger:
+				_properties.MeleeDamageMult *= this.m.MeleeDamageMult_Dagger;
 				break;
 
 			case ::Const.Items.WeaponType.Flail:
@@ -107,7 +112,7 @@
 					id = 7,
 					type = "text",
 					icon = "ui/icons/regular_damage.png",
-					text = ::MSU.Text.colorGreen("20%") + " increased damage"
+					text = ::MSU.Text.colorizeMult(this.m.MeleeDamageMult_Dagger) + " increased damage"
 				});
 				ret.push({
 					id = 7,
@@ -294,9 +299,9 @@
 			}
 		}
 
-		if (_skill.getID() != "actives.puncture" && this.m.CurrWeaponType == ::Const.Items.WeaponType.Dagger)
+		if (_skill.getID() == "actives.puncture" && this.m.CurrWeaponType == ::Const.Items.WeaponType.Dagger)
 		{
-			_properties.MeleeDamageMult *= 1.2;
+			_properties.MeleeDamageMult /= this.m.MeleeDamageMult_Dagger;
 		}
 	}
 

--- a/mod_reforged/hooks/skills/special/double_grip.nut
+++ b/mod_reforged/hooks/skills/special/double_grip.nut
@@ -40,10 +40,6 @@
 				_properties.MeleeDamageMult *= 1.3;
 				break;
 
-			case ::Const.Items.WeaponType.Dagger:
-				_properties.MeleeDamageMult *= 1.2;
-				break;
-
 			case ::Const.Items.WeaponType.Flail:
 				_properties.HitChanceMult[::Const.BodyPart.Head] += 0.1;
 				_properties.DamageDirectAdd += 0.2;
@@ -296,6 +292,11 @@
 					}
 				}
 			}
+		}
+
+		if (_skill.getID() != "actives.puncture" && this.m.CurrWeaponType == ::Const.Items.WeaponType.Dagger)
+		{
+			_properties.MeleeDamageMult *= 1.2;
 		}
 	}
 


### PR DESCRIPTION
I really don't like that we have to overwrite the vanilla function and do the switcheroo but I don't know if there is a cleaner way. Please suggest a better way if possible.