### PR TITLE
fix: overwrite modular vanilla reduction of AP cost for polearm skills

### DIFF
--- a/mod_reforged/hooks/skills/actives/hook.nut
+++ b/mod_reforged/hooks/skills/actives/hook.nut
@@ -1,0 +1,12 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/hook", function(q) {
+	// Overwrite the function provided by mod_modular_vanilla to remove
+	// the reduction of AP cost from Polearm Mastery. We instead apply a
+	// custom version of that in our hook on perk_mastery_polearm
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/impale.nut
+++ b/mod_reforged/hooks/skills/actives/impale.nut
@@ -1,0 +1,12 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/impale", function(q) {
+	// Overwrite the function provided by mod_modular_vanilla to remove
+	// the reduction of AP cost from Polearm Mastery. We instead apply a
+	// custom version of that in our hook on perk_mastery_polearm
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/reap_skill.nut
+++ b/mod_reforged/hooks/skills/actives/reap_skill.nut
@@ -1,0 +1,12 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/reap_skill", function(q) {
+	// Overwrite the function provided by mod_modular_vanilla to remove
+	// the reduction of AP cost from Polearm Mastery. We instead apply a
+	// custom version of that in our hook on perk_mastery_polearm
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/repel.nut
+++ b/mod_reforged/hooks/skills/actives/repel.nut
@@ -1,0 +1,12 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/repel", function(q) {
+	// Overwrite the function provided by mod_modular_vanilla to remove
+	// the reduction of AP cost from Polearm Mastery. We instead apply a
+	// custom version of that in our hook on perk_mastery_polearm
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/rupture.nut
+++ b/mod_reforged/hooks/skills/actives/rupture.nut
@@ -1,0 +1,12 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/rupture", function(q) {
+	// Overwrite the function provided by mod_modular_vanilla to remove
+	// the reduction of AP cost from Polearm Mastery. We instead apply a
+	// custom version of that in our hook on perk_mastery_polearm
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/actives/strike_skill.nut
+++ b/mod_reforged/hooks/skills/actives/strike_skill.nut
@@ -1,0 +1,19 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/strike_skill", function(q) {
+	// Overwrite the function provided by mod_modular_vanilla to remove
+	// the reduction of AP cost from Polearm Mastery. We instead apply a
+	// custom version of that in our hook on perk_mastery_polearm
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (this.m.ApplyAxeMastery)
+		{
+			if (_properties.IsSpecializedInAxes)
+			{
+				this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			}
+		}
+		else if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_reforged/hooks/skills/perks/perk_mastery_polearm.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_polearm.nut
@@ -22,7 +22,7 @@
 		{
 			foreach (skill in weapon.getSkills())
 			{
-				if (skill.m.MaxRange == 2 && skill.m.ActionPointCost > 5)
+				if (skill.getMaxRange() == 2 && skill.getBaseValue("ActionPointCost") > 5 && skill.m.ActionPointCost > 1)
 				{
 					skill.m.ActionPointCost -= 1;
 				}


### PR DESCRIPTION
And apply the AP reduction from our polearm mastery hook. This avoids applying the bonus twice because modular vanilla reduces it based on Base ActionPointCost within the onAfterUpdate of the active skills and polearm mastery perk skill order is before that of actives.