### PR TITLE
refactor: add tip of the day for dismissing brothers

### DIFF
--- a/mod_reforged/hooks/config/tip_of_the_day.nut
+++ b/mod_reforged/hooks/config/tip_of_the_day.nut
@@ -19,6 +19,7 @@ for (local index = (::Const.TipOfTheDay.len() - 1); index >= 0; index--)
 }
 
 ::Const.TipOfTheDay.extend([
+	"Dismissing a brother will transfer all of their equipped items into your stash if you have space."
 	"Reforged: While on a caravan mission, you can enter towns up to 2 tiles away instead of only on the same tile.",
     "The Mod Options have a lot of customizations regarding quality of life.",
     "Morale Checks are harder for every adjacent enemy and easier for every adjacent ally.",


### PR DESCRIPTION
This tip is supposed to emphasize that this happens automatically. 
Otherwise a new player might start stripping those characters every time they are dismissed.