### PR TITLE
fix: calculation for shield defense fatigue multiplier

### DIFF
--- a/mod_reforged/hooks/items/shields/shield.nut
+++ b/mod_reforged/hooks/items/shields/shield.nut
@@ -93,8 +93,6 @@
 			return 1.0;
 		}
 
-		local maxMalus = actor.getCurrentProperties().IsSpecializedInShields ? 0.25 : 0.5;
-
-		return 1.0 - maxMalus * actor.getFatigue() / actor.getFatigueMax();
+		return 1.0 - (actor.getCurrentProperties().IsSpecializedInShields ? 0.25 : 0.5) * actor.getFatigue() / actor.getFatigueMax();
 	}
 });

--- a/mod_reforged/hooks/items/shields/shield.nut
+++ b/mod_reforged/hooks/items/shields/shield.nut
@@ -93,6 +93,8 @@
 			return 1.0;
 		}
 
-		return (actor.getCurrentProperties().IsSpecializedInShields ? 0.75 : 0.5) * actor.getFatigue() / actor.getFatigueMax();
+		local maxMalus = actor.getCurrentProperties().IsSpecializedInShields ? 0.25 : 0.5;
+
+		return 1.0 - maxMalus * actor.getFatigue() / actor.getFatigueMax();
 	}
 });


### PR DESCRIPTION
Subtract from 1.0 and multiply with max malus so that at 0 fatigue the multiplier is 1 and not 0.