### PR TITLE
feat: improve craftable shields by giving them unique identities

### DIFF
--- a/mod_reforged/hooks/items/shields/special/craftable_kraken_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_kraken_shield.nut
@@ -4,5 +4,23 @@
 		__original();
 		this.m.Condition = 220;
 		this.m.ConditionMax = 220;
+		this.m.ReachIgnore = 3;
+	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Reduces the [Resolve|Concept.Bravery] of any opponent engaged in melee by " + ::MSU.Text.colorNegative(10))
+		});
+		return ret;
+	}
+
+	q.onUpdateProperties = @( _properties )
+	{
+		_properties.Threat += 10;
 	}
 });

--- a/mod_reforged/hooks/items/shields/special/craftable_kraken_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_kraken_shield.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/items/shields/special/craftable_kraken_shield", function(q) {
+	q.m.ThreatModifier <- 10;
+
 	q.create = @(__original) function()
 	{
 		__original();
@@ -10,18 +12,21 @@
 	q.getTooltip = @(__original) function()
 	{
 		local ret = __original();
-		ret.push({
-			id = 10,
-			type = "text",
-			icon = "ui/icons/special.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Reduces the [Resolve|Concept.Bravery] of any opponent engaged in melee by " + ::MSU.Text.colorNegative(10))
-		});
+		if (this.m.ThreatModifier != 0)
+		{
+			ret.push({
+				id = 10,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Reduces the [Resolve|Concept.Bravery] of any opponent engaged in melee by " + ::MSU.Text.colorNegative(10))
+			});
+		}
 		return ret;
 	}
 
 	q.onUpdateProperties = @(__original) function( _properties )
 	{
 		__original(_properties);
-		_properties.Threat += 10;
+		_properties.Threat += this.m.ThreatModifier;
 	}
 });

--- a/mod_reforged/hooks/items/shields/special/craftable_kraken_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_kraken_shield.nut
@@ -19,8 +19,9 @@
 		return ret;
 	}
 
-	q.onUpdateProperties = @( _properties )
+	q.onUpdateProperties = @(__original) function( _properties )
 	{
+		__original(_properties);
 		_properties.Threat += 10;
 	}
 });

--- a/mod_reforged/hooks/items/shields/special/craftable_lindwurm_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_lindwurm_shield.nut
@@ -2,8 +2,14 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Condition = 250;
-		this.m.ConditionMax = 250;
+		this.m.Condition = 200;
+		this.m.ConditionMax = 200;
+		// Similar description as vanilla but add mention of "weighs little" because our design of the shield
+		// has a much lower stamina modifier than vanilla.
+		this.m.Description = "This sturdy shield fashioned from the shimmering scales of a Lindwurm weighs little but makes for protection nigh indestructible.";
+		this.m.StaminaModifier = -8; // vanilla -14
+		this.m.MeleeDefense = 20; // vanilla 17
+		this.m.RangedDefense = 20; // vanilla 25
 		this.m.ReachIgnore = 3;
 	}
 });

--- a/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
@@ -17,7 +17,7 @@
 			id = 10,
 			type = "text",
 			icon = "ui/icons/special.png",
-			text = "When hit while having at least " + ::MSU.Text.colorGreen(this.m.SpawnSaplingConditionThreshold) + " durability, spawns a " + ::Const.Strings.EntityName[::Const.EntityType.SchratSmall] + " on an adjacent tile, losing " + ::MSU.Text.colorNegative(this.m.SpawnSaplingConditionLoss) + " points of durability"
+			text = "When hit while having at least " + ::MSU.Text.colorGreen(this.m.SpawnSaplingConditionThreshold) + " durability, spawns a small " + ::Const.Strings.EntityName[::Const.EntityType.Schrat] + " on an adjacent tile, losing " + ::MSU.Text.colorNegative(this.m.SpawnSaplingConditionLoss) + " points of durability"
 		});
 		return ret;
 	}

--- a/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
@@ -1,8 +1,51 @@
 ::Reforged.HooksMod.hook("scripts/items/shields/special/craftable_schrat_shield", function(q) {
+	q.m.SpawnSaplingConditionThreshold <- 125;
+	q.m.SpawnSaplingConditionLoss <- 50;
+
 	q.create = @(__original) function()
 	{
 		__original();
 		this.m.Condition = 150;
 		this.m.ConditionMax = 150;
+		this.m.ReachIgnore = 3;
+	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = "When hit while having at least " + ::MSU.Text.colorGreen(this.m.SpawnSaplingConditionThreshold) + " durability, spawns a " + ::Const.Strings.EntityName[::Const.EntityType.SchratSmall] + " on an adjacent tile, losing " + ::MSU.Text.colorNegative(this.m.SpawnSaplingConditionLoss) + " points of durability"
+		});
+		return ret;
+	}
+
+	q.onShieldHit = @() function( _attacker, _skill )
+	{
+		if (this.getCondition() >= this.m.SpawnSaplingConditionThreshold && this.getCondition() > this.m.SpawnSaplingConditionLoss)
+		{
+			this.spawnSapling();
+		}
+	}
+
+// New functions
+	q.spawnSapling <- function()
+	{
+		local actor = this.getContainer().getActor();
+		if (!actor.isPlacedOnMap())
+			return;
+
+		local myTile = actor.getTile();
+		local neighboringTiles = ::MSU.Tile.getNeighbors(myTile).filter(@(_, _t) _t.IsEmpty && ::Math.abs(myTile.Level - _t.Level) <= 1);
+
+		if (neighboringTiles.len() != 0)
+		{
+			local sapling = ::Tactical.spawnEntity("scripts/entity/tactical/enemies/schrat_small", ::MSU.Array.rand(neighboringTiles).Coords);
+			sapling.setFaction(actor.isPlayerControlled() ? ::Const.Faction.PlayerAnimals : actor.getFaction());
+			sapling.riseFromGround();
+			this.setCondition(::Math.max(0, this.getCondition() - this.m.SpawnSaplingConditionLoss));
+		}
 	}
 });


### PR DESCRIPTION
- Kraken Shield: Improve ReachIgnore to 3 and reduce adjacent opponents Resolve by 10.
- Lindwurm Shield: Lightest shield that provides great defenses and durability. Improve melee defense from 17 to 20 and reduce ranged defense from 25 to 20 but reduce StaminaModifier greatly from -14 to -8. Durability slightly reduced from 250 to 200.
- Schrat Shield: Improve ReachIgnore to 3 and spawn a sapling when hit, losing durability, but regenerates durability over time.