### PR TITLE
Fix axe skills

### DIFF
--- a/mod_reforged/hooks/skills/perks/perk_mastery_axe.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_axe.nut
@@ -10,7 +10,9 @@
 		if (_item.isItemType(::Const.Items.ItemType.Weapon) && _item.isWeaponType(::Const.Items.WeaponType.Axe))
 		{
 			_item.addSkill(::new("scripts/skills/actives/rf_bearded_blade_skill"));
-			_item.addSkill(::new("scripts/skills/actives/rf_hook_shield_skill"));
+			_item.addSkill(::Reforged.new("scripts/skills/actives/rf_hook_shield_skill", function(o) {
+				o.m.MaxRange = _item.getRangeMax();
+			}));
 		}
 	}
 });

--- a/scripts/items/weapons/rf_poleaxe.nut
+++ b/scripts/items/weapons/rf_poleaxe.nut
@@ -33,11 +33,13 @@ this.rf_poleaxe <- ::inherit("scripts/items/weapons/weapon", {
 	{
 		this.weapon.onEquip();
 
-		this.addSkill(::Reforged.new("scripts/skills/actives/impale", function(o) {
-			o.m.Icon = "skills/rf_poleaxe_impale_skill.png";
-			o.m.IconDisabled = "skills/rf_poleaxe_impale_skill_sw.png";
-			o.m.Overlay = "rf_poleaxe_impale_skill";
-			o.m.IsIgnoredAsAOO = true;
+		this.addSkill(::Reforged.new("scripts/skills/actives/chop", function(o) {
+			o.m.Name = "Hew";
+			o.m.ActionPointCost = 6;
+			o.m.FatigueCost = 15;
+			o.m.Icon = "skills/rf_poleaxe_hew_skill.png";
+			o.m.IconDisabled = "skills/rf_poleaxe_hew_skill_sw.png";
+			o.m.Overlay = "rf_poleaxe_hew_skill";
 		}));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/strike_skill", function(o) {
@@ -48,13 +50,11 @@ this.rf_poleaxe <- ::inherit("scripts/items/weapons/weapon", {
 			o.m.IsIgnoredAsAOO = true;
 		}));
 
-		this.addSkill(::Reforged.new("scripts/skills/actives/chop", function(o) {
-			o.m.Name = "Hew";
-			o.m.ActionPointCost = 6;
-			o.m.FatigueCost = 15;
-			o.m.Icon = "skills/rf_poleaxe_hew_skill.png";
-			o.m.IconDisabled = "skills/rf_poleaxe_hew_skill_sw.png";
-			o.m.Overlay = "rf_poleaxe_hew_skill";
+		this.addSkill(::Reforged.new("scripts/skills/actives/impale", function(o) {
+			o.m.Icon = "skills/rf_poleaxe_impale_skill.png";
+			o.m.IconDisabled = "skills/rf_poleaxe_impale_skill_sw.png";
+			o.m.Overlay = "rf_poleaxe_impale_skill";
+			o.m.IsIgnoredAsAOO = true;
 		}));
 	}
 });


### PR DESCRIPTION
- Set Hook Shield to have the max range of the weapon it gets added to, instead of always having a range of 1.
- Rearrange Poleaxe skills to move the AOO to the front and Impale to the end. So it is now Hew, Strike, Impale.