### PR TITLE
fix: revert reload skills to vanilla behavior of removal upon firing

### DIFF
--- a/mod_reforged/hooks/items/weapons/crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/crossbow.nut
@@ -11,9 +11,13 @@
 
 		this.addSkill(::new("scripts/skills/actives/shoot_bolt"));
 
-		local reload = ::Reforged.new("scripts/skills/actives/reload_bolt", function(o) {
-			o.m.FatigueCost -= 2;
-		});
-		this.addSkill(reload);
+		// Always add reload skill to DummyPlayer so that it appears in nested tooltips of weapons
+		if (!this.m.IsLoaded || ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			local reload = ::Reforged.new("scripts/skills/actives/reload_bolt", function(o) {
+				o.m.FatigueCost -= 2;
+			});
+			this.addSkill(reload);
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/greenskins/goblin_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/goblin_crossbow.nut
@@ -11,7 +11,11 @@
 
 		this.addSkill(::new("scripts/skills/actives/shoot_stake"));
 
-		local reload = ::Reforged.new("scripts/skills/actives/reload_bolt");
-		this.addSkill(reload);
+		// Always add reload skill to DummyPlayer so that it appears in nested tooltips of weapons
+		if (!this.m.IsLoaded || ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			local reload = ::Reforged.new("scripts/skills/actives/reload_bolt");
+			this.addSkill(reload);
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
@@ -11,9 +11,13 @@
 
 		this.addSkill(::new("scripts/skills/actives/shoot_bolt"));
 
-		local reload = ::Reforged.new("scripts/skills/actives/reload_bolt", function(o) {
-			o.m.ActionPointCost += 1;
-		});
-		this.addSkill(reload);
+		// Always add reload skill to DummyPlayer so that it appears in nested tooltips of weapons
+		if (!this.m.IsLoaded || ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			local reload = ::Reforged.new("scripts/skills/actives/reload_bolt", function(o) {
+				o.m.ActionPointCost += 1;
+			});
+			this.addSkill(reload);
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/light_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/light_crossbow.nut
@@ -11,9 +11,13 @@
 
 		this.addSkill(::new("scripts/skills/actives/shoot_bolt"));
 
-		local reload = ::Reforged.new("scripts/skills/actives/reload_bolt", function(o) {
-			o.m.FatigueCost -= 5;
-		});
-		this.addSkill(reload);
+		// Always add reload skill to DummyPlayer so that it appears in nested tooltips of weapons
+		if (!this.m.IsLoaded || ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			local reload = ::Reforged.new("scripts/skills/actives/reload_bolt", function(o) {
+				o.m.FatigueCost -= 5;
+			});
+			this.addSkill(reload);
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/named/named_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/named/named_crossbow.nut
@@ -7,9 +7,13 @@
 
 		this.addSkill(::new("scripts/skills/actives/shoot_bolt"));
 
-		local reload = ::Reforged.new("scripts/skills/actives/reload_bolt", function(o) {
-			o.m.ActionPointCost += 1;
-		});
-		this.addSkill(reload);
+		// Always add reload skill to DummyPlayer so that it appears in nested tooltips of weapons
+		if (!this.m.IsLoaded || ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			local reload = ::Reforged.new("scripts/skills/actives/reload_bolt", function(o) {
+				o.m.ActionPointCost += 1;
+			});
+			this.addSkill(reload);
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/named/named_handgonne.nut
+++ b/mod_reforged/hooks/items/weapons/named/named_handgonne.nut
@@ -7,8 +7,12 @@
 
 		this.addSkill(::new("scripts/skills/actives/fire_handgonne_skill"));
 
-		this.addSkill(::Reforged.new("scripts/skills/actives/reload_handgonne_skill", function(o) {
-			o.m.FatigueCost += 2;
-		}));
+		// Always add reload skill to DummyPlayer so that it appears in nested tooltips of weapons
+		if (!this.m.IsLoaded || ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			this.addSkill(::Reforged.new("scripts/skills/actives/reload_handgonne_skill", function(o) {
+				o.m.FatigueCost += 2;
+			}));
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/oriental/handgonne.nut
+++ b/mod_reforged/hooks/items/weapons/oriental/handgonne.nut
@@ -11,9 +11,13 @@
 
 		this.addSkill(::new("scripts/skills/actives/fire_handgonne_skill"));
 
-		local reload = ::Reforged.new("scripts/skills/actives/reload_handgonne_skill", function(o) {
-			o.m.FatigueCost += 2;
-		});
-		this.addSkill(reload);
+		// Always add reload skill to DummyPlayer so that it appears in nested tooltips of weapons
+		if (!this.m.IsLoaded || ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			local reload = ::Reforged.new("scripts/skills/actives/reload_handgonne_skill", function(o) {
+				o.m.FatigueCost += 2;
+			});
+			this.addSkill(reload);
+		}
 	}
 });

--- a/mod_reforged/hooks/skills/actives/fire_handgonne_skill.nut
+++ b/mod_reforged/hooks/skills/actives/fire_handgonne_skill.nut
@@ -2,26 +2,6 @@
 	q.m.AdditionalAccuracy = 10;
 	q.m.AdditionalHitChance = -10;
 
-	// Overwrite vanilla function to prevent repeated adding of reload skill
-	q.onUse = @() function( _user, _targetTile	)
-	{
-		::Sound.play(this.m.SoundOnFire[::Math.rand(0, this.m.SoundOnFire.len() - 1)], ::Const.Sound.Volume.Skill * this.m.SoundVolume, _user.getPos());
-		local tag = {
-			Skill = this,
-			User = _user,
-			TargetTile = _targetTile
-		};
-		::Time.scheduleEvent(::TimeUnit.Virtual, 500, this.onDelayedEffect.bindenv(this), tag);
-		this.getItem().setLoaded(false);
-
-		return true;
-	}
-
-	// Overwrite the vanilla function to prevent removal of reload skill
-	q.onRemoved = @() function()
-	{
-	}
-
 	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getDefaultTooltip();

--- a/mod_reforged/hooks/skills/actives/reload_bolt.nut
+++ b/mod_reforged/hooks/skills/actives/reload_bolt.nut
@@ -5,19 +5,4 @@
 		this.m.IsRemovedAfterBattle = false;
 		this.m.Order = ::Const.SkillOrder.OffensiveTargeted;	// Players expect this skill to come earlier than most other active skills because of muscle memory, so we move it forward to be immediately after the shoot skill
 	}
-
-	// Overwrite vanilla function to prevent removal of this skill
-	q.onUse = @() function( _user, _targetTile	)
-	{
-		this.consumeAmmo();
-		this.getItem().setLoaded(true);
-		return true;
-	}
-
-	q.isHidden <- function()
-	{
-		if (!this.getContainer().getActor().isPlacedOnMap()) return true;	// In the character screen this is always hidden
-
-		return this.getItem().isLoaded();
-	}
 });

--- a/mod_reforged/hooks/skills/actives/shoot_bolt.nut
+++ b/mod_reforged/hooks/skills/actives/shoot_bolt.nut
@@ -2,18 +2,6 @@
 	q.m.AdditionalAccuracy = 15;
 	q.m.AdditionalHitChance = -3;
 
-	// Overwrite vanilla function to prevent repeated adding of reload skill
-	q.onUse = @() function( _user, _targetTile	)
-	{
-		this.getItem().setLoaded(false);
-		return this.attackEntity(_user, _targetTile.getEntity());
-	}
-
-	// Overwrite the vanilla function to prevent removal of reload skill
-	q.onRemoved = @() function()
-	{
-	}
-
 	q.getTooltip = @() function()
 	{
 		local ret = this.getRangedTooltip(this.skill.getDefaultTooltip());

--- a/mod_reforged/hooks/skills/actives/shoot_stake.nut
+++ b/mod_reforged/hooks/skills/actives/shoot_stake.nut
@@ -2,18 +2,6 @@
 	q.m.AdditionalAccuracy = 10;
 	q.m.AdditionalHitChance = -3;
 
-	// Overwrite vanilla function to prevent repeated adding of reload skill
-	q.onUse = @() function( _user, _targetTile	)
-	{
-		this.getItem().setLoaded(false);
-		return this.attackEntity(_user, _targetTile.getEntity());
-	}
-
-	// Overwrite the vanilla function to prevent removal of reload skill
-	q.onRemoved = @() function()
-	{
-	}
-
 	q.getTooltip = @() function()
 	{
 		local ret = this.getRangedTooltip(this.skill.getDefaultTooltip());


### PR DESCRIPTION
The goal of showing them in nested tooltips is achieved instead by ensuring that the reload skill is always added to the dummy player. This keeps the skills themselves functioning as vanilla so that mods which use these skills do not run into unintended behavior.

Fixes [this issue](https://discord.com/channels/1006908336991645757/1268104130803535964).