### PR TITLE
balance: bloodlust to recover fatigue instead of reducing fatigue cost

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1012,7 +1012,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Type = ::UPD.EffectType.Passive,
 			Description = [
 				"After inflicting a fatality, gain " + ::MSU.Text.colorGreen("2") + " stacks of Bloodlust, up to a maximum of 2 stacks.",
-				"For each stack [Resolve|Concept.Bravery] and [Initiative|Concept.Initiative] are increased by " + ::MSU.Text.colorGreen("25%") + " and skills build up " + ::MSU.Text.colorGreen("25%") + " less [Fatigue|Concept.Fatigue], stacking [additively|Concept.StackAdditively].",
+				"For each stack [Resolve|Concept.Bravery], [Initiative|Concept.Initiative] and [Fatigue Recovery|Concept.FatigueRecovery] rate are increased by " + ::MSU.Text.colorGreen("25%") + " stacking [additively|Concept.StackAdditively].",
 				"You lose " + ::MSU.Text.colorRed("1") + " stack every [turn|Concept.Turn]."
 			]
 		}]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1013,7 +1013,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Description = [
 				"After inflicting a fatality, gain " + ::MSU.Text.colorGreen("2") + " stacks of Bloodlust, up to a maximum of 2 stacks.",
 				"For each stack [Resolve|Concept.Bravery], [Initiative|Concept.Initiative] and [Fatigue Recovery|Concept.FatigueRecovery] rate are increased by " + ::MSU.Text.colorGreen("25%") + " stacking [additively|Concept.StackAdditively].",
-				"You lose " + ::MSU.Text.colorRed("1") + " stack every [turn|Concept.Turn]."
+				"You lose " + ::MSU.Text.colorRed("1") + " stack at the start of every [turn|Concept.Turn]."
 			]
 		}]
  	}),

--- a/scripts/skills/perks/perk_rf_bloodlust.nut
+++ b/scripts/skills/perks/perk_rf_bloodlust.nut
@@ -46,7 +46,7 @@ this.perk_rf_bloodlust <- ::inherit("scripts/skills/skill", {
 			id = 12,
 			type = "text",
 			icon = "ui/icons/fatigue.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Skills build up " + ::MSU.Text.colorizeMult(mult) + " less [Fatigue|Concept.Fatigue]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMult(mult) + " more [Fatigue recovered|Concept.FatigueRecovery] next [turn|Concept.Turn]")
 		});
 		ret.push({
 			id = 13,
@@ -73,6 +73,7 @@ this.perk_rf_bloodlust <- ::inherit("scripts/skills/skill", {
 		local mult = 1.0 + this.m.MultPerStack * this.m.Stacks;
 		_properties.BraveryMult *= mult;
 		_properties.InitiativeMult *= mult;
+		_properties.FatigueRecoveryRateMult *= mult;
 	}
 
 	function onAfterUpdate( _properties )


### PR DESCRIPTION
Instead of a flat Fatigue Recovery bonus e.g. +3 per stack, I went with a % based bonus so the entire perk is much more clean this way. 50% increased Fatigue Recovery means for a bro with 15 base recovery you get 7 additional Fatigue recovery next turn. And this is fine imo.