### PR TITLE
feat: onSpawnEntity experimental module

### DIFF
--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -240,10 +240,6 @@
 	{
 		this.m.IsWaitingTurn = _bool;
 	}
-
-	q.onSetupEntity <- function()
-	{
-	}
 });
 
 ::Reforged.HooksMod.hookTree("scripts/entity/tactical/actor", function(q) {

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_leader.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_leader.nut
@@ -177,7 +177,7 @@
 		return true;
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_marksman.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_marksman.nut
@@ -83,7 +83,7 @@
 		}
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
@@ -90,7 +90,7 @@
 		}
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/mod_reforged/hooks/entity/tactical/enemies/goblin_leader.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/goblin_leader.nut
@@ -22,7 +22,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_duelist"));
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
 		::Reforged.Skills.addPerkGroup(this, "pg.rf_sword");

--- a/mod_reforged/hooks/entity/tactical/enemies/orc_young.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/orc_young.nut
@@ -168,7 +168,7 @@
 		}
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 3);
 	}

--- a/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy.nut
@@ -79,7 +79,7 @@
 		return true;
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
 

--- a/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy_bodyguard.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy_bodyguard.nut
@@ -60,7 +60,7 @@
 		}
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
 

--- a/mod_reforged/hooks/entity/tactical/enemies/skeleton_light.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/skeleton_light.nut
@@ -49,7 +49,7 @@
 		}
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null && mainhandItem.isItemType(::Const.Items.ItemType.MeleeWeapon)) // melee weapon equipped

--- a/mod_reforged/hooks/entity/tactical/enemies/skeleton_medium.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/skeleton_medium.nut
@@ -59,7 +59,7 @@
 		}
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/mod_reforged/hooks/entity/tactical/enemies/skeleton_medium_polearm.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/skeleton_medium_polearm.nut
@@ -54,7 +54,7 @@
 		}
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/mod_reforged/hooks/entity/tactical/enemies/vampire.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/vampire.nut
@@ -193,7 +193,7 @@
 		__original(_killer, _skill, _tile, _fatalityType);
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/mod_reforged/hooks/entity/tactical/humans/barbarian_madman.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/barbarian_madman.nut
@@ -59,7 +59,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_vigorous_assault"));
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
 	}

--- a/mod_reforged/hooks/entity/tactical/humans/conscript.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/conscript.nut
@@ -35,7 +35,7 @@
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		this.m.Skills.add(::new("scripts/skills/perks/perk_backstabber"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_quick_hands"));

--- a/mod_reforged/hooks/entity/tactical/humans/conscript_polearm.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/conscript_polearm.nut
@@ -19,7 +19,7 @@
 		}
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_polearm"));
 	}

--- a/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
@@ -116,7 +116,7 @@
 		return true;
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/mod_reforged/hooks/entity/tactical/humans/knight.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/knight.nut
@@ -74,7 +74,7 @@
 		}
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/mod_reforged/hooks/entity/tactical/humans/master_archer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/master_archer.nut
@@ -112,7 +112,7 @@
 		return true;
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/mod_reforged/hooks/entity/tactical/humans/noble_arbalester.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_arbalester.nut
@@ -59,7 +59,7 @@
 		}
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/mod_reforged/hooks/entity/tactical/humans/noble_billman.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_billman.nut
@@ -90,7 +90,7 @@
 		}
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/mod_reforged/hooks/entity/tactical/humans/noble_footman.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_footman.nut
@@ -103,7 +103,7 @@
 		}
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
 	}

--- a/mod_reforged/hooks/entity/tactical/humans/noble_greatsword.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_greatsword.nut
@@ -71,7 +71,7 @@
 		}
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/mod_reforged/hooks/entity/tactical/humans/noble_sergeant.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_sergeant.nut
@@ -72,7 +72,7 @@
 		}
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/mod_reforged/hooks/entity/tactical/humans/nomad_archer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/nomad_archer.nut
@@ -50,7 +50,7 @@
 		// }
 	}
 
-	q.onSetupEntity = @() function()
+	q.onSpawned = @() function()
 	{
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
 	}

--- a/mod_reforged/hooks/entity/tactical/humans/swordmaster.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/swordmaster.nut
@@ -238,7 +238,7 @@
 		return true;
 	}
 
-	q.onSetupEntity <- function()
+	q.onSpawned = @() function()
 	{
 		if (this.m.MyArmorVariant == 0) // light armor
 		{

--- a/mod_reforged/hooks/entity/tactical/tactical_entity_manager.nut
+++ b/mod_reforged/hooks/entity/tactical/tactical_entity_manager.nut
@@ -1,7 +1,0 @@
-::Reforged.HooksMod.hook("scripts/entity/tactical/tactical_entity_manager", function(q) {
-	q.setupEntity = @(__original) function( _e, _t )
-	{
-		__original(_e, _t);
-		_e.onSetupEntity();
-	}
-});

--- a/mod_reforged/hooks/experimental_modules/onSpawnEntity.nut
+++ b/mod_reforged/hooks/experimental_modules/onSpawnEntity.nut
@@ -1,0 +1,130 @@
+// Original feature request and detailed discussion here: https://github.com/MSUTeam/MSU/issues/301
+
+// Goal:
+// - Call onActorSpawned event for all entities on the battlefield whenever an entity spawns or resurrects.
+// - This call should happen AFTER the faction, skills and equipment of the entity has been assigned and equipped.
+
+::Reforged.HooksMod.hook("scripts/skills/skill", function(q) {
+	// This actor MUST NOT get killed during this if this spawning is via a resurrection because
+	// tactical_entity_manager.onResurrect calls entity.riseFromGround after entity.onResurrected
+	// and riseFromGround tries to access the entity's tile.
+	q.onActorSpawned <- function( _entity )
+	{
+	}
+});
+
+::Reforged.HooksMod.hook("scripts/skills/skill_container", function(q) {
+	q.onActorSpawned <- function( _entity )
+	{
+		this.callSkillsFunction("onActorSpawned", [
+			_entity
+		]);
+	}
+});
+
+::Reforged.HooksMod.hook("scripts/entity/tactical/actor", function(q) {
+	// Because we call onSpawn from actor.onSkillsUpdated which happens every skill_container.update
+	// we use this field to ensure that onSpawn is never called more than once for an actor.
+	// Is set to false in actor.onAfterInit to allow onSpawn to trigger afterward.
+	q.m.RF_HasOnSpawnBeenCalled <- true;
+	// Because we trigger onSpawn from actor.onSkillsUpdated, this field is used
+	// to block onSpawn from triggering during certain functions where the entity
+	// is still being set up but which also triggers skill_container.update.
+	// For example: during assignRandomEquipment and onResurrect.
+	q.m.RF_OnSpawnBlockerCount <- 0;
+
+	// This function should be used to do something with this entity after it has fully spawned
+	// e.g. add perks based on its equipment, or something else.
+	q.onSpawned <- function()
+	{
+	}
+
+	// Internal function to check if it is valid to call onSpawn
+	q.RF_canCallOnSpawn <- function()
+	{
+		// Faction is 0 when an actor is first actor.onPlacedOnMap and
+		// later the faction is set correctly via actor.setFaction.
+		return !this.m.RF_HasOnSpawnBeenCalled && this.m.RF_OnSpawnBlockerCount == 0 && this.isPlacedOnMap() && this.getFaction() != 0;
+	}
+
+	// Internal function to handle calling of onSpawn. We expose the public onSpawned function separately
+	// so that the conditions inside this function can be handled safely by the backend as onSpawned is meant
+	// to be overwritten by child classes.
+	q.RF_onSpawn <- function()
+	{
+		if (!this.canCallOnSpawn())
+			return;
+
+		this.m.RF_HasOnSpawnBeenCalled = true;
+
+		this.onSpawned();
+
+		// ::logInfo(format("RF_onSpawn %s (%i) of faction %i with %i items at tile %i with %i skills and %i skillsToAdd", this.getName(), this.getID(), this.getFaction(), this.getItems().getAllItems().len(), this.getTile().ID, this.getSkills().m.Skills.len(), this.getSkills().m.SkillsToAdd.len()));
+
+		foreach (faction in ::Tactical.Entities.getAllInstances())
+		{
+			foreach (actor in faction)
+			{
+				// This actor MUST NOT get killed during this if this spawning is via a resurrection because
+				// tactical_entity_manager.onResurrect calls entity.riseFromGround after entity.onResurrected
+				// and riseFromGround tries to access the entity's tile.
+				actor.getSkills().onActorSpawned(this);
+			}
+		}
+	}
+});
+
+::Reforged.QueueBucket.VeryLate.push(function() {
+	::Reforged.HooksMod.hookTree("scripts/entity/tactical/actor", function(q) {
+		// We call onSpawn from here because there is otherwise no real way to know
+		// when an entity has finished spawning with all the skills + equipment. We keep trying
+		// to call onSpawn and block it during resurrection/skills/equipment assigning manually.
+		q.onSkillsUpdated = @(__original) function()
+		{
+			__original();
+			this.RF_onSpawn();
+		}
+
+		// Prevent onSpawn from being triggered while the entity is still getting
+		// its equipment assigned or skills assigned during assignRandomEquipment.
+		q.assignRandomEquipment = @(__original) function()
+		{
+			this.m.RF_OnSpawnBlockerCount++;
+			__original();
+			this.m.RF_OnSpawnBlockerCount--;
+		}
+
+		// Prevent onSpawn from being triggered for the resurrecting
+		// entity before it got all its skills and picked up equipment.
+		q.onResurrected = @(__original) function( _info )
+		{
+			this.m.RF_OnSpawnBlockerCount++;
+			__original(_info);
+			this.m.RF_OnSpawnBlockerCount--;
+			this.RF_onSpawn();
+		}
+
+		q.onAfterInit = @(__original) function()
+		{
+			__original();
+			this.m.RF_HasOnSpawnBeenCalled = false;
+		}
+	});
+
+	// Alternative approach instead of hooking actor.onResurrected
+	// this will allow the actor to be safely killed inside onSpawn but
+	// requires the code to be a bit uglier AND has an edge case where we can't handle
+	// onSpawn calling properly if one resurrection causes another midway.
+
+	// ::Reforged.HooksMod.hook("scripts/entity/tactical/tactical_entity_manager", function(q) {
+	// 	q.onResurrect = @(__original) function( _info, _force = false )
+	// 	{
+	// 		this.m.MSU_IsResurrecting = true;
+	// 		local ret = __original(_info, _force);
+	// 		if (ret != null)
+	// 			ret.RF_onSpawn();
+	// 		this.m.MSU_IsResurrecting = false;
+	// 		return ret;
+	// 	}
+	// });
+});

--- a/scripts/!mods_preload/mod_reforged.nut
+++ b/scripts/!mods_preload/mod_reforged.nut
@@ -6,6 +6,7 @@
 	ItemTable = {},
 	QueueBucket = {
 		Late = [],
+		Verylate = [], // For experimental modules only
 		AfterHooks = [],
 		FirstWorldInit = []
 	}
@@ -138,6 +139,13 @@ foreach (requirement in requiredMods)
 		func();
 	}
 }, ::Hooks.QueueBucket.Late);
+
+::Reforged.HooksMod.queue(queueLoadOrder, function() {
+	foreach (func in ::Reforged.QueueBucket.VeryLate)
+	{
+		func();
+	}
+}, ::Hooks.QueueBucket.VeryLate);
 
 ::Reforged.HooksMod.queue(queueLoadOrder, function() {
 	foreach (func in ::Reforged.QueueBucket.AfterHooks)

--- a/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
@@ -133,7 +133,7 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_bandit_baron.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_baron.nut
@@ -212,7 +212,7 @@ this.rf_bandit_baron <- ::inherit("scripts/entity/tactical/human", {
 		return true;
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
@@ -110,7 +110,7 @@ this.rf_bandit_highwayman <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_bandit_hunter.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_hunter.nut
@@ -115,7 +115,7 @@ this.rf_bandit_hunter <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/scripts/entity/tactical/enemies/rf_bandit_killer.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_killer.nut
@@ -134,7 +134,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		if (this.m.HasNet)
 		{

--- a/scripts/entity/tactical/enemies/rf_bandit_marauder.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_marauder.nut
@@ -86,7 +86,7 @@ this.rf_bandit_marauder <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_bandit_outlaw.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_outlaw.nut
@@ -85,7 +85,7 @@ this.rf_bandit_outlaw <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_bandit_pillager.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_pillager.nut
@@ -85,7 +85,7 @@ this.rf_bandit_pillager <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_bandit_robber.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_robber.nut
@@ -117,7 +117,7 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_bandit_sharpshooter.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_sharpshooter.nut
@@ -105,7 +105,7 @@ this.rf_bandit_sharpshooter <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
@@ -110,7 +110,7 @@ this.rf_bandit_vandal <- ::inherit("scripts/entity/tactical/human", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_skeleton_centurion.nut
+++ b/scripts/entity/tactical/enemies/rf_skeleton_centurion.nut
@@ -51,7 +51,7 @@ this.rf_skeleton_centurion <- ::inherit("scripts/entity/tactical/rf_skeleton_com
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_skeleton_decanus.nut
+++ b/scripts/entity/tactical/enemies/rf_skeleton_decanus.nut
@@ -56,9 +56,9 @@ this.rf_skeleton_decanus <- ::inherit("scripts/entity/tactical/rf_skeleton_comma
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
-		this.rf_skeleton_commander.onSetupEntity();
+		this.rf_skeleton_commander.onSpawned();
 		::Reforged.Skills.addPerkGroup(this, "pg.rf_dagger", 4);
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_tempo"));
 	}

--- a/scripts/entity/tactical/enemies/rf_skeleton_heavy_lesser.nut
+++ b/scripts/entity/tactical/enemies/rf_skeleton_heavy_lesser.nut
@@ -59,7 +59,7 @@ this.rf_skeleton_heavy_lesser <- ::inherit("scripts/entity/tactical/skeleton", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
 

--- a/scripts/entity/tactical/enemies/rf_skeleton_legatus.nut
+++ b/scripts/entity/tactical/enemies/rf_skeleton_legatus.nut
@@ -71,7 +71,7 @@ this.rf_skeleton_legatus <- ::inherit("scripts/entity/tactical/rf_skeleton_comma
 		return true;
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_skeleton_light_elite.nut
+++ b/scripts/entity/tactical/enemies/rf_skeleton_light_elite.nut
@@ -63,7 +63,7 @@ this.rf_skeleton_light_elite <- ::inherit("scripts/entity/tactical/skeleton", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_skeleton_light_elite_polearm.nut
+++ b/scripts/entity/tactical/enemies/rf_skeleton_light_elite_polearm.nut
@@ -47,7 +47,7 @@ this.rf_skeleton_light_elite_polearm <- ::inherit("scripts/entity/tactical/enemi
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/enemies/rf_skeleton_medium_elite.nut
+++ b/scripts/entity/tactical/enemies/rf_skeleton_medium_elite.nut
@@ -56,9 +56,9 @@ this.rf_skeleton_medium_elite <- ::inherit("scripts/entity/tactical/skeleton", {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
-		this.skeleton.onSetupEntity();
+		this.skeleton.onSpawned();
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)
 		{

--- a/scripts/entity/tactical/enemies/rf_skeleton_medium_elite_polearm.nut
+++ b/scripts/entity/tactical/enemies/rf_skeleton_medium_elite_polearm.nut
@@ -49,9 +49,9 @@ this.rf_skeleton_medium_elite_polearm <- ::inherit("scripts/entity/tactical/enem
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
-		this.skeleton.onSetupEntity();
+		this.skeleton.onSpawned();
 		local weapon = this.getMainhandItem();
 		if (weapon != null)
 		{

--- a/scripts/entity/tactical/enemies/rf_vampire_lord.nut
+++ b/scripts/entity/tactical/enemies/rf_vampire_lord.nut
@@ -76,7 +76,7 @@ this.rf_vampire_lord <- ::inherit("scripts/entity/tactical/enemies/vampire", {
 		return true;
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)

--- a/scripts/entity/tactical/humans/rf_arbalester_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_arbalester_heavy.nut
@@ -70,7 +70,7 @@ this.rf_arbalester_heavy <- ::inherit("scripts/entity/tactical/human" {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/scripts/entity/tactical/humans/rf_billman_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_billman_heavy.nut
@@ -112,7 +112,7 @@ this.rf_billman_heavy <- ::inherit("scripts/entity/tactical/human" {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/scripts/entity/tactical/humans/rf_fencer.nut
+++ b/scripts/entity/tactical/humans/rf_fencer.nut
@@ -87,7 +87,7 @@ this.rf_fencer <- ::inherit("scripts/entity/tactical/human" {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/scripts/entity/tactical/humans/rf_footman_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_footman_heavy.nut
@@ -111,7 +111,7 @@ this.rf_footman_heavy <- ::inherit("scripts/entity/tactical/human" {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/scripts/entity/tactical/humans/rf_heralds_bodyguard.nut
+++ b/scripts/entity/tactical/humans/rf_heralds_bodyguard.nut
@@ -152,7 +152,7 @@ this.rf_heralds_bodyguard <- ::inherit("scripts/entity/tactical/human" {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/scripts/entity/tactical/humans/rf_knight_anointed.nut
+++ b/scripts/entity/tactical/humans/rf_knight_anointed.nut
@@ -92,7 +92,7 @@ this.rf_knight_anointed <- ::inherit("scripts/entity/tactical/human" {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/scripts/entity/tactical/humans/rf_man_at_arms.nut
+++ b/scripts/entity/tactical/humans/rf_man_at_arms.nut
@@ -94,7 +94,7 @@ this.rf_man_at_arms <- ::inherit("scripts/entity/tactical/human" {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/scripts/entity/tactical/humans/rf_marshal.nut
+++ b/scripts/entity/tactical/humans/rf_marshal.nut
@@ -85,7 +85,7 @@ this.rf_marshal <- ::inherit("scripts/entity/tactical/human" {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)

--- a/scripts/entity/tactical/humans/rf_squire.nut
+++ b/scripts/entity/tactical/humans/rf_squire.nut
@@ -83,7 +83,7 @@ this.rf_squire <- ::inherit("scripts/entity/tactical/human" {
 		}
 	}
 
-	function onSetupEntity()
+	function onSpawned()
 	{
 		local weapon = this.getMainhandItem();
 		if (weapon != null)


### PR DESCRIPTION
This is in response to this [feature request](https://github.com/MSUTeam/MSU/issues/301) over at MSU. I've implemented it as an experimental feature here in Reforged because we can't do experimental stuff in MSU. Once it has been tested and perfected we can move this to MSU.

### Goal
- Call `onActorSpawned` event for all entities on the battlefield whenever an entity spawns or resurrects.
- This call should happen AFTER the faction, skills and equipment of the entity has been assigned and equipped.

### Implementation
- Details about the thought process behind this implementation can be found in my [comment](https://github.com/MSUTeam/MSU/issues/301#issuecomment-1750016358) on the original feature request.
- This PR contains both the implementation of the function AND cleanup of the code to use this new function where relevant. For the implementation of the framework itself you should look at the singular `feat` commit.

### Benefits:
- Fixes the issue currently in Reforged where we are assigning weapon-based perks in the Reforged-added `onSetupEntity` event which is called from `setupEntity` of `tactical_entity_manager`. Since resurrecting entities do not trigger that function, this causes zombies, skeletons and any other resurrected entity in Reforged to not get the weapon-based perks from their `onSetupEntity` function.
- We can and should use the new `onSpawned` function to do these things and ideally even modularize it further and move the perks assignment into a separate function `assignPerks` which we call from within `onSpawned`. However, that is not immediately necessary.
- Entities can now do some things based off of the spawning of some entity thanks to the `skill_container.onActorSpawned` event. Because it is called even for the actor himself, this means perks/skills of the actor can also do something when the actor spawns or resurrects.
- This lays the foundation for the aura framework which I will implement in a separate PR.

### Issues / Quirks
- The spawning actor must not be killed during the spawn event if the actor is spawning via resurrection. This is because `tactical_entity_manager.onResurrect` calls `entity.riseFromGround()` after `entity.onResurrect` and that function accesses the actor's tile.