### PR TITLE
fix: floating point errors in colorizeMult and colorizeFraction

### DIFF
--- a/mod_reforged/hooks/msu.nut
+++ b/mod_reforged/hooks/msu.nut
@@ -86,7 +86,7 @@
 	if (_options == null) _options = {};
 	if (!("AddSign" in _options)) _options.AddSign <- false;
 	_options.AddPercent <- true;
-	return this.colorizeValue((_value - 1.0) * 100, _options);
+	return this.colorizeValue(::Math.round((_value - 1.0) * 100), _options);
 }
 
 ::logInfo("Reforged::MSU -- adding ::MSU.Text.colorizeFraction");
@@ -100,7 +100,7 @@
 	if (_options == null) _options = {};
 	if (!("AddSign" in _options)) _options.AddSign <- false;
 	_options.AddPercent <- true;
-	return this.colorizeValue(_value * 100, _options);
+	return this.colorizeValue(::Math.round(_value * 100), _options);
 }
 
 ::logInfo("Reforged::MSU -- adding ::MSU.Tile.getNeighbors");


### PR DESCRIPTION
This fixes situations where printing (1.0 + 2 * 0.03) would print 5.99999% instead of 6%.