### PR TITLE
refactor: adjust excluded undead injuries

### DIFF
--- a/mod_reforged/config/msu_excluded_injuries.nut
+++ b/mod_reforged/config/msu_excluded_injuries.nut
@@ -3,6 +3,8 @@
 	[
 		"injury.bruised_leg",
 		"injury.broken_nose",
+		"injury.broken_ribs",
+		"injury.fractured_ribs",
 		"injury.severe_concussion",
 		"injury.crushed_windpipe",
 		"injury.cut_artery",
@@ -10,6 +12,7 @@
 		"injury.ripped_ear",
 		"injury.split_nose",
 		"injury.pierced_cheek",
+		"injury.pierced_side",
 		"injury.grazed_neck",
 		"injury.cut_throat",
 		"injury.grazed_kidney",
@@ -26,14 +29,17 @@
 ::Const.Injury.ExcludedInjuries.add(
 	"RF_Skeleton",
 	[
+		"injury.burnt_face",
+		"injury.burnt_legs",
+		"injury.burnt_hands",
 		"injury.sprained_ankle",
 		"injury.deep_abdominal_cut",
+		"injury.cut_arm_sinew",
 		"injury.cut_leg_muscles",
 		"injury.cut_achilles_tendon",
 		"injury.deep_chest_cut",
 		"injury.pierced_leg_muscles",
 		"injury.pierced_chest",
-		"injury.pierced_side",
 		"injury.pierced_arm_muscles",
 		"injury.stabbed_guts",
 		"injury.rf_dislocated_jaw"

--- a/mod_reforged/config/msu_excluded_injuries.nut
+++ b/mod_reforged/config/msu_excluded_injuries.nut
@@ -1,48 +1,53 @@
 ::Const.Injury.ExcludedInjuries.add(
 	"RF_Undead",
 	[
-		"injury.bruised_leg",
+		// Blunt
+		"injury.rf_black_eye",
 		"injury.broken_nose",
 		"injury.broken_ribs",
+		"injury.bruised_leg",
+		"injury.crushed_windpipe",
 		"injury.fractured_ribs",
 		"injury.severe_concussion",
-		"injury.crushed_windpipe",
+		// Burning
+		"injury.rf_heat_stroke",
+		"injury.inhaled_flames",
+		// Cutting
 		"injury.cut_artery",
+		"injury.cut_throat",
 		"injury.exposed_ribs",
+		"injury.grazed_neck",
 		"injury.ripped_ear",
 		"injury.split_nose",
-		"injury.pierced_cheek",
-		"injury.pierced_side",
-		"injury.grazed_neck",
-		"injury.cut_throat",
+		// Piercing
 		"injury.grazed_kidney",
+		"injury.pierced_cheek",
 		"injury.pierced_lung",
-		"injury.grazed_neck",
-		"injury.cut_throat",
-		"injury.crushed_windpipe",
-		"injury.inhaled_flames",
-		"injury.rf_heat_stroke",
-		"injury.rf_black_eye"
+		"injury.pierced_side"
 	]
 );
 
 ::Const.Injury.ExcludedInjuries.add(
 	"RF_Skeleton",
 	[
+		// Blunt
+		"injury.rf_dislocated_jaw",
+		"injury.sprained_ankle",
+		// Burning
 		"injury.burnt_face",
 		"injury.burnt_legs",
 		"injury.burnt_hands",
-		"injury.sprained_ankle",
-		"injury.deep_abdominal_cut",
+		// Cutting
+		"injury.cut_achilles_tendon",
 		"injury.cut_arm_sinew",
 		"injury.cut_leg_muscles",
-		"injury.cut_achilles_tendon",
+		"injury.deep_abdominal_cut",
 		"injury.deep_chest_cut",
-		"injury.pierced_leg_muscles",
-		"injury.pierced_chest",
+		// Piercing
 		"injury.pierced_arm_muscles",
-		"injury.stabbed_guts",
-		"injury.rf_dislocated_jaw"
+		"injury.pierced_chest",
+		"injury.pierced_leg_muscles",
+		"injury.stabbed_guts"
 	],
 	[
 		::Const.Injury.ExcludedInjuries.RF_Undead


### PR DESCRIPTION
- Add exclusion for Broken Ribs and Fractured Ribs to all undead and move exclusion of Pierced Side from skeleton only to all undead because these injuries affect Fatigue only.
- Exclude Burnt Face, Burnt Leg and Burnt Hands from skeletons.
- Exclude Cut Arm Sinew from skeletons.
- Reorganize the injuries for readability by separating them into types.
- Remove duplicate entries.