### PR TITLE
feat: add more southern names and extend last names using basic names

### DIFF
--- a/mod_reforged/hooks/config/character_names.nut
+++ b/mod_reforged/hooks/config/character_names.nut
@@ -308,10 +308,23 @@ foreach(characterName in ::Const.Strings.CharacterNames)
 // The array contains some duplicates even in vanilla
 ::Const.Strings.SouthernNames = ::MSU.Array.removeDuplicates(::Const.Strings.SouthernNames);
 
-foreach (name in ::Const.Strings.SouthernNames)
+foreach (i, name in ::Const.Strings.SouthernNames)
 {
 	::Const.Strings.SouthernNamesLast.push("Ibn " + name);
 	::Const.Strings.SouthernNamesLast.push("Al-" + name);
+	// For Officer Titles we push all Al- variants but fewer Ibn variants
+	// and a small number of long variants of the form "Al-Name Ibn Name"
+	// this is similar to the distribution of vanilla SouthernOfficerTitles
+	::Const.Strings.SouthernOfficerTitles.push("Al-" + name);
+	if (i % 3 == 0)
+	{
+		::Const.Strings.SouthernOfficerTitles.push("Ibn " + name);
+	}
+	if (i % 5 == 0)
+	{
+		::Const.Strings.SouthernOfficerTitles.push("Al-" + name + " Ibn " + ::MSU.Array.rand(::Const.Strings.SouthernNames));
+	}
 }
 
 ::Const.Strings.SouthernNamesLast = ::MSU.Array.removeDuplicates(::Const.Strings.SouthernNamesLast);
+::Const.Strings.SouthernOfficerTitles = ::MSU.Array.removeDuplicates(::Const.Strings.SouthernOfficerTitles);

--- a/mod_reforged/hooks/config/character_names.nut
+++ b/mod_reforged/hooks/config/character_names.nut
@@ -305,8 +305,13 @@ foreach(characterName in ::Const.Strings.CharacterNames)
 	"Zubayr"
 ]);
 
+// The array contains some duplicates even in vanilla
+::Const.Strings.SouthernNames = ::MSU.Array.removeDuplicates(::Const.Strings.SouthernNames);
+
 foreach (name in ::Const.Strings.SouthernNames)
 {
 	::Const.Strings.SouthernNamesLast.push("Ibn " + name);
 	::Const.Strings.SouthernNamesLast.push("Al-" + name);
 }
+
+::Const.Strings.SouthernNamesLast = ::MSU.Array.removeDuplicates(::Const.Strings.SouthernNamesLast);

--- a/mod_reforged/hooks/config/character_names.nut
+++ b/mod_reforged/hooks/config/character_names.nut
@@ -242,3 +242,71 @@ foreach(characterName in ::Const.Strings.CharacterNames)
 
 // Remove The Robber Baron as a bandit leader name because we have a RobberBaron entity in Reforged
 ::MSU.Array.removeByValue(::Const.Strings.BanditLeaderNames, "The Robber Baron");
+
+::Const.Strings.SouthernNames.extend([
+	"Adil",
+	"Akil",
+	"Akram",
+	"Amin",
+	"Anwar",
+	"Asim",
+	"Badr",
+	"Bashir",
+	"Fahad",
+	"Faisal",
+	"Farid",
+	"Ghassan",
+	"Habib",
+	"Hadi",
+	"Hakim",
+	"Harith",
+	"Idris",
+	"Ihsan",
+	"Imad",
+	"Imran",
+	"Ishaq",
+	"Jafar",
+	"Jamal",
+	"Jibril",
+	"Karim",
+	"Khalid",
+	"Khalil",
+	"Latif",
+	"Layth",
+	"Mahdi",
+	"Mahir",
+	"Marwan",
+	"Munir",
+	"Nadir",
+	"Najeeb",
+	"Naji",
+	"Nawfal",
+	"Qadir",
+	"Qasim",
+	"Qays",
+	"Rafiq",
+	"Saad",
+	"Safwan",
+	"Salah",
+	"Salim",
+	"Samir",
+	"Suhayl",
+	"Talib",
+	"Thabit",
+	"Wahid",
+	"Waqas",
+	"Yasir",
+	"Zafar",
+	"Zayd",
+	"Zeeshan",
+	"Ziyad",
+	"Zuhair",
+	"Zahid",
+	"Zubayr"
+]);
+
+foreach (name in ::Const.Strings.SouthernNames)
+{
+	::Const.Strings.SouthernNamesLast.push("Ibn " + name);
+	::Const.Strings.SouthernNamesLast.push("Al-" + name);
+}

--- a/mod_reforged/hooks/config/character_names.nut
+++ b/mod_reforged/hooks/config/character_names.nut
@@ -300,7 +300,7 @@ foreach(characterName in ::Const.Strings.CharacterNames)
 	"Zayd",
 	"Zeeshan",
 	"Ziyad",
-	"Zuhair",
+	"Zuhayr",
 	"Zahid",
 	"Zubayr"
 ]);


### PR DESCRIPTION
This adds more variety for southern names:
- Add 59 new names.
- Extend the vanilla "southern last names" list by prefixing `Ibn` and `Al-` to all the first names.