### PR TITLE
refactor: require Poise System temporarily

### DIFF
--- a/scripts/!mods_preload/mod_reforged.nut
+++ b/scripts/!mods_preload/mod_reforged.nut
@@ -26,11 +26,15 @@ local requiredMods = [
 	"mod_stack_based_skills >= 0.5.0"
 ];
 
+requiredMods.push("mod_poise_system >= 0.1.1");
+
 ::Reforged.HooksMod <- ::Hooks.register(::Reforged.ID, ::Reforged.Version, ::Reforged.Name);
 ::Reforged.HooksMod.require(requiredMods);
 ::Reforged.HooksMod.conflictWith(
 	"mod_legends"
 );
+
+requiredMods.pop();	// Poise System must load after Reforged, even though it's a requirement for reforged
 
 local queueLoadOrder = [];
 foreach (requirement in requiredMods)


### PR DESCRIPTION
This is meant to enforce testing of that system. Eventually the plan is to inporporate it into reforged in which case this commit will have to be reverted.

Here is the repository: https://github.com/Battle-Modders/Poise-System