### PR TITLE
feat: add onDropLoot experimental module

### DIFF
--- a/mod_reforged/hooks/experimental_modules/onDropLoot.nut
+++ b/mod_reforged/hooks/experimental_modules/onDropLoot.nut
@@ -1,0 +1,60 @@
+// Original feature request: https://github.com/MSUTeam/MSU/issues/220
+
+// Goal:
+// - Add a new function to all actors which can be used to modify the existing loot they drop on death, or to add new loot.
+
+::Reforged.HooksMod.hook("scripts/entity/tactical/actor", function(q) {
+	q.onDropLoot <- function( _originalLoot, _killer, _skill, _tile, _fatalityType )
+	{
+		if (_tile != null)
+		{
+			foreach (item in _originalLoot)
+			{
+				item.drop(_tile);
+			}
+		}
+	}
+});
+
+::Reforged.QueueBucket.VeryLate.push(function() {
+	::Reforged.HooksMod.hookTree("scripts/entity/tactical/actor", function(q) {
+		q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )
+		{
+			local loot = [];
+
+			// Switcheroo the ::new function to detect the creation of an item.
+			// Then switcheroo the `drop` function of the item to instead push the item
+			// to our local `loot` array. This will be used to pass this item to the `onDropLoot`
+			// function as the _originalLoot.
+			local new = ::new;
+			::new = function( _script )
+			{
+				local item = new(_script);
+				if (::isKindOf(item, "item"))
+				{
+					item.drop_temp <- item.drop;
+					item.drop = @(_t) loot.push(this);
+				}
+				return item;
+			}
+
+			__original(_killer, _skill, _tile, _fatalityType);
+
+			// Revert the switcheroo on ::new
+			::new = new;
+
+			// Revert the switcheroo on the drop function of all dropped items
+			foreach (item in loot)
+			{
+				item.drop = item.drop_temp;
+				delete item.drop_temp;
+			}
+
+			// Note: `loot` here only contains the items that actually got dropped.
+			// It doesn't contain all the possible items that could be dropped, as items
+			// created for dropping are gated behind random rolls and if/else statements.
+
+			this.onDropLoot(loot, _killer, _skill, _tile, _fatalityType);
+		}
+	});
+});

--- a/mod_reforged/hooks/experimental_modules/onDropLoot.nut
+++ b/mod_reforged/hooks/experimental_modules/onDropLoot.nut
@@ -4,11 +4,15 @@
 // - Add a new function to all actors which can be used to modify the existing loot they drop on death, or to add new loot.
 
 ::Reforged.HooksMod.hook("scripts/entity/tactical/actor", function(q) {
-	q.onDropLoot <- function( _originalLoot, _killer, _skill, _tile, _fatalityType )
+	q.prepareLoot <- function( _loot, _killer, _skill, _tile, _fatalityType )
+	{
+	}
+
+	q.dropLoot <- function( _loot, _tile )
 	{
 		if (_tile != null)
 		{
-			foreach (item in _originalLoot)
+			foreach (item in _loot)
 			{
 				item.drop(_tile);
 			}
@@ -24,8 +28,8 @@
 
 			// Switcheroo the ::new function to detect the creation of an item.
 			// Then switcheroo the `drop` function of the item to instead push the item
-			// to our local `loot` array. This will be used to pass this item to the `onDropLoot`
-			// function as the _originalLoot.
+			// to our local `loot` array. This will be used to pass this item to the `prepareLoot`
+			// function as the _loot.
 			local new = ::new;
 			::new = function( _script )
 			{
@@ -54,7 +58,8 @@
 			// It doesn't contain all the possible items that could be dropped, as items
 			// created for dropping are gated behind random rolls and if/else statements.
 
-			this.onDropLoot(loot, _killer, _skill, _tile, _fatalityType);
+			this.prepareLoot(loot, _killer, _skill, _tile, _fatalityType);
+			this.dropLoot(loot, _tile);
 		}
 	});
 });


### PR DESCRIPTION
This is in response to this [feature request](https://github.com/MSUTeam/MSU/issues/220) over at MSU. We implement an experimental version of it in Reforged and if everything looks good we can consider it as a candidate for inclusion in MSU or in Modular Vanilla mod.