### PR TITLE
refactor: remove auto pause on leaving location

### DIFF
--- a/mod_reforged/hooks/entity/world/location.nut
+++ b/mod_reforged/hooks/entity/world/location.nut
@@ -11,12 +11,6 @@
 		this.adjustBannerOffset();
 	}
 
-	q.onLeave = @(__original) function()
-	{
-		__original();
-		::World.State.setPause(true);
-	}
-
 	q.getTooltip = @(__original) function()
 	{
 		local ret = __original();


### PR DESCRIPTION
Because this is an option available in the default vanilla options for the game.