### PR TITLE
refactor: improve split_shield hook making it more moddable

### DIFF
--- a/mod_reforged/hooks/skills/actives/split_shield.nut
+++ b/mod_reforged/hooks/skills/actives/split_shield.nut
@@ -54,7 +54,7 @@
 		if (shield != null)
 		{
 			this.spawnAttackEffect(_targetTile, ::Const.Tactical.AttackEffectSplitShield);
-			local damage = this.RF_getShieldDamage();
+			local damage = this.RF_getShieldDamage(targetEntity);
 
 			local conditionBefore = shield.getCondition();
 			shield.applyShieldDamage(damage);
@@ -106,7 +106,7 @@
 	}
 
 // New Functions
-	q.RF_getShieldDamage <- function()
+	q.RF_getShieldDamage <- function( _targetEntity = null )
 	{
 		if (::MSU.isNull(this.getContainer()) || ::MSU.isNull(this.getContainer().getActor()))
 			return 1; // return a non-zero number so the tooltip gets added

--- a/mod_reforged/hooks/skills/actives/split_shield.nut
+++ b/mod_reforged/hooks/skills/actives/split_shield.nut
@@ -70,7 +70,7 @@
 			{
 				if (this.m.SoundOnHit.len() != 0)
 				{
-					::Sound.play(this.m.SoundOnHit[::Math.rand(0, this.m.SoundOnHit.len() - 1)], ::Const.Sound.Volume.Skill, _targetTile.getEntity().getPos());
+					::Sound.play(::MSU.Array.rand(this.m.SoundOnHit), ::Const.Sound.Volume.Skill, _targetTile.getEntity().getPos());
 				}
 
 				if (!_user.isHiddenToPlayer() && _targetTile.IsVisibleForPlayer)

--- a/mod_reforged/hooks/skills/actives/split_shield.nut
+++ b/mod_reforged/hooks/skills/actives/split_shield.nut
@@ -29,7 +29,7 @@
 		if (this.RF_getFatigueDamage() != 0)
 		{
 			ret.push({
-				id = 7,
+				id = 11,
 				type = "text",
 				icon = "ui/icons/special.png",
 				text = ::Reforged.Mod.Tooltips.parseString("Inflicts [color=" + ::Const.UI.Color.DamageValue + "]" + this.RF_getFatigueDamage() + "[/color] [Fatigue|Concept.Fatigue] on the target")
@@ -39,7 +39,7 @@
 		if (this.getMaxRange() > 1)
 		{
 			ret.push({
-				id = 8,
+				id = 12,
 				type = "text",
 				icon = "ui/icons/vision.png",
 				text = "Has a range of " + ::MSU.Text.colorPositive(this.m.MaxRange) + " tiles"

--- a/mod_reforged/hooks/skills/actives/split_shield.nut
+++ b/mod_reforged/hooks/skills/actives/split_shield.nut
@@ -3,15 +3,27 @@
 	{
 		local ret = this.skill.getDefaultUtilityTooltip();
 
-		local shieldDamage = this._RF_getShieldDamage();
-		if (shieldDamage != 0)
+		if (::MSU.isNull(this.getContainer()) || this.getContainer().getActor().getMainhandItem() == null)
 		{
 			ret.push({
-				id = 7,
+				id = 10,
 				type = "text",
 				icon = "ui/icons/shield_damage.png",
-				text = format("Inflicts%s damage to shields", ::MSU.isNull(this.getContainer()) || this.getContainer().getActor().getID() == ::MSU.getDummyPlayer().getID() ? "" : " " + ::MSU.Text.colorRed(shieldDamage))
+				text = "Inflicts damage to shields"
 			});
+		}
+		else
+		{
+			local shieldDamage = this._RF_getShieldDamage();
+			if (shieldDamage != 0)
+			{
+				ret.push({
+					id = 10,
+					type = "text",
+					icon = "ui/icons/shield_damage.png",
+					text = format("Inflicts %s damage to shields", ::MSU.Text.colorDamage(shieldDamage))
+				});
+			}
 		}
 
 		if (this.RF_getFatigueDamage() != 0)
@@ -106,10 +118,12 @@
 	}
 
 // New Functions
+	// Returns the shield damage dealt by this skill
+	// Returns 0 if no shield damage could be retrieved
 	q.RF_getShieldDamage <- function( _targetEntity = null )
 	{
 		if (::MSU.isNull(this.getContainer()) || ::MSU.isNull(this.getContainer().getActor()))
-			return 1; // return a non-zero number so the tooltip gets added
+			return 0; // return a non-zero number so the tooltip gets added
 
 		local weapon = this.getContainer().getActor().getMainhandItem();
 		return weapon == null ? 0 : weapon.getShieldDamage();

--- a/mod_reforged/hooks/skills/actives/split_shield.nut
+++ b/mod_reforged/hooks/skills/actives/split_shield.nut
@@ -3,13 +3,14 @@
 	{
 		local ret = this.skill.getDefaultUtilityTooltip();
 
-		if (this.getShieldDamage(this.getContainer().getActor()) != 0)
+		local shieldDamage = this._RF_getShieldDamage();
+		if (shieldDamage != 0)
 		{
 			ret.push({
 				id = 7,
 				type = "text",
 				icon = "ui/icons/shield_damage.png",
-				text = "Inflicts " + ::MSU.Text.colorGreen(this.getShieldDamage(this.getContainer().getActor())) + " damage to shields"
+				text = format("Inflicts%s damage to shields", ::MSU.isNull(this.getContainer()) || this.getContainer().getActor().getID() == ::MSU.getDummyPlayer().getID() ? "" : " " + ::MSU.Text.colorRed(shieldDamage))
 			});
 		}
 
@@ -53,7 +54,7 @@
 		if (shield != null)
 		{
 			this.spawnAttackEffect(_targetTile, ::Const.Tactical.AttackEffectSplitShield);
-			local damage = this.getShieldDamage(_user);
+			local damage = this.RF_getShieldDamage();
 
 			local conditionBefore = shield.getCondition();
 			shield.applyShieldDamage(damage);
@@ -105,9 +106,13 @@
 	}
 
 // New Functions
-	q.getShieldDamage <- function( _user )
+	q.RF_getShieldDamage <- function()
 	{
-		return _user.getItems().getItemAtSlot(::Const.ItemSlot.Mainhand).getShieldDamage();
+		if (::MSU.isNull(this.getContainer()) || ::MSU.isNull(this.getContainer().getActor()))
+			return 1; // return a non-zero number so the tooltip gets added
+
+		local weapon = this.getContainer().getActor().getMainhandItem();
+		return weapon == null ? 0 : weapon.getShieldDamage();
 	}
 
 	q.RF_getFatigueDamage <- function()

--- a/mod_reforged/hooks/skills/actives/split_shield.nut
+++ b/mod_reforged/hooks/skills/actives/split_shield.nut
@@ -3,19 +3,25 @@
 	{
 		local ret = this.skill.getDefaultUtilityTooltip();
 
-		ret.push({
-			id = 10,
-			type = "text",
-			icon = "ui/icons/shield_damage.png",
-			text = "Inflicts " + ::MSU.Text.colorDamage(this.getContainer().getActor().getMainhandItem().getShieldDamage()) + " damage to shields"
-		});
+		if (this.getShieldDamage(this.getContainer().getActor()) != 0)
+		{
+			ret.push({
+				id = 7,
+				type = "text",
+				icon = "ui/icons/shield_damage.png",
+				text = "Inflicts " + ::MSU.Text.colorGreen(this.getShieldDamage(this.getContainer().getActor())) + " damage to shields"
+			});
+		}
 
-		ret.push({
-			id = 11,
-			type = "text",
-			icon = "ui/icons/special.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Inflicts " + ::MSU.Text.colorDamage(this.RF_getFatigueDamage()) + " [Fatigue|Concept.Fatigue] on the target")
-		});
+		if (this.RF_getFatigueDamage() != 0)
+		{
+			ret.push({
+				id = 7,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Inflicts [color=" + ::Const.UI.Color.DamageValue + "]" + this.RF_getFatigueDamage() + "[/color] [Fatigue|Concept.Fatigue] on the target")
+			});
+		}
 
 		if (this.getMaxRange() > 1)
 		{
@@ -47,7 +53,7 @@
 		if (shield != null)
 		{
 			this.spawnAttackEffect(_targetTile, ::Const.Tactical.AttackEffectSplitShield);
-			local damage = _user.getItems().getItemAtSlot(::Const.ItemSlot.Mainhand).getShieldDamage();
+			local damage = this.getShieldDamage(_user);
 
 			local conditionBefore = shield.getCondition();
 			shield.applyShieldDamage(damage);
@@ -56,7 +62,7 @@
 			{
 				if (!_user.isHiddenToPlayer() && _targetTile.IsVisibleForPlayer)
 				{
-					::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " uses Smash Shield and destroys " + ::Const.UI.getColorizedEntityName(_targetTile.getEntity()) + "\'s shield");
+					::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " uses " + this.getName() + " and destroys " + ::Const.UI.getColorizedEntityName(_targetTile.getEntity()) + "\'s shield");
 				}
 			}
 			else
@@ -68,7 +74,7 @@
 
 				if (!_user.isHiddenToPlayer() && _targetTile.IsVisibleForPlayer)
 				{
-					::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " uses Smash Shield and hits " + ::Const.UI.getColorizedEntityName(_targetTile.getEntity()) + "\'s shield for [b]" + (conditionBefore - shield.getCondition()) + "[/b] damage");
+					::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " uses " + this.getName() + " and hits " + ::Const.UI.getColorizedEntityName(_targetTile.getEntity()) + "\'s shield for [b]" + (conditionBefore - shield.getCondition()) + "[/b] damage");
 				}
 			}
 
@@ -96,6 +102,12 @@
 		}
 
 		return true;
+	}
+
+// New Functions
+	q.getShieldDamage <- function( _user )
+	{
+		return _user.getItems().getItemAtSlot(::Const.ItemSlot.Mainhand).getShieldDamage();
 	}
 
 	q.RF_getFatigueDamage <- function()

--- a/mod_reforged/hooks/skills/actives/split_shield.nut
+++ b/mod_reforged/hooks/skills/actives/split_shield.nut
@@ -32,7 +32,7 @@
 				id = 11,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Inflicts [color=" + ::Const.UI.Color.DamageValue + "]" + this.RF_getFatigueDamage() + "[/color] [Fatigue|Concept.Fatigue] on the target")
+				text = ::Reforged.Mod.Tooltips.parseString("Inflicts " + ::MSU.Text.colorDamage(this.RF_getFatigueDamage()) + " [Fatigue|Concept.Fatigue] on the target")
 			});
 		}
 


### PR DESCRIPTION
Extract shield damage calculation into new function. Hide tooltips for effects that are disabled.
Use this.getName() instead of a hard coded name for the combat log.