### PR TITLE
refactor: rework offhand training

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1768,8 +1768,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Once per [turn,|Concept.Turn] the first use of the tool in your offhand costs no [Action Points.|Concept.ActionPoints]",
-				"Once per [turn,|Concept.Turn] switching an offhand item costs no [Action Points.|Concept.ActionPoints] Does not work when switching items with a weight of " + ::MSU.Text.colorNegative("10") + " or more. Does not stack with other free item swapping skills e.g. Quick Hands.",
+				"Once per [turn,|Concept.Turn] the first use of your offhand item weighing less than " + ::MSU.Text.colorRed(10) + " costs no [Action Points.|Concept.ActionPoints]",
 				"When equipped with a net, gain the [Trip Artist|NullEntitySkill+rf_trip_artist_effect] effect."
 			]
 		}]

--- a/scripts/skills/perks/perk_rf_offhand_training.nut
+++ b/scripts/skills/perks/perk_rf_offhand_training.nut
@@ -1,8 +1,8 @@
 this.perk_rf_offhand_training <- ::inherit("scripts/skills/skill", {
 	m = {
 		StaminaModifierThreshold = -10,
-		IsFreeUse = false,
-		IsConsumingFreeUse = false // Used in onBeforeAnySkillExecuted to flip IsFreeUse in onAnySkillExecuted
+		IsSpent = true,
+		IsConsumingFreeUse = false // Used in onBeforeAnySkillExecuted to flip IsSpent in onAnySkillExecuted
 	},
 	function create()
 	{
@@ -17,7 +17,7 @@ this.perk_rf_offhand_training <- ::inherit("scripts/skills/skill", {
 
 	function isHidden()
 	{
-		return !this.m.IsFreeUse;
+		return this.m.IsSpent;
 	}
 
 	function getTooltip()
@@ -44,7 +44,7 @@ this.perk_rf_offhand_training <- ::inherit("scripts/skills/skill", {
 
 	function onBeforeAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
 	{
-		if (!this.m.IsFreeUse || _forFree || !::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()))
+		if (this.m.IsSpent || _forFree || !::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()))
 			return;
 
 		if (_skill.getItem() != null && ::MSU.isEqual(_skill.getItem(), this.getContainer().getActor().getOffhandItem()))
@@ -58,12 +58,12 @@ this.perk_rf_offhand_training <- ::inherit("scripts/skills/skill", {
 	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
 	{
 		if (this.m.IsConsumingFreeUse)
-			this.m.IsFreeUse = false;
+			this.m.IsSpent = true;
 	}
 
 	function onAfterUpdate( _properties )
 	{
-		if (!this.m.IsFreeUse)
+		if (this.m.IsSpent)
 			return;
 
 		local offhand = this.getContainer().getActor().getOffhandItem();
@@ -79,13 +79,13 @@ this.perk_rf_offhand_training <- ::inherit("scripts/skills/skill", {
 	function onTurnStart()
 	{
 		this.m.IsConsumingFreeUse = false;
-		this.m.IsFreeUse = true;
+		this.m.IsSpent = false;
 	}
 
 	function onCombatFinished()
 	{
 		this.skill.onCombatFinished();
 		this.m.IsConsumingFreeUse = false;
-		this.m.IsFreeUse = false;
+		this.m.IsSpent = true;
 	}
 });


### PR DESCRIPTION
- Remove free swap.
- Instead of only tool, extend the one free use per turn to all offhand items less than 10 weight.