### PR TITLE
feat hide some active skills in tooltip

### DIFF
--- a/mod_reforged/actor_tooltip_functions.nut
+++ b/mod_reforged/actor_tooltip_functions.nut
@@ -49,7 +49,7 @@
     local collapseThreshold = ::Reforged.Mod.ModSettings.getSetting("CollapseEffectsWhenX").getValue();
     local effectList = [];
 
-    local statusEffects = _actor.getSkills().query(::Const.SkillType.StatusEffect | ::Const.SkillType.PermanentInjury, false, true);
+    local statusEffects = this.__querySkills(_actor, ::Const.SkillType.StatusEffect | ::Const.SkillType.PermanentInjury, false, true);
     if (statusEffects.len() != 0 || ::Reforged.Mod.ModSettings.getSetting("HeaderForEmptyCategories").getValue() == true) ::Reforged.TacticalTooltip.pushSectionName(effectList, "Effects", currentID);
     currentID++;
 
@@ -106,7 +106,7 @@
     local collapseThreshold = ::Reforged.Mod.ModSettings.getSetting("CollapsePerksWhenX").getValue();
     local perkList = [];
 
-    local perks = _actor.getSkills().query(::Const.SkillType.Perk, true, true);
+    local perks = this.__querySkills(_actor, ::Const.SkillType.Perk, true, true);
     if (perks.len() != 0 || ::Reforged.Mod.ModSettings.getSetting("HeaderForEmptyCategories").getValue() == true) ::Reforged.TacticalTooltip.pushSectionName(perkList, "Perks", currentID);
     currentID++;
 
@@ -270,7 +270,7 @@
 {
 	local ret = [];
 
-	local skills = _actor.getSkills().getAllSkillsOfType(::Const.SkillType.Active);
+	local skills = this.__querySkills(_actor, ::Const.SkillType.Active, false, true);
 
 	if (skills.len() != 0 || ::Reforged.Mod.ModSettings.getSetting("HeaderForEmptyCategories").getValue() == true)
 	{
@@ -381,4 +381,18 @@
 {
     local fileName = split(::IO.scriptFilenameByHash(_skill.ClassNameHash), "/").top();
     return ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|%s]", !_skill.isActive() || _skill.isAffordable() ? _skill.getIconColored() : _skill.getIconDisabled(), "Skill+" + fileName));
+}
+
+// Private Functions
+::Reforged.TacticalTooltip.__querySkills <- function( _actor, _filter, _includeHidden, _ordered )
+{
+	local ret = _actor.getSkills().query(_filter, _includeHidden, _ordered);
+	for (local i = ret.len() - 1; i >= 0; i--)
+	{
+		if (ret[i].hideInTooltip())	// Enforce our reforged flag for REALLY hiding this skill no matter what
+		{
+			ret.remove(i);
+		}
+	}
+	return ret;
 }

--- a/mod_reforged/hooks/skills/actives/sweep_zoc_skill.nut
+++ b/mod_reforged/hooks/skills/actives/sweep_zoc_skill.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/sweep_zoc_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.RF_HideInTooltip = true;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/tail_slam_zoc_skill.nut
+++ b/mod_reforged/hooks/skills/actives/tail_slam_zoc_skill.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/tail_slam_zoc_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.RF_HideInTooltip = true;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/uproot_zoc_skill.nut
+++ b/mod_reforged/hooks/skills/actives/uproot_zoc_skill.nut
@@ -8,6 +8,7 @@
 			"sounds/combat/break_free_roots_02.wav",
 			"sounds/combat/break_free_roots_03.wav"
 		];
+		this.m.RF_HideInTooltip = true;
 	}
 
 	q.onTargetHit <- function( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )

--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/skills/skill", function(q) {
+	q.m.RF_HideInTooltip <- false;	// If true, then this skill with never be listed in the combat tooltip. e.g. for dummy ZoC skills on enemies.
+
 	q.isDuelistValid <- function()
 	{
 		return this.isAttack() && !this.isRanged() && !this.isAOE() && this.getBaseValue("MaxRange") == 1;
@@ -77,6 +79,12 @@
 		}
 
 		return ret;
+	}
+
+// New Functions
+	q.hideInTooltip <- function()
+	{
+		return this.m.RF_HideInTooltip
 	}
 });
 


### PR DESCRIPTION
- add new flag for preventing any skill from showing up in combat tooltips
- turn that flag on for zoc versions of sweep, tail slam and uproot
- fix: enforce the skill order for displaying active skills in the tooltip

![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/ce9c6633-5058-4b07-a73d-1fc044d991c6)
![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/4ffbb267-1a93-4276-a3a6-45f4f6e6e3d1)
![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/7a8864c6-3f3d-4b7b-993c-1a9c34b5132f)

Closes: #281 