### PR TITLE
fix: random crash during getting item skills

### DIFF
--- a/mod_reforged/actor_tooltip_functions.nut
+++ b/mod_reforged/actor_tooltip_functions.nut
@@ -201,7 +201,7 @@
 			id = currentID,
 			type = "text",
 			icon = "ui/items/" + mainhandItem.getIcon(),
-			text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,%s,entity]", mainhandItem.getName(), split(::IO.scriptFilenameByHash(mainhandItem.ClassNameHash), "/").top(), mainhandItem.getInstanceID()))
+			text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,itemId:%s,itemOwner:entity]", mainhandItem.getName(), mainhandItem.ClassName, mainhandItem.getInstanceID()))
 		});
 		currentID++;
 	}
@@ -211,7 +211,7 @@
 			id = currentID,
 			type = "text",
 			icon = "ui/items/" + offhandItem.getIcon(),
-			text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,%s,entity]", offhandItem.getName(), split(::IO.scriptFilenameByHash(offhandItem.ClassNameHash), "/").top(), offhandItem.getInstanceID()))
+			text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,itemId:%s,itemOwner:entity]", offhandItem.getName(), offhandItem.ClassName, offhandItem.getInstanceID()))
 		});
 		currentID++;
 	}
@@ -221,7 +221,7 @@
 			id = currentID,
 			type = "text",
 			icon = "ui/items/" + accessory.getIcon(),
-			text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,%s,entity]", accessory.getName(), split(::IO.scriptFilenameByHash(accessory.ClassNameHash), "/").top(), accessory.getInstanceID()))
+			text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,itemId:%s,itemOwner:entity]", accessory.getName(), accessory.ClassName, accessory.getInstanceID()))
 		});
 		currentID++;
 	}
@@ -245,7 +245,7 @@
 			id = currentID,
 			type = "text",
 			icon = "ui/items/" + bagItem.getIcon(),
-			text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,%s,entity]", bagItem.getName(), split(::IO.scriptFilenameByHash(bagItem.ClassNameHash), "/").top(), bagItem.getInstanceID()))
+			text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,itemId:%s,itemOwner:entity]", bagItem.getName(), bagItem.ClassName, bagItem.getInstanceID()))
 		});
 		currentID++;
 	}
@@ -271,7 +271,7 @@
 				id = currentID,
 				type = "text",
 				icon = "ui/items/" + groundItem.getIcon(),
-				text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,%s,ground]", groundItem.getName(), split(::IO.scriptFilenameByHash(groundItem.ClassNameHash), "/").top(), groundItem.getInstanceID()))
+				text = ::Reforged.Mod.Tooltips.parseString(format("[%s|Item+%s,itemId:%s,itemOwner:ground]", groundItem.getName(), groundItem.ClassName, groundItem.getInstanceID()))
 			});
 			currentID++;
 		}

--- a/mod_reforged/config/items.nut
+++ b/mod_reforged/config/items.nut
@@ -20,13 +20,45 @@
 		return ret;
 	}
 
+	// This function is used to get the skills of an item that one gets from equipping the item.
 	function getSkills( _item )
 	{
-		local copy = ::new(::IO.scriptFilenameByHash(_item.ClassNameHash));
+		local ret = [];
+
 		local player = ::MSU.getDummyPlayer();
-		player.getItems().equip(copy);
-		local ret = copy.getSkills();
-		player.getItems().unequip(copy);
+
+		// Switcheroo addSkill to push the skill to our return array instead of adding it to the container
+		local addSkill = _item.addSkill;
+		_item.addSkill = @( _skill ) ret.push(_skill);
+
+		// Switcheroo to prevent addition of the generic_item skill as we don't want that in the returned array
+		local addGenericItemSkill = _item.addGenericItemSkill;
+		_item.addGenericItemSkill = @() null;
+
+		// Switcheroo player.onAppearanceChanged and item.updateAppearance to do nothing for performance reasons
+		local onAppearanceChanged = player.onAppearanceChanged;
+		player.onAppearanceChanged = @(...) null;
+
+		local updateAppearance = _item.updateAppearance;
+		_item.updateAppearance = @(...) null;
+
+		// Switcheroo the container of the item to that of the dummy player
+		local originalItemContainer = _item.m.Container;
+		_item.m.Container = player.getItems();
+
+		// Store the last equipped by faction field to revert it later
+		local lastEquippedByFaction = _item.m.LastEquippedByFaction;
+
+		_item.onEquip();
+
+		// Revert all switcheroos
+		_item.addSkill = addSkill;
+		_item.addGenericItemSkill = addGenericItemSkill;
+		player.onAppearanceChanged = onAppearanceChanged;
+		_item.updateAppearance = updateAppearance;
+		_item.m.Container = originalItemContainer;
+		_item.m.LastEquippedByFaction = lastEquippedByFaction;
+
 		return ret;
 	}
 };

--- a/mod_reforged/hooks/items/item.nut
+++ b/mod_reforged/hooks/items/item.nut
@@ -11,8 +11,12 @@
 		local itemID = this.getInstanceID();
 		foreach (skill in ::Reforged.Items.getSkills(this))
 		{
-			local name = ::Reforged.Mod.Tooltips.parseString(format("[%s|Skill+%s,itemId:%s,itemOwner:null]", skill.getName(), skill.ClassName, itemID));
-			skillsString += format("- %s (%s, %s)\n", name, ::MSU.Text.colorPositive(skill.m.ActionPointCost), ::MSU.Text.colorNegative(skill.m.FatigueCost));
+			if (skill.isHidden() && !skill.isType(::Const.SkillType.Perk))
+				continue;
+
+			local identifier = skill.isType(::Const.SkillType.Perk) && !skill.isType(::Const.SkillType.StatusEffect) ? "Perk" : "Skill";
+			local suffix = skill.isType(::Const.SkillType.Active) ? format(" (%s, %s)", ::MSU.Text.colorPositive(skill.m.ActionPointCost), ::MSU.Text.colorNegative(skill.m.FatigueCost)) : "";
+			skillsString += format("- [%s|%s+%s,itemId:%s,itemOwner:null]%s\n", skill.getName(), identifier, skill.ClassName, itemID, suffix);
 		}
 
 		if (skillsString != "")
@@ -21,7 +25,7 @@
 				id = 20,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Skills: (" + ::MSU.Text.colorPositive("AP") + ", " + ::MSU.Text.colorNegative("Fatigue") + ")\n" + skillsString
+				text = ::Reforged.Mod.Tooltips.parseString(format("Skills: (%s, %s)\n%s", ::MSU.Text.colorPositive("AP"), ::MSU.Text.colorNegative("Fatigue"), skillsString))
 			});
 		}
 

--- a/mod_reforged/hooks/items/item.nut
+++ b/mod_reforged/hooks/items/item.nut
@@ -8,15 +8,15 @@
 
 		local ret = __original();
 		local skillsString = "";
+		local itemID = this.getInstanceID();
 		foreach (skill in ::Reforged.Items.getSkills(this))
 		{
-			local name = ::Reforged.Mod.Tooltips.parseString(format("[%s|Skill+%s]", skill.getName(), skill.ClassName));
+			local name = ::Reforged.Mod.Tooltips.parseString(format("[%s|Skill+%s,itemId:%s,itemOwner:null]", skill.getName(), skill.ClassName, itemID));
 			skillsString += format("- %s (%s, %s)\n", name, ::MSU.Text.colorPositive(skill.m.ActionPointCost), ::MSU.Text.colorNegative(skill.m.FatigueCost));
 		}
 
 		if (skillsString != "")
 		{
-			::MSU.NestedTooltips.setNestedSkillItem(this);
 			ret.push({
 				id = 20,
 				type = "text",

--- a/scripts/!mods_preload/mod_reforged.nut
+++ b/scripts/!mods_preload/mod_reforged.nut
@@ -14,7 +14,7 @@
 local requiredMods = [
 	"mod_modular_vanilla >= 0.3.0",
 	"mod_msu >= 1.5.0",
-	"mod_nested_tooltips",
+	"mod_nested_tooltips >= 0.1.2",
 	"mod_modern_hooks >= 0.4.10"
 	"dlc_lindwurm",
 	"dlc_unhold",


### PR DESCRIPTION
As it turns out the crash is primarily fixed by fixing a bug over at Modern Hooks that caused `FirstWorldInit` bucket to run too early causing the dummy player to be initialized in a weird limbo state. I've also improved some stuff over at nested tooltips framework and this PR changes existing code to align with those improvements.

In view of the above, this PR is no longer a "crash fix" PR but rather an improvement PR to update our setup based on nested tooltips framework update and fix a technical issue on our side with regards to how we fetch the skills: The main technical change in Reforged is that our `getSkills` function now uses switcheroos and calls `onEquip` instead of creating a copy of the item and equipping that on the dummy player. This is important because certain items have modifications to their state which won't be available when we create a copy e.g. named items with randomized values or if you have an armor with an attachment.

- Nested tooltips of item skills will now properly show their actual damage range as what they'd have when you'd equip the item (thanks to better handling available from nested tooltips framework).
- A quirk right now is that the skills of equipped items show the values that apply to the equipping character, rather than the base values. This is not trivial to fix over at nested tooltips framework but I'll work on it later. It is a minor thing for now.