### PR TITLE
Swordmaster and Hedgeknight background adjustments

### DIFF
--- a/mod_reforged/hooks/skills/backgrounds/hedge_knight_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/hedge_knight_background.nut
@@ -47,4 +47,26 @@
 				return _collection.getMin() + 1;
 		}
 	}
+
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Has access to the [Lone Wolf|Perk+perk_lone_wolf] [perk|Concept.Perk] at tier 1 of the perk tree")
+		});
+		return ret;
+	}
+
+	q.onBuildPerkTree <- function()
+	{
+		local perkTree = this.getContainer().getActor().getPerkTree();
+		if (perkTree.hasPerk("perk.lone_wolf"))
+		{
+			perkTree.removePerk("perk.lone_wolf");
+		}
+		perkTree.addPerk("perk.lone_wolf", 1);
+	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
@@ -9,6 +9,7 @@
 			"pg.rf_vigorous": 0.25,
 			"pg.rf_tactician": 2,
 
+			"pg.special.rf_professional": 0,
 			"pg.special.rf_fencer": -1
 		};
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
@@ -74,17 +75,5 @@
 			}));
 		}
 		return __original();
-	}
-
-	q.onBuildPerkTree <- function()
-	{
-		local perkTree = this.getContainer().getActor().getPerkTree();
-		local perksToRemove = [
-			"perk.rf_professional"
-		];
-		foreach (perk in perksToRemove)
-		{
-			if (perkTree.hasPerk(perk)) perkTree.removePerk(perk);
-		}
 	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
@@ -68,18 +68,7 @@
 	{
 		local perkTree = this.getContainer().getActor().getPerkTree();
 		local perksToRemove = [
-			"perk.rf_professional",
-			"perk.mastery.axe",
-			"perk.mastery.bow",
-			"perk.mastery.cleaver",
-			"perk.mastery.crossbow",
-			"perk.mastery.dagger",
-			"perk.mastery.flail",
-			"perk.mastery.hammer",
-			"perk.mastery.mace",
-			"perk.mastery.polearm",
-			"perk.mastery.spear",
-			"perk.mastery.throwing"
+			"perk.rf_professional"
 		];
 		foreach (perk in perksToRemove)
 		{

--- a/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
@@ -53,6 +53,18 @@
 		}
 	}
 
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Has the [Sword Mastery|Perk+perk_mastery_sword] perk permanently for free")
+		});
+		return ret;
+	}
+
 	q.onAdded = @(__original) function()
 	{
 		if (this.m.IsNew)


### PR DESCRIPTION
- Remove manual removal of mastery perks from swordmaster bg because we restricted him to 1 weapon perk group so it's redundant now.
- Add tooltip about free sword mastery perk for swordmaster bg.
- Add lone wolf at tier 1 of hedge knight background perk tree.