### PR TITLE
refactor: show troop cost instead of strength in world entity tooltip

### DIFF
--- a/mod_reforged/hooks/entity/world/location.nut
+++ b/mod_reforged/hooks/entity/world/location.nut
@@ -26,7 +26,7 @@
 		{
 			foreach (troop in ::Const.World.Spawn.Troops)
 			{
-				if (troop.ID = t.ID && troop.Script == t.Script)
+				if (troop.ID == t.ID && troop.Script == t.Script)
 				{
 					worth += troop.Cost;
 					break;

--- a/mod_reforged/hooks/entity/world/location.nut
+++ b/mod_reforged/hooks/entity/world/location.nut
@@ -20,13 +20,20 @@
 	q.getTooltip = @(__original) function()
 	{
 		local ret = __original();
+
+		local worth = 0;
+		foreach (t in this.m.Troops)
+		{
+			worth += t.Cost;
+		}
+
 		if (!this.isHiddenToPlayer() && this.m.Troops.len() != 0 && this.getFaction() != 0)
 		{
 			ret.push({
 				id = 100,
 				type = "text",
 				icon = "ui/icons/icon_contract_swords.png",
-				text = format("Strength: %s / %s", ::MSU.Text.colorGreen(::World.State.getPlayer().getStrength()), ::MSU.Text.colorRed(this.getStrength()))
+				text = format("Strength: %s / %s", ::MSU.Text.colorGreen(::World.State.getPlayer().getStrength()), ::MSU.Text.colorRed(worth))
 			});
 		}
 		return ret;

--- a/mod_reforged/hooks/entity/world/location.nut
+++ b/mod_reforged/hooks/entity/world/location.nut
@@ -24,7 +24,14 @@
 		local worth = 0;
 		foreach (t in this.m.Troops)
 		{
-			worth += t.Cost;
+			foreach (troop in ::Const.World.Spawn.Troops)
+			{
+				if (troop.ID = t.ID && troop.Script == t.Script)
+				{
+					worth += troop.Cost;
+					break;
+				}
+			}
 		}
 
 		if (!this.isHiddenToPlayer() && this.m.Troops.len() != 0 && this.getFaction() != 0)

--- a/mod_reforged/hooks/entity/world/party.nut
+++ b/mod_reforged/hooks/entity/world/party.nut
@@ -2,13 +2,20 @@
 	q.getTooltip = @(__original) function()
 	{
 		local ret = __original();
+
+		local worth = 0;
+		foreach (t in this.m.Troops)
+		{
+			worth += t.Cost;
+		}
+
 		if (!this.isHiddenToPlayer() && this.m.Troops.len() != 0)
 		{
 			ret.push({
 				id = 100,
 				type = "text",
 				icon = "ui/icons/icon_contract_swords.png",
-				text = format("Strength: %s / %s", ::MSU.Text.colorGreen(::World.State.getPlayer().getStrength()), ::MSU.Text.colorRed(this.getStrength()))
+				text = format("Strength: %s / %s", ::MSU.Text.colorGreen(::World.State.getPlayer().getStrength()), ::MSU.Text.colorRed(worth))
 			});
 		}
 		return ret;

--- a/mod_reforged/hooks/entity/world/party.nut
+++ b/mod_reforged/hooks/entity/world/party.nut
@@ -8,7 +8,7 @@
 		{
 			foreach (troop in ::Const.World.Spawn.Troops)
 			{
-				if (troop.ID = t.ID && troop.Script == t.Script)
+				if (troop.ID == t.ID && troop.Script == t.Script)
 				{
 					worth += troop.Cost;
 					break;

--- a/mod_reforged/hooks/entity/world/party.nut
+++ b/mod_reforged/hooks/entity/world/party.nut
@@ -6,7 +6,14 @@
 		local worth = 0;
 		foreach (t in this.m.Troops)
 		{
-			worth += t.Cost;
+			foreach (troop in ::Const.World.Spawn.Troops)
+			{
+				if (troop.ID = t.ID && troop.Script == t.Script)
+				{
+					worth += troop.Cost;
+					break;
+				}
+			}
 		}
 
 		if (!this.isHiddenToPlayer() && this.m.Troops.len() != 0)


### PR DESCRIPTION
The cost is a better indication of the "resources" that were spent on this troop composition and serves a better purpose to compare the spawns for which this tooltip entry was added.