### PR TITLE
Refactor reforged shield mechanics to make them more moddable and changable

### DIFF
--- a/mod_reforged/hooks/items/shields/shield.nut
+++ b/mod_reforged/hooks/items/shields/shield.nut
@@ -20,12 +20,15 @@
 			});
 		}
 
-		ret.push({
-			id = 8,
-			type = "text",
-			icon = "ui/icons/reach.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Ignores " + ::MSU.Text.colorGreen(this.getReachIgnore()) + " [Reach Advantage|Concept.ReachAdvantage]")
-		});
+		if (this.getReachIgnore() != 0)
+		{
+			ret.push({
+				id = 12,
+				type = "text",
+				icon = "ui/icons/reach.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Ignores " + ::MSU.Text.colorGreen(this.getReachIgnore()) + " [Reach Advantage|Concept.ReachAdvantage]")
+			});
+		}
 
 		return ret;
 	}


### PR DESCRIPTION
A new `getDefenseFractionFromFatigue` function allies submods to much easier tweak aswell as disable the fatigue defense mechanic for shields.

The Reach Tooltip is no longer shown on a shield without any reach.