### PR TITLE
feat: add nps skill descriptions

### DIFF
--- a/mod_reforged/hooks/skills/actives/alp_teleport_skill.nut
+++ b/mod_reforged/hooks/skills/actives/alp_teleport_skill.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/alp_teleport_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.Description = "Will teleport to a random tile when any Alp is attacked."; // Vanilla is missing a description for this skill
+	}
+});

--- a/mod_reforged/hooks/skills/actives/barbarian_fury_skill.nut
+++ b/mod_reforged/hooks/skills/actives/barbarian_fury_skill.nut
@@ -4,5 +4,7 @@
 		__original();
 		this.m.Icon = "skills/active_175.png";
 		this.m.IconDisabled = "skills/active_175_sw.png";
+		// Vanilla is missing a description for this skill
+		this.m.Description = ::Reforged.Mod.Tooltips.parseString("Switch places with an adjacent ally, provided neither you nor the ally is [stunned|Skill+stunned_effect] or rooted. Rotate the battle line to keep fresh troops in front!");
 	}
 });

--- a/mod_reforged/hooks/skills/actives/charm_skill.nut
+++ b/mod_reforged/hooks/skills/actives/charm_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/charm_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = ::Reforged.Mod.Tooltips.parseString("Try to charm a character, forcing him to turn on his allies and obey you instead. The higher a character\'s [Resolve|Concept.Bravery], the higher the chance to resist being charmed.");
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Will trigger up to " + ::MSU.Text.colorRed("2") + " [morale checks|Concept.Morale] on the target and if any are successful, the target gains the [Charmed|Skill+charmed_effect] effect")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/crack_the_whip_skill.nut
+++ b/mod_reforged/hooks/skills/actives/crack_the_whip_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/crack_the_whip_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Crack your whip to keep your wild pets obedient.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Will prevent your animals from going wild for their next [turn|Concept.Turn]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/darkflight.nut
+++ b/mod_reforged/hooks/skills/actives/darkflight.nut
@@ -1,0 +1,8 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/darkflight", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = ::Reforged.Mod.Tooltips.parseString("Transform into a swarm of bats to quickly navigate the field of battle ignoring [Zone of Control|Concept.ZoneOfControl].");
+	}
+});

--- a/mod_reforged/hooks/skills/actives/drums_of_war_skill.nut
+++ b/mod_reforged/hooks/skills/actives/drums_of_war_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/drums_of_war_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Strike a vigorous rhythm making your allies feel less tired and more eager to fight.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/fatigue.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Every other ally on the battlefield gains the [Drums of War|Skill+drums_of_war_effect] effect")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/explode_skill.nut
+++ b/mod_reforged/hooks/skills/actives/explode_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/explode_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Explode into a shrapnel of bone damaging everyone next to you.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Deals a small amount of damage to everyone on adjacent tiles")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/fire_mortar_skill.nut
+++ b/mod_reforged/hooks/skills/actives/fire_mortar_skill.nut
@@ -1,0 +1,27 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/fire_mortar_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Fire a shell high in the air to wreak havoc upon returning to earth with a blasting impact.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Will mark a tile and its surrounding tiles for impact for this character\'s next [turn|Concept.Turn]. Upon impact, characters in the tiles take damage and may be [Shellshocked|Skill+shellshocked_effect]")
+		});
+		ret.push({
+			id = 20,
+			type = "text",
+			icon = "ui/icons/warning.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Can only be used once every " + ::MSU.Text.colorRed(this.m.Cooldown) + " [turns|Concept.Turn]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/fling_back_skill.nut
+++ b/mod_reforged/hooks/skills/actives/fling_back_skill.nut
@@ -1,4 +1,42 @@
 ::Reforged.HooksMod.hook("scripts/skills/actives/fling_back_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Fling a character backwards and move into their position!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/fatigue.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target builds " + ::MSU.Text.colorRed("10") + " [fatigue|Concept.Fatigue]")
+		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/regular_damage.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target is flung backwards and receives damage upon landing")
+		});
+		ret.push({
+			id = 12,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target loses effects such as [Shieldwall|Skill+shieldwall_effect], [Spearwall|Skill+spearwall_effect] and [Riposte|Skill+riposte_effect]")
+		});
+		ret.push({
+			id = 13,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("You move into the target tile ignoring [Zone of Control|Concept.ZoneOfControl]")
+		});
+		return ret;
+	}
+
 	// We delay the onFollow of this skill by another 100ms because otherwise the entity doesn't follow through with this function properly when at very high speeds using some faster combat speed mods
 	q.onFollow = @(__original) function( _tag )
 	{

--- a/mod_reforged/hooks/skills/actives/ghastly_touch.nut
+++ b/mod_reforged/hooks/skills/actives/ghastly_touch.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/ghastly_touch", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Attack the very soul of an opponent, damaging them through their armor.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.skill.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/goblin_whip.nut
+++ b/mod_reforged/hooks/skills/actives/goblin_whip.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/goblin_whip", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Crack the whip and ensure your goblins\' motivation for the battle.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/bravery.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Raises the target\'s [morale|Concept.Morale] to Confident unless they are Fleeing in which case raises it to Steady instead")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/gorge_skill.nut
+++ b/mod_reforged/hooks/skills/actives/gorge_skill.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/gorge_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "A forceful bite intended to crush and maul the target to pieces!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.skill.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/grant_night_vision_skill.nut
+++ b/mod_reforged/hooks/skills/actives/grant_night_vision_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/grant_night_vision_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Grant your allies the ability to see clearly in the dark!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target and allies adjacent to the target will no longer be affected by [Nighttime|Skill+night_effect] for the course of this battle")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/grow_shield_skill.nut
+++ b/mod_reforged/hooks/skills/actives/grow_shield_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/grow_shield_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Regrow your shield to protect your most vulnerable parts!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Gain a [Schrat Shield|Item+schrat_shield]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/gruesome_feast.nut
+++ b/mod_reforged/hooks/skills/actives/gruesome_feast.nut
@@ -1,0 +1,27 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/gruesome_feast", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Feast on a corpse to heal yourself and grow larger!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/health.png",
+			text = ::Reforged.Mod.Tooltips.parseString("All [Hitpoints|Concept.Hitpoints] and [injuries|Concept.TemporaryInjury] are fully healed")
+		});
+		ret.push({
+			id = 12,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Gain the [Feasted|Skill+gruesome_feast_effect] effect")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/headbutt_skill.nut
+++ b/mod_reforged/hooks/skills/actives/headbutt_skill.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/headbutt_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "A forceful attack to inflict blunt trauma.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.skill.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/hex_skill.nut
+++ b/mod_reforged/hooks/skills/actives/hex_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/hex_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Curse a target to suffer every bit of scratch, itch and pain that dares affect you!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target gains the [Hex|Skill+hex_slave_effect]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/horrific_scream.nut
+++ b/mod_reforged/hooks/skills/actives/horrific_scream.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/horrific_scream", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Let loose a scream causing your enemies to flee and scatter!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/bravery.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target receives " + ::MSU.Text.colorRed(4) " + mental [morale checks|Concept.Morale]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/horror_skill.nut
+++ b/mod_reforged/hooks/skills/actives/horror_skill.nut
@@ -1,0 +1,27 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/horror_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Trigger your targets\' deepest fears, causing them to freeze with fright!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/bravery.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target receives a negative mental [morale check|Concept.Morale] with a " + ::MSU.Text.colorRed(-15) + " penalty to [Resolve|Concept.Bravery]")
+		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/bravery.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target receives an additional mental [morale check|Concept.Morale] with a " + ::MSU.Text.colorRed(-5) " + penalty to [Resolve|Concept.Bravery]. If this [morale check|Concept.MoraleCheck] succeeds, the target gains the [Horrified|Skill+horrified_effect] effect")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/hyena_bite.nut
+++ b/mod_reforged/hooks/skills/actives/hyena_bite.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/hyena_bite", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "An attack adept at piercing through armor to get to the flesh beneath!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Inflicts [Bleeding|Skill+bleeding_effect] when dealing at least " + ::MSU.Text.colorRed(::Const.Combat.MinDamageToApplyBleeding) + " damage to [Hitpoints|Concept.Hitpoints]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/insects_skill.nut
+++ b/mod_reforged/hooks/skills/actives/insects_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/insects_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Summon a swarm of insects to surround an enemy, reducing their ability to focus on combat!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target gains the [Swarm of Insects|Skill+insect_swarm_effect] effect")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/kraken_bite_skill.nut
+++ b/mod_reforged/hooks/skills/actives/kraken_bite_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/kraken_bite_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Mangle the target with your massive maw!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Inflicts [Bleeding|Skill+bleeding_effect] when dealing at least " + ::MSU.Text.colorRed(::Const.Combat.MinDamageToApplyBleeding) + " damage to [Hitpoints|Concept.Hitpoints]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/kraken_devour_skill.nut
+++ b/mod_reforged/hooks/skills/actives/kraken_devour_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/kraken_devour_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Eat them alive!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Kills the target")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/kraken_ensnare_skill.nut
+++ b/mod_reforged/hooks/skills/actives/kraken_ensnare_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/kraken_ensnare_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Trap the target using a giant tentacle to slowly drag them towards you!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target gains the [Entangled|Skill+kraken_ensnare_effect] effect")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/kraken_move_ensnared_skill.nut
+++ b/mod_reforged/hooks/skills/actives/kraken_move_ensnared_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/kraken_move_ensnared_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "This character is being dragged towards the Kraken!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Every turn you are moved towards the Kraken")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/kraken_move_skill.nut
+++ b/mod_reforged/hooks/skills/actives/kraken_move_skill.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/kraken_move_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Move a tentacle from one place to another.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.skill.getDefaultUtilityTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/line_breaker.nut
+++ b/mod_reforged/hooks/skills/actives/line_breaker.nut
@@ -1,4 +1,11 @@
 ::Reforged.HooksMod.hook("scripts/skills/actives/line_breaker", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Shove them out of your way and move forward, breaking their ranks.";
+	}
+
 	// Vanilla does not have a tooltip function for this skill.
 	q.getTooltip = @() function()
 	{

--- a/mod_reforged/hooks/skills/actives/load_mortar_skill.nut
+++ b/mod_reforged/hooks/skills/actives/load_mortar_skill.nut
@@ -1,0 +1,30 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/load_mortar_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Load a large shell into an adjacent mortar.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 20,
+			type = "text",
+			icon = "ui/icons/warning.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Can only be used once every " + ::MSU.Text.colorRed(this.m.Cooldown) + " [turns|Concept.Turn]")
+		});
+		if (this.getContainer().getActor().isEngagedInMelee())
+		{
+			ret.push({
+				id = 21,
+				type = "text",
+				icon = "ui/icons/warning.png",
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorRed("Cannot be used when [engaged|Concept.ZoneOfControl] in melee"))
+			});
+		}
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/merge_golem_skill.nut
+++ b/mod_reforged/hooks/skills/actives/merge_golem_skill.nut
@@ -1,0 +1,29 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/merge_golem_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Grow larger by bringing together the living sands and stone around you!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Fully heals all [Hitpoints|Concept.Hitpoints]")
+		});
+
+		local entityType = ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()) ? ::Const.EntityType.SandGolem : this.getContainer().getActor().getType();
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Consumes 2 adjacent " + ::Const.Strings.EntityNamePlural[entityType] + " and makes you [grow|Skill+golem_racial] larger")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/miasma_skill.nut
+++ b/mod_reforged/hooks/skills/actives/miasma_skill.nut
@@ -1,0 +1,33 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/miasma_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Summon a toxic miasma in the target area dealing damage to anything that lives and breathes!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The targeted tiles gain miasma that lasts " + ::MSU.Text.colorGreen(3) + " [rounds|Concept.Round]")
+		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("All characters except the undead receive " + ::MSU.Text.colorRed(5) + " - " + ::MSU.Text.colorRed(10) + " damage when they end their [turn|Concept.Turn] in the miasma")
+		});
+		ret.push({
+			id = 12,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Blows away existing tile effects like Fire or Smoke")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/move_tail_skill.nut
+++ b/mod_reforged/hooks/skills/actives/move_tail_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/move_tail_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Bring your tail along with you wherever you go!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Brings your tail next to you ignoring [zone of control|Concept.ZoneOfControl]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/nightmare_skill.nut
+++ b/mod_reforged/hooks/skills/actives/nightmare_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/nightmare_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Plunge your target into a world of nightmares and feast upon their souls while they sleep!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultTooltip();
+		ret.push({
+			id = 20,
+			type = "text",
+			icon = "ui/icons/warning.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Can only be used on [sleeping|Skill+sleeping_effect] targets")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/possess_undead_skill.nut
+++ b/mod_reforged/hooks/skills/actives/possess_undead_skill.nut
@@ -1,0 +1,30 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/possess_undead_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Concentrate on one of your wiedergangers to grant him great boons!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/warning.png",
+			text = ::Reforged.Mod.Tooltips.parseString("You gain the [Possessing Undead|Skill+possessing_undead_effect] effect and the target gains the [Possessed Undead|Skill+possessed_undead_effect] effect")
+		});
+		if (this.getContainer().getActor().isEngagedInMelee())
+		{
+			ret.push({
+				id = 21,
+				type = "text",
+				icon = "ui/icons/warning.png",
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorRed("Cannot be used when [engaged|Concept.ZoneOfControl] in melee"))
+			});
+		}
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/raise_undead.nut
+++ b/mod_reforged/hooks/skills/actives/raise_undead.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/raise_undead", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Reanimate a corpse to do your bidding!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/warning.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Raises the targeted resurrectable corpse as a wiederganger")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/root_skill.nut
+++ b/mod_reforged/hooks/skills/actives/root_skill.nut
@@ -2,6 +2,26 @@
 	q.m.Cooldown <- 0;
 	q.m.TurnsRemaining <- 0;
 
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Raise thick vines from the ground to trap your enemies in place, hampering their ability to move and defend themselves.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target and all adjacent enemies receive the [Rooted|Skill+rooted_effect] effect")
+		});
+		return ret;
+	}
+
 	q.onUse = @(__original) function( _user, _targetTile )
 	{
 		this.m.TurnsRemaining = this.m.Cooldown;

--- a/mod_reforged/hooks/skills/actives/serpent_bite_skill.nut
+++ b/mod_reforged/hooks/skills/actives/serpent_bite_skill.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/serpent_bite_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Use your fangs to bite and pierce your target\'s flesh.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.skill.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/serpent_hook_skill.nut
+++ b/mod_reforged/hooks/skills/actives/serpent_hook_skill.nut
@@ -1,0 +1,39 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/serpent_hook_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Wrap your body around the target and pull them towards a more vulnerable position!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Will grab the target and pull it to a tile next to you")
+		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target becomes [Staggered|Skill+staggered_effect]")
+		});
+		ret.push({
+			id = 12,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target loses the [Shieldwall|Skill+shieldwall_effect], [Spearwall|Skill+spearwall_effect] and [Riposte|Skill+riposte_effect] effects")
+		});
+		ret.push({
+			id = 13,
+			type = "text",
+			icon = "ui/icons/regular_damage.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target will receive damage when being pulled to a lower elevation")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/sleep_skill.nut
+++ b/mod_reforged/hooks/skills/actives/sleep_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/sleep_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Put your enemies to sleep, making them vulnerable to soul-shattering nightmares!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target receives a mental [morale check|Concept.Morale] with a greater penalty to [Resolve|Concept.Bravery] the closer they are to you. If successful, the target falls [asleep|Skill+sleeping_effect]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/spider_bite_skill.nut
+++ b/mod_reforged/hooks/skills/actives/spider_bite_skill.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/spider_bite_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Impale them with your fangs and inject your deadly venom!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.skill.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/swallow_whole_skill.nut
+++ b/mod_reforged/hooks/skills/actives/swallow_whole_skill.nut
@@ -1,0 +1,33 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/swallow_whole_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Devour an adjacent target whole!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target goes inside your belly, gaining the [Swallowed Whole|Skills+swallowed_whole_effect] effect")
+		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/bravery.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target\'s [morale|Concept.Morale] is set to [Breaking|Concept.Morale]")
+		});
+		// ret.push({
+		// 	id = 12,
+		// 	type = "text",
+		// 	icon = "ui/icons/special.png",
+		// 	text = ::Reforged.Mod.Tooltips.parseString("The target loses the [Shieldwall|Skill+shieldwall_effect], [Spearwall|Skill+spearwall_effect] and [Riposte|Skill+riposte_effect] effects")
+		// });
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/sweep_skill.nut
+++ b/mod_reforged/hooks/skills/actives/sweep_skill.nut
@@ -1,0 +1,33 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/sweep_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Swing your fists in a wide arc, hitting up to three adjacent characters in counter-clockwise order!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Can hit up to " + ::MSU.Text.colorGreen(3) + " targets")
+		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Will knock back targets who are not immune to being knocked back or being rooted. Upon being knocked back, the targets lose the [Shieldwall|Skill+shieldwall_effect], [Spearwall|Skill+spearwall_effect] and [Riposte|Skill+riposte_effect] effects")
+		});
+		ret.push({
+			id = 12,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Targets immune to being knocked back or rooted are [staggered|Skill+staggered_effect] instead")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/sweep_zoc_skill.nut
+++ b/mod_reforged/hooks/skills/actives/sweep_zoc_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/sweep_zoc_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = ::Reforged.Mod.Tooltips.parseString("Swing your fists at a character who tries to move [away|Concept.ZoneOfControl] from you.");
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.skill.getDefaultTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Will [stagger|Skill+staggered_effect] the target on a hit")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/tail_slam_big_skill.nut
+++ b/mod_reforged/hooks/skills/actives/tail_slam_big_skill.nut
@@ -1,0 +1,26 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/tail_slam_big_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla has the name Tail Slam for this skill which is the same as the name for tail_slam_skill
+		// We give it a unique name to help differentiate the two skills
+		this.m.Name = "Tail Thresh";
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Swing your tail in a reckless round swing, threshing all the targets around you, friend and foe alike!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Will randomly either [daze|Skill+dazed_effect], [stun|Skill+stunned_effect] or knock back the target")
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/tail_slam_skill.nut
+++ b/mod_reforged/hooks/skills/actives/tail_slam_skill.nut
@@ -1,0 +1,23 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/tail_slam_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Slam your tail from above with full force to smash the target to bits.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Will randomly either [daze|Skill+dazed_effect], [stun|Skill+stunned_effect] or knock back the target")
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/tail_slam_split_skill.nut
+++ b/mod_reforged/hooks/skills/actives/tail_slam_split_skill.nut
@@ -1,0 +1,26 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/tail_slam_split_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla has the name Tail Slam for this skill which is the same as the name for tail_slam_skill
+		// We give it a unique name to help differentiate the two skills
+		this.m.Name = "Tail Split";
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Slam your tail in a wide-swinging overhead attack that can hit two tiles in a straight line.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Will randomly either [daze|Skill+dazed_effect] or [stun|Skill+stunned_effect] the target")
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/throw_golem_skill.nut
+++ b/mod_reforged/hooks/skills/actives/throw_golem_skill.nut
@@ -1,0 +1,30 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/throw_golem_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Throw a boulder of your sand and stone at a target, splitting yourself into smaller living!";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		local entityType = ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()) ? ::Const.EntityType.SandGolem : this.getContainer().getActor().getType();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Will spawn a " + ::Const.Strings.EntityName[entityType] + " adjacent to the target")
+			},
+			{
+				id = 11,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Will reduce your size and spawn two " + ::Const.Strings.EntityNamePlural[entityType] + " of this size adjacent to you")
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/unstoppable_charge_skill.nut
+++ b/mod_reforged/hooks/skills/actives/unstoppable_charge_skill.nut
@@ -1,0 +1,30 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/unstoppable_charge_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Charge into a tile with unstoppable force, wreaking havoc in the area!";
+	}
+
+	// Vanilla has a getTooltip function defined for this skill but it doesn't provide all the details
+	// so we overwrite it to produce a better tooltip overall
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultUtilityTooltip();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Will move you into the target tile and randomly [stun|Skill+stunned_effect], or [stagger|Skill+staggered_effect] and knock back enemies around that tile")
+			},
+			{
+				id = 11,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Knocked back targets will lose the [Shieldwall|Skill+shieldwall_effect], [Spearwall|Skill+spearwall_effect] and [Riposte|Skill+riposte_effect] effects")
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/uproot_skill.nut
+++ b/mod_reforged/hooks/skills/actives/uproot_skill.nut
@@ -1,0 +1,35 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/uproot_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Raise large thorny roots from the ground to smash and impale multiple targets.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Will attack up to " + ::MSU.Text.colorGreen(3) + " targets in a straight line")
+			},
+			{
+				id = 11,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Targets become [staggered|Skill+staggered_effect] on a hit")
+			},
+			{
+				id = 12,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Does not damage or affect other Schrats")
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/uproot_small_skill.nut
+++ b/mod_reforged/hooks/skills/actives/uproot_small_skill.nut
@@ -1,0 +1,29 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/uproot_small_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Raise thorny roots from the ground to smash and impale multiple targets.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("The target becomes [staggered|Skill+staggered_effect] on a hit")
+			},
+			{
+				id = 11,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Does not damage or affect other Schrats")
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/uproot_small_zoc_skill.nut
+++ b/mod_reforged/hooks/skills/actives/uproot_small_zoc_skill.nut
@@ -1,0 +1,29 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/uproot_small_zoc_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = ::Reforged.Mod.Tooltips.parseString("Raise thorny roots from the ground to attack someone trying to move [away|Concept.ZoneOfControl] from you!");
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("The target becomes [staggered|Skill+staggered_effect] on a hit")
+			},
+			{
+				id = 11,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Does not damage or affect other Schrats")
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/uproot_zoc_skill.nut
+++ b/mod_reforged/hooks/skills/actives/uproot_zoc_skill.nut
@@ -8,11 +8,34 @@
 			"sounds/combat/break_free_roots_02.wav",
 			"sounds/combat/break_free_roots_03.wav"
 		];
+		// Vanilla is missing a description for this skill
+		this.m.Description = ::Reforged.Mod.Tooltips.parseString("Raise large thorny roots from the ground to attack someone trying to move [away|Concept.ZoneOfControl] from you!");
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultTooltip();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("The target becomes [staggered|Skill+staggered_effect] and [rooted|Skill+rooted_effect] on a hit")
+			},
+			{
+				id = 11,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Does not damage or affect other Schrats")
+			}
+		]);
+		return ret;
 	}
 
 	q.onTargetHit <- function( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
 	{
-		if (_skill == this && _targetEntity.isAlive())
+		if (_skill == this && _targetEntity.isAlive() && _targetEntity.getType() != ::Const.EntityType.Schrat && _targetEntity.getType() != ::Const.EntityType.SchratSmall)
 		{
 			_targetEntity.getSkills().add(::new("scripts/skills/effects/rooted_effect"));
 

--- a/mod_reforged/hooks/skills/actives/warcry.nut
+++ b/mod_reforged/hooks/skills/actives/warcry.nut
@@ -6,5 +6,21 @@
 		// VanillaFix: vanilla uses the wrong icon active_41
 		this.m.Icon = "skills/active_49.png";
 		this.m.IconDisabled = "skills/active_49_sw.png";
+
+		// Vanilla is missing a description for this skill
+		this.m.Description = ::Reforged.Mod.Tooltips.parseString("Let out a bellowing roar to bolster the [morale|Concept.Morale] of your allies while giving your enemies [second thoughts|Concept.Morale]!");
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("All allies and enemies receive positive and negative [morale checks|Concept.Morale] respectively, with those closer to you receiving stronger checks")
+		});
+		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/wardog_bite.nut
+++ b/mod_reforged/hooks/skills/actives/wardog_bite.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/wardog_bite", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Lash at them with your muzzle, biting and tearing apart flesh.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/warhound_bite.nut
+++ b/mod_reforged/hooks/skills/actives/warhound_bite.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/warhound_bite", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Lash at them with your large muzzle, biting and tearing apart flesh.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/web_skill.nut
+++ b/mod_reforged/hooks/skills/actives/web_skill.nut
@@ -1,0 +1,29 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/web_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Spin a web around a target, trapping them in place and hindering their ability to fight and defend themselves.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultUtilityTooltip();
+		ret.extend([
+			{
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("The target becomes [webbed|Skill+webbed_effect]")
+			},
+			{
+				id = 11,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Can only be used once every " + ::MSU.Text.colorRed(3) + " turns");
+			}
+		]);
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/werewolf_bite.nut
+++ b/mod_reforged/hooks/skills/actives/werewolf_bite.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/warhound_bite", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Tear into an enemy with your powerful jaw and sharp teeth.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/wither_skill.nut
+++ b/mod_reforged/hooks/skills/actives/wither_skill.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/wither_skill", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Curse the target, causing its body to wither away.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		local ret = this.getDefaultUtilityTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The target becomes [withered|Skill+withered_effect]")
+		});
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/wolf_bite.nut
+++ b/mod_reforged/hooks/skills/actives/wolf_bite.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/wolf_bite", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Lash at them with your muzzle, biting and tearing apart flesh.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/actives/zombie_bite.nut
+++ b/mod_reforged/hooks/skills/actives/zombie_bite.nut
@@ -1,0 +1,14 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/zombie_bite", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "Use your rotten teeth to deliver a painful bite.";
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @() function()
+	{
+		return this.getDefaultTooltip();
+	}
+});

--- a/mod_reforged/hooks/skills/effects/drums_of_war_effect.nut
+++ b/mod_reforged/hooks/skills/effects/drums_of_war_effect.nut
@@ -1,0 +1,30 @@
+::Reforged.HooksMod.hook("scripts/skills/effects/drums_of_war_effect", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla is missing a description for this skill
+		this.m.Description = "This character is feeling more energetic, thanks to the vigorous rhythm of his allies' war drums."
+		// In vanilla it is hidden but we reveal it because we have custom description and tooltip for it.
+		this.m.IsHidden = false;
+	}
+
+	// Vanilla doesn't have a getTooltip function defined for this skill
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/fatigue.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Built [Fatigue|Concept.Fatigue] is reduced by " + ::MSU.Text.colorGreen("15") + " when this effect is received")
+		});
+		ret.push({
+			id = 20,
+			type = "text",
+			icon = "ui/icons/warning.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Cannot receive this effect more than once per [turn|Concept.Turn]")
+		});
+
+		return ret;
+	}
+});


### PR DESCRIPTION
Almost all NPC only active skills have no tooltip. They don't even list the action point and fatigue cost. That info is only viewable while they are not collapted in the combat tooltip.

This is a draft project for eventually assigning every enemy only active skill a description.
The list is long. I assume there to be around 40 skills that need description. However several descriptions we can borrow from similar working weapon/perk skills.

One remaining issue is that those skills fail to show any damage numbers. Therefor any base damage granted by the respective skills is hidden.

![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/3f8ef684-dd5e-4e21-840f-e89563313fb3)
![image](https://github.com/Battle-Modders/mod-reforged/assets/2252464/8f3dd770-98ad-4a58-980f-6ba1a54597a0)
