### PR TITLE
feat: improve tooltips for flails

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -568,7 +568,7 @@ local vanillaDescriptions = [
  				Type = ::UPD.EffectType.Passive,
  				Description = [
 					"Skills build up [color=" + ::Const.UI.Color.NegativeValue + "]25%[/color] less Fatigue.",
-					"[Lash|Skill+lash_skill] and [Hail|Skill+hail_skill] ignore the defense bonus of shields.",
+					"[Lash|Skill+lash_skill] and [Hail|Skill+hail_skill] ignore the defense bonus granted by shields, but not by [Shieldwall|Skill+shieldwall].",
 					"Gain the [From all Sides|Perk+perk_rf_from_all_sides] perk.",
 					"Pound ignores an additional [color=" + ::Const.UI.Color.PositiveValue + "]+10%[/color] of armor on head hits.",
 					"Thresh gains [color=" + ::Const.UI.Color.PositiveValue + "]+5%[/color] chance to hit.",

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -568,7 +568,7 @@ local vanillaDescriptions = [
  				Type = ::UPD.EffectType.Passive,
  				Description = [
 					"Skills build up [color=" + ::Const.UI.Color.NegativeValue + "]25%[/color] less Fatigue.",
-					"[Lash|Skill+lash_skill] and [Hail|Skill+hail_skill] ignore the defense bonus granted by shields, but not by [Shieldwall|Skill+shieldwall].",
+					"[Lash|Skill+lash_skill] and [Hail|Skill+hail_skill] ignore the defense bonus granted by shields, but not by [Shieldwall|Skill+shieldwall_effect].",
 					"Gain the [From all Sides|Perk+perk_rf_from_all_sides] perk.",
 					"Pound ignores an additional [color=" + ::Const.UI.Color.PositiveValue + "]+10%[/color] of armor on head hits.",
 					"Thresh gains [color=" + ::Const.UI.Color.PositiveValue + "]+5%[/color] chance to hit.",

--- a/mod_reforged/hooks/skills/actives/cascade_skill.nut
+++ b/mod_reforged/hooks/skills/actives/cascade_skill.nut
@@ -2,6 +2,26 @@
 	q.m.RerollDamageMult <- 1.0;
 	q.m.IsAttacking <- false;
 
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 7,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = "Will make three separate attack rolls for one third of the weapon\'s damage each, combined into one strike"
+			},
+			{
+				id = 8,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall]")
+			}
+		]);
+		return ret;
+	}
+
 	q.onUse = @() function( _user, _targetTile )
 	{
 		this.m.RerollDamageMult = 1.0;			

--- a/mod_reforged/hooks/skills/actives/cascade_skill.nut
+++ b/mod_reforged/hooks/skills/actives/cascade_skill.nut
@@ -10,13 +10,13 @@
 				id = 7,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Will make three separate attack rolls for one third of the weapon\'s damage each, combined into one strike"
+				text = "Will make three separate attack rolls for one third of the damage each, combined into one strike"
 			},
 			{
 				id = 8,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall]")
+				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall_effect]")
 			}
 		]);
 		return ret;

--- a/mod_reforged/hooks/skills/actives/flail_skill.nut
+++ b/mod_reforged/hooks/skills/actives/flail_skill.nut
@@ -7,7 +7,7 @@
 				id = 7,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall]")
+				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall_effect]")
 			}
 		]);
 		return ret;

--- a/mod_reforged/hooks/skills/actives/flail_skill.nut
+++ b/mod_reforged/hooks/skills/actives/flail_skill.nut
@@ -1,0 +1,15 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/flail_skill", function(q) {
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 7,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall]")
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/hail_skill.nut
+++ b/mod_reforged/hooks/skills/actives/hail_skill.nut
@@ -2,6 +2,37 @@
 	q.m.RerollDamageMult <- 1.0;
 	q.m.IsAttacking <- false;
 
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 9,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = "Has a [color=" + this.Const.UI.Color.PositiveValue + "]100%[/color] chance to hit the head"
+			},
+			{
+				id = 7,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = "Will make three separate attack rolls for one third of the weapon\'s damage each, combined into one strike"
+			}
+		]);
+
+		if (this.getContainer().getActor().getCurrentProperties().IsSpecializedInFlails)
+		{
+			ret.push({
+				id = 8,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall]")
+			});
+		}
+
+		return ret;
+	}
+
 	q.onUse = @() function( _user, _targetTile )
 	{
 		this.m.RerollDamageMult = 1.0;			

--- a/mod_reforged/hooks/skills/actives/hail_skill.nut
+++ b/mod_reforged/hooks/skills/actives/hail_skill.nut
@@ -7,16 +7,16 @@
 		local ret = this.getDefaultTooltip();
 		ret.extend([
 			{
-				id = 9,
+				id = 9, // In vanilla the id is 9 for this and 7 for the three separate attack rolls entry in this order, so we kept it like that
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Has a [color=" + this.Const.UI.Color.PositiveValue + "]100%[/color] chance to hit the head"
+				text = "Has a " + ::MSU.Text.colorGreen("100%") + " chance to hit the head"
 			},
 			{
 				id = 7,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Will make three separate attack rolls for one third of the weapon\'s damage each, combined into one strike"
+				text = "Will make three separate attack rolls for one third of the damage each, combined into one strike"
 			}
 		]);
 
@@ -26,7 +26,7 @@
 				id = 8,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall]")
+				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall_effect]")
 			});
 		}
 

--- a/mod_reforged/hooks/skills/actives/lash_skill.nut
+++ b/mod_reforged/hooks/skills/actives/lash_skill.nut
@@ -1,0 +1,26 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/lash_skill", function(q) {
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 9,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = "Has a [color=" + this.Const.UI.Color.PositiveValue + "]100%[/color] chance to hit the head"
+			}
+		]);
+
+		if (this.getContainer().getActor().getCurrentProperties().IsSpecializedInFlails)
+		{
+			ret.push({
+				id = 8,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall]")
+			});
+		}
+
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/lash_skill.nut
+++ b/mod_reforged/hooks/skills/actives/lash_skill.nut
@@ -7,7 +7,7 @@
 				id = 9,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Has a [color=" + this.Const.UI.Color.PositiveValue + "]100%[/color] chance to hit the head"
+				text = "Has a " + ::MSU.Text.colorGreen("100%") + " chance to hit the head"
 			}
 		]);
 
@@ -17,7 +17,7 @@
 				id = 8,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall]")
+				text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields but not by [Shieldwall|Skill+shieldwall_effect]")
 			});
 		}
 


### PR DESCRIPTION
Add that flails only ignore Melee Defense from shields and not Shieldwall.
Improve tooltips for how three headed flail skills work in reforged.