### PR TITLE
Balance adarga and sipar shields

### DIFF
--- a/mod_reforged/hooks/items/shields/buckler_shield.nut
+++ b/mod_reforged/hooks/items/shields/buckler_shield.nut
@@ -3,7 +3,7 @@
 	{
 		__original();
 		this.m.ReachIgnore = 1;
-		this.m.Condition = 40;
-		this.m.ConditionMax = 40;
+		this.m.Condition = 30;
+		this.m.ConditionMax = 30;
 	}
 });

--- a/mod_reforged/hooks/items/shields/greenskins/orc_heavy_shield.nut
+++ b/mod_reforged/hooks/items/shields/greenskins/orc_heavy_shield.nut
@@ -4,5 +4,6 @@
 		__original();
 		this.m.Condition = 300;
 		this.m.ConditionMax = 300;
+		this.m.StaminaModifier = -25;
 	}
 });

--- a/mod_reforged/hooks/items/shields/oriental/metal_round_shield.nut
+++ b/mod_reforged/hooks/items/shields/oriental/metal_round_shield.nut
@@ -4,5 +4,9 @@
 		__original();
 		this.m.Condition = 300;
 		this.m.ConditionMax = 300;
+		this.m.MeleeDefense = 25;
+		this.m.RangedDefense = 15;
+		this.m.StaminaModifier = -25;
+		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/oriental/southern_light_shield.nut
+++ b/mod_reforged/hooks/items/shields/oriental/southern_light_shield.nut
@@ -2,8 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.StaminaModifier = -9; // Vanilla is -10.
-		this.m.Condition = 80;
-		this.m.ConditionMax = 80;
+		this.m.StaminaModifier = -8; // Vanilla is -10.
+		this.m.Condition = 40;
+		this.m.ConditionMax = 40;
 	}
 });


### PR DESCRIPTION
Prior to our redesign of the shield paradigm, certain shields had an identity:
- Wooden Shield, your regular shield.
- Adarga, better than wooden in ranged defense, but less durable.
- Kite, quite durable and good for ranged defense.
- Heater, less durable than Kite but better for melee defense.
- Sipar, if you want a pseudo-unbreakable shield, otherwise middle of the ground defenses.

Having made most shields "unbreakable" the identities for Adarga and Sipar have been lost. Heater and Kite still maintain their identity thanks to the defenses they provide. There is no reason to use Sipar anymore because Kite (and arguably even Heater) provides a better overall mix of defense stats considering the lower fatigue cost.  Adarga is overwhelmingly better than wooden shield. 

This PR improves the situation with the following changes:
- Drop Adarga durability down to that of Buckler (i.e. from current 80 to 40).
- Drop Buckler durability from 40 to 30.
- Increase Sipar melee defense from 18 to 25, drop ranged defense from 18 to 15, but increase fatigue penalty from 18 to 25, and increase Reach ignore from 2 to 3. So it becomes the best melee shield but costs a lot of fatigue.
- Orc Shield has a fatigue penalty of 22, so that will look out of place with Sipar being at 25. We increase the orc one to 25. It also has the +5 fatigue cost on skills used.