### PR TITLE
refactor: recover some troops in black monolith before combat

### DIFF
--- a/mod_reforged/hooks/entity/world/locations/legendary/black_monolith_location.nut
+++ b/mod_reforged/hooks/entity/world/locations/legendary/black_monolith_location.nut
@@ -1,4 +1,8 @@
 ::Reforged.HooksMod.hook("scripts/entity/world/locations/legendary/black_monolith_location", function(q) {
+	// These fields are used to spawn new entities before combat
+	q.m.NumTroopsMax <- 47;
+	q.m.NumTroopsToRecoverBeforeCombat <- 6;
+
 	q.onSpawned = @() function()
 	{
 		this.m.Name = "Black Monolith";
@@ -42,5 +46,59 @@
 	q.onBeforeCombatStarted = @() function()
 	{
 		this.location.onBeforeCombatStarted();
+
+		// Vanilla adds up to 6 new troops before every combat up to a maximum of 47 total troops
+		// We emulate that behavior using a custom entity pool
+
+		if (this.m.Troops.len() == this.m.NumTroopsMax || this.m.NumTroopsToRecoverBeforeCombat == 0)
+			return;
+
+		local pool = this.getTroopRecoveryPool();
+		if (pool.len() == 0)
+			return;
+
+		for (local i = 0; i < this.m.NumTroopsToRecoverBeforeCombat && this.m.Troops.len() < this.m.NumTroopsMax; i++)
+		{
+			::Const.World.Common.addTroop(this, { Type = pool.roll() }, false);
+		}
+	}
+
+	// Reforged added function in this class
+	q.getTroopRecoveryPool <- function()
+	{
+		local pool = ::MSU.Class.WeightedContainer().addMany(1, [
+			::Const.World.Spawn.Troops.SkeletonMedium,
+			::Const.World.Spawn.Troops.SkeletonMediumPolearm,
+			::Const.World.Spawn.Troops.RF_SkeletonMediumElite,
+			::Const.World.Spawn.Troops.RF_SkeletonMediumElitePolearm,
+			::Const.World.Spawn.Troops.RF_SkeletonHeavyLesser,
+			::Const.World.Spawn.Troops.SkeletonHeavy,
+			::Const.World.Spawn.Troops.SkeletonPriest,
+			::Const.World.Spawn.Troops.Vampire
+		]);
+
+		local function addToPoolIfFewerThan( _troopType, _count )
+		{
+			local numPresent = 0;
+			foreach (t in this.getTroops())
+			{
+				if (t.Script == _troopType.Script)
+				{
+					numPresent++;
+				}
+			}
+
+			if (numPresent < _count)
+			{
+				pool.add(_troopType, _count - numPresent);
+			}
+		}
+
+		addToPoolIfFewerThan(::Const.World.Spawn.Troops.RF_SkeletonDecanus, 3);
+		addToPoolIfFewerThan(::Const.World.Spawn.Troops.RF_SkeletonCenturion, 2);
+		addToPoolIfFewerThan(::Const.World.Spawn.Troops.RF_SkeletonLegatus, 1);
+		addToPoolIfFewerThan(::Const.World.Spawn.Troops.RF_VampireLord, 1);
+
+		return pool;
 	}
 });

--- a/mod_reforged/hooks/entity/world/locations/legendary/black_monolith_location.nut
+++ b/mod_reforged/hooks/entity/world/locations/legendary/black_monolith_location.nut
@@ -57,7 +57,7 @@
 		if (pool.len() == 0)
 			return;
 
-		for (local i = 0; i < this.m.NumTroopsToRecoverBeforeCombat && this.m.Troops.len() < this.m.NumTroopsMax; i++)
+		for (local i = 0; i < this.m.NumTroopsToRecoverBeforeCombat && this.m.Troops.len() <= this.m.NumTroopsMax; i++)
 		{
 			::Const.World.Common.addTroop(this, { Type = pool.roll() }, false);
 		}

--- a/mod_reforged/hooks/entity/world/locations/legendary/black_monolith_location.nut
+++ b/mod_reforged/hooks/entity/world/locations/legendary/black_monolith_location.nut
@@ -59,7 +59,14 @@
 
 		for (local i = 0; i < this.m.NumTroopsToRecoverBeforeCombat && this.m.Troops.len() <= this.m.NumTroopsMax; i++)
 		{
-			::Const.World.Common.addTroop(this, { Type = pool.roll() }, false);
+			local type = pool.roll();
+			// Reduce the weight of these entities by 1 if they spawn  because
+			// we don't want them to be able to spawn beyond a certain number.
+			if (type == ::Const.World.Spawn.Troops.RF_SkeletonDecanus || ::Const.World.Spawn.Troops.RF_SkeletonCenturion || ::Const.World.Spawn.Troops.RF_SkeletonLegatus || ::Const.World.Spawn.Troops.RF_VampireLord)
+			{
+				pool.setWeight(type, pool.getWeight(type) - 1);
+			}
+			::Const.World.Common.addTroop(this, { Type = type }, false);
 		}
 	}
 


### PR DESCRIPTION
Similar to how vanilla recovers up to 6 troops before combat up to a maximum of 47.

We have an assortment of regular skeletons and if decanus, centurion, legatus and vampire lord are below their desired numbers we also add them to the pool of potential entities.