### PR TITLE
refactor: improve code and design of bandits

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
@@ -44,14 +44,16 @@
 			this.m.Items.equip(::new(weapon));
 		}
 
-		local throwing = ::MSU.Class.WeightedContainer([
-			[1, "scripts/items/weapons/throwing_spear"]
-		]).rollChance(33);
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))
+		{
+			local throwing = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/throwing_spear"]
+			]).rollChance(33);
 
-		if (throwing != null) this.m.Items.addToBag(::new(throwing));
+			if (throwing != null) this.m.Items.addToBag(::new(throwing));
+		}
 
-		local weapon = this.getMainhandItem();
-		if (weapon.isItemType(::Const.Items.ItemType.OneHanded))
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			local shield = ::MSU.Class.WeightedContainer([
 				[1.0, "scripts/items/shields/wooden_shield"],

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
@@ -19,6 +19,7 @@
 		this.getSprite("shield_icon").setBrightness(0.85);
 
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_bully"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_quick_hands"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rotation"));
 		// this.m.Skills.add(::new("scripts/skills/perks/perk_recover"));	// Now granted to all humans by default
 	}
@@ -27,44 +28,35 @@
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local throwing = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/throwing_spear"]
-			]).rollChance(33);
+			local weapon = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/arming_sword"],
+				[1, "scripts/items/weapons/boar_spear"],
+				[1, "scripts/items/weapons/falchion"],
+				[1, "scripts/items/weapons/flail"],
+				[1, "scripts/items/weapons/hand_axe"],
+				[1, "scripts/items/weapons/military_pick"],
+				[1, "scripts/items/weapons/morning_star"],
+				[1, "scripts/items/weapons/scramasax"],
 
-			if (throwing != null) this.m.Items.equip(::new(throwing));
+				[1, "scripts/items/weapons/longaxe"],
+				[1, "scripts/items/weapons/polehammer"]
+			]).roll();
+			this.m.Items.equip(::new(weapon));
 		}
 
-		local weapon = ::MSU.Class.WeightedContainer([
-			[1, "scripts/items/weapons/arming_sword"],
-			[1, "scripts/items/weapons/boar_spear"],
-			[1, "scripts/items/weapons/falchion"],
-			[1, "scripts/items/weapons/flail"],
-			[1, "scripts/items/weapons/hand_axe"],
-			[1, "scripts/items/weapons/military_pick"],
-			[1, "scripts/items/weapons/morning_star"],
-			[1, "scripts/items/weapons/scramasax"],
+		local throwing = ::MSU.Class.WeightedContainer([
+			[1, "scripts/items/weapons/throwing_spear"]
+		]).rollChance(33);
 
-			[1, "scripts/items/weapons/longaxe"],
-			[1, "scripts/items/weapons/polehammer"]
-		]).roll();
-		weapon = ::new(weapon);
+		if (throwing != null) this.m.Items.addToBag(::new(throwing));
 
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-		{
-			this.m.Items.equip(weapon);
-		}
-		else
-		{
-			this.m.Items.addToBag(weapon);
-		}
-
+		local weapon = this.getMainhandItem();
 		if (weapon.isItemType(::Const.Items.ItemType.OneHanded))
 		{
 			local shield = ::MSU.Class.WeightedContainer([
 				[1.0, "scripts/items/shields/wooden_shield"],
 				[1.0, "scripts/items/shields/kite_shield"]
 			]).roll();
-
 			this.m.Items.equip(::new(shield));
 		}
 
@@ -98,20 +90,9 @@
 	q.onSetupEntity <- function()
 	{
 		local mainhandItem = this.getMainhandItem();
-		if (mainhandItem != null && mainhandItem.isItemType(::Const.Items.ItemType.MeleeWeapon)) // melee weapon equipped
+		if (mainhandItem != null)
 		{
 			::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
-		}
-		else // melee waepon in bag
-		{
-			foreach (item in this.m.Items.getAllItemsAtSlot(::Const.ItemSlot.Bag))
-			{
-				if (item.isItemType(::Const.Items.ItemType.Weapon))
-				{
-					::Reforged.Skills.addPerkGroupOfWeapon(this, item, 4);
-					break;
-				}
-			}
 		}
 
 		local offhandItem = this.getOffhandItem();

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
@@ -39,7 +39,8 @@
 				[1, "scripts/items/weapons/scramasax"],
 
 				[1, "scripts/items/weapons/longaxe"],
-				[1, "scripts/items/weapons/polehammer"]
+				[1, "scripts/items/weapons/polehammer"],
+				[1, "scripts/items/weapons/rf_two_handed_falchion"]
 			]).roll();
 			this.m.Items.equip(::new(weapon));
 		}

--- a/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
@@ -81,7 +81,6 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 					"scripts/items/weapons/rf_poleflail",
 					"scripts/items/weapons/pike",
 					"scripts/items/weapons/spetum",
-					"scripts/items/weapons/rf_two_handed_falchion",
 					"scripts/items/weapons/warbrand"
 				]);
 			}

--- a/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
@@ -61,7 +61,7 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 
 	function assignRandomEquipment()
 	{
-		if (this.m.HasNet == true && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
+		if (this.m.HasNet && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
 
@@ -76,38 +76,38 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 				this.m.Items.equip(::new(weapon));
 			}
 		}
-		else
+		else if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-			{
-				local weapon = ::MSU.Class.WeightedContainer([
-					[1, "scripts/items/weapons/boar_spear"],
-					[1, "scripts/items/weapons/rondel_dagger"],
-					[1, "scripts/items/weapons/arming_sword"],
-					[1, "scripts/items/weapons/scramasax"],
+			local weapon = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/boar_spear"],
+				[1, "scripts/items/weapons/rondel_dagger"],
+				[1, "scripts/items/weapons/arming_sword"],
+				[1, "scripts/items/weapons/scramasax"],
 
-					[1, "scripts/items/weapons/rf_poleflail"],
-					[1, "scripts/items/weapons/pike"],
-					[1, "scripts/items/weapons/spetum"],
-					[1, "scripts/items/weapons/rf_two_handed_falchion"],
-					[1, "scripts/items/weapons/warbrand"]
-				]).roll();
-				this.m.Items.equip(::new(weapon));
-			}
-		}
-
-		if (this.m.IsRegularThrower == true)
-		{
-			local throwingWeapon = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/javelin"],
-				[1, "scripts/items/weapons/throwing_axe"]
+				[1, "scripts/items/weapons/rf_poleflail"],
+				[1, "scripts/items/weapons/pike"],
+				[1, "scripts/items/weapons/spetum"],
+				[1, "scripts/items/weapons/rf_two_handed_falchion"],
+				[1, "scripts/items/weapons/warbrand"]
 			]).roll();
-
-			this.m.Items.addToBag(::new(throwingWeapon));
+			this.m.Items.equip(::new(weapon));
 		}
-		else if (this.m.IsSpearThrower == true)
+
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))
 		{
-			this.m.Items.addToBag(::new("scripts/items/weapons/throwing_spear"));
+			if (this.m.IsRegularThrower)
+			{
+				local throwingWeapon = ::MSU.Class.WeightedContainer([
+					[1, "scripts/items/weapons/javelin"],
+					[1, "scripts/items/weapons/throwing_axe"]
+				]).roll();
+
+				this.m.Items.addToBag(::new(throwingWeapon));
+			}
+			else if (this.m.IsSpearThrower)
+			{
+				this.m.Items.addToBag(::new("scripts/items/weapons/throwing_spear"));
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))

--- a/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
@@ -1,8 +1,8 @@
 this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 	m = {
-		HasNet = 0, // 33% chance
-		IsRegularThrower = 0, // 50% chance
-		IsSpearThrower = 0 // 25% chance. only rolled if not regular thrower.
+		HasNet = false,
+		IsRegularThrower = false,
+		IsSpearThrower = false
 	},
 	function create()
 	{
@@ -44,12 +44,12 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 		this.m.Skills.add(::new("scripts/skills/perks/perk_quick_hands"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_relentless"));
 
-		this.m.HasNet = ::Math.rand(0, 2); // 2 has net
-		this.m.IsRegularThrower = ::Math.rand(0, 1); // 1 is regular thrower
+		this.m.HasNet = ::Math.rand(1, 3) == 3; // 33% chance
+		this.m.IsRegularThrower = ::Math.rand(1, 2) == 2;  // 50% chance
 
-		if (this.m.IsRegularThrower != 1)
+		if (this.m.IsRegularThrower == false)
 		{
-			this.m.IsSpearThrower = ::Math.rand(0, 3); // 3 is spear thrower
+			this.m.IsSpearThrower = ::Math.rand(1, 4) == 4; // 25% chance. only rolled if not regular thrower.
 		}
 	}
 
@@ -61,7 +61,7 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 
 	function assignRandomEquipment()
 	{
-		if (this.m.HasNet == 2 && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
+		if (this.m.HasNet == true && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
 
@@ -96,7 +96,7 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 			}
 		}
 
-		if (this.m.IsRegularThrower == 1)
+		if (this.m.IsRegularThrower == true)
 		{
 			local throwingWeapon = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/javelin"],
@@ -105,7 +105,7 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 
 			this.m.Items.addToBag(::new(throwingWeapon));
 		}
-		else if (this.m.IsSpearThrower == 3)
+		else if (this.m.IsSpearThrower == true)
 		{
 			this.m.Items.addToBag(::new("scripts/items/weapons/throwing_spear"));
 		}
@@ -158,7 +158,7 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 				break;
 		}
 
-		if (this.m.IsRegularThrower == 1 || this.m.IsSpearThrower == 3)
+		if (this.m.IsRegularThrower == true || this.m.IsSpearThrower == true)
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_throwing"));
 		}

--- a/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
@@ -64,33 +64,29 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 		if (this.m.HasNet && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
-
-			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-			{
-				local weapon = ::MSU.Class.WeightedContainer([
-					[1, "scripts/items/weapons/boar_spear"],
-					[1, "scripts/items/weapons/rondel_dagger"],
-					[1, "scripts/items/weapons/arming_sword"],
-					[1, "scripts/items/weapons/scramasax"],
-				]).roll();
-				this.m.Items.equip(::new(weapon));
-			}
 		}
-		else if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-		{
-			local weapon = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/boar_spear"],
-				[1, "scripts/items/weapons/rondel_dagger"],
-				[1, "scripts/items/weapons/arming_sword"],
-				[1, "scripts/items/weapons/scramasax"],
 
-				[1, "scripts/items/weapons/rf_poleflail"],
-				[1, "scripts/items/weapons/pike"],
-				[1, "scripts/items/weapons/spetum"],
-				[1, "scripts/items/weapons/rf_two_handed_falchion"],
-				[1, "scripts/items/weapons/warbrand"]
-			]).roll();
-			this.m.Items.equip(::new(weapon));
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
+		{
+			local weapons = ::MSU.Class.WeightedContainer.addMany(1, [
+				"scripts/items/weapons/boar_spear",
+				"scripts/items/weapons/rondel_dagger",
+				"scripts/items/weapons/arming_sword",
+				"scripts/items/weapons/scramasax",
+			]);
+
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)) // both hands free
+			{
+				weapons.addMany(1, [
+					"scripts/items/weapons/rf_poleflail",
+					"scripts/items/weapons/pike",
+					"scripts/items/weapons/spetum",
+					"scripts/items/weapons/rf_two_handed_falchion",
+					"scripts/items/weapons/warbrand"
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))

--- a/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
@@ -68,7 +68,7 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapons = ::MSU.Class.WeightedContainer.addMany(1, [
+			local weapons = ::MSU.Class.WeightedContainer().addMany(1, [
 				"scripts/items/weapons/boar_spear",
 				"scripts/items/weapons/rondel_dagger",
 				"scripts/items/weapons/arming_sword",

--- a/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
@@ -154,7 +154,7 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 				break;
 		}
 
-		if (this.m.IsRegularThrower == true || this.m.IsSpearThrower == true)
+		if (this.m.IsRegularThrower || this.m.IsSpearThrower)
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_throwing"));
 		}

--- a/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
@@ -63,14 +63,16 @@ this.rf_bandit_highwayman <- ::inherit("scripts/entity/tactical/human", {
 			this.m.Items.equip(::new(weapon));
 		}
 
-		local throwing = ::MSU.Class.WeightedContainer([
-			[1, "scripts/items/weapons/throwing_spear"]
-		]).rollChance(33);
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))
+		{
+			local throwing = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/throwing_spear"]
+			]).rollChance(33);
 
-		if (throwing != null) this.m.Items.addToBag(::new(throwing));
+			if (throwing != null) this.m.Items.addToBag(::new(throwing));
+		}
 
-		local weapon = this.getMainhandItem();
-		if (weapon.isItemType(::Const.Items.ItemType.OneHanded))
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			local shield = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/shields/kite_shield"],

--- a/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
@@ -34,6 +34,7 @@ this.rf_bandit_highwayman <- ::inherit("scripts/entity/tactical/human", {
 		this.getSprite("shield_icon").setBrightness(0.85);
 
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_bully"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_quick_hands"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rotation"));
 	}
 
@@ -47,13 +48,6 @@ this.rf_bandit_highwayman <- ::inherit("scripts/entity/tactical/human", {
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local throwing = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/throwing_spear"]
-			]).rollChance(33);
-
-			if (throwing != null) this.m.Items.equip(::new(throwing));
-		}
-
 			local weapon = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/arming_sword"],
 				[1, "scripts/items/weapons/boar_spear"],
@@ -66,26 +60,25 @@ this.rf_bandit_highwayman <- ::inherit("scripts/entity/tactical/human", {
 				[1, "scripts/items/weapons/longaxe"],
 				[1, "scripts/items/weapons/polehammer"]
 			]).roll();
-			weapon = ::new(weapon);
+			this.m.Items.equip(::new(weapon));
+		}
 
-			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-			{
-				this.m.Items.equip(weapon);
-			}
-			else
-			{
-				this.m.Items.addToBag(weapon);
-			}
+		local throwing = ::MSU.Class.WeightedContainer([
+			[1, "scripts/items/weapons/throwing_spear"]
+		]).rollChance(33);
 
-			if (weapon.isItemType(::Const.Items.ItemType.OneHanded))
-			{
-				local shield = ::MSU.Class.WeightedContainer([
-					[1, "scripts/items/shields/kite_shield"],
-					[1, "scripts/items/shields/heater_shield"]
-				]).roll();
+		if (throwing != null) this.m.Items.addToBag(::new(throwing));
 
-				this.m.Items.equip(::new(shield));
-			}
+		local weapon = this.getMainhandItem();
+		if (weapon.isItemType(::Const.Items.ItemType.OneHanded))
+		{
+			local shield = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/shields/kite_shield"],
+				[1, "scripts/items/shields/heater_shield"]
+			]).roll();
+
+			this.m.Items.equip(::new(shield));
+		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
 		{
@@ -119,31 +112,22 @@ this.rf_bandit_highwayman <- ::inherit("scripts/entity/tactical/human", {
 		local mainhandItem = this.getMainhandItem();
 		if (mainhandItem != null)
 		{
+			::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
 			if (mainhandItem.isItemType(::Const.Items.ItemType.OneHanded))
 			{
-				::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
 				this.m.Skills.add(::new("scripts/skills/perks/perk_devastating_strikes"));
 			}
 			else // two handed weapon
 			{
-				::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
-				if (mainhandItem.isWeaponType(::Const.Items.WeaponType.Axe))
-				{
-					this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_polearm"));
-					this.m.Skills.add(::new("scripts/skills/perks/perk_rf_formidable_approach"));
-				}
-				else if (mainhandItem.isWeaponType(::Const.Items.WeaponType.Hammer))
-				{
-					this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_polearm"));
-					this.m.Skills.add(::new("scripts/skills/perks/perk_rf_formidable_approach"));
-				}
+				this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_polearm"));
+				this.m.Skills.add(::new("scripts/skills/perks/perk_rf_formidable_approach"));
 			}
-		}
 
-		local offhandItem = this.getOffhandItem();
-		if (offhandItem != null && offhandItem.isItemType(::Const.Items.ItemType.Shield))
-		{
-			this.m.Skills.add(::new("scripts/skills/perks/perk_shield_expert"));
+			local offhandItem = this.getOffhandItem();
+			if (offhandItem != null && offhandItem.isItemType(::Const.Items.ItemType.Shield))
+			{
+				this.m.Skills.add(::new("scripts/skills/perks/perk_shield_expert"));
+			}
 		}
 	}
 });

--- a/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
@@ -58,7 +58,8 @@ this.rf_bandit_highwayman <- ::inherit("scripts/entity/tactical/human", {
 				[1, "scripts/items/weapons/scramasax"],
 
 				[1, "scripts/items/weapons/longaxe"],
-				[1, "scripts/items/weapons/polehammer"]
+				[1, "scripts/items/weapons/polehammer"],
+				[1, "scripts/items/weapons/rf_two_handed_falchion"]
 			]).roll();
 			this.m.Items.equip(::new(weapon));
 		}
@@ -119,7 +120,11 @@ this.rf_bandit_highwayman <- ::inherit("scripts/entity/tactical/human", {
 			{
 				this.m.Skills.add(::new("scripts/skills/perks/perk_devastating_strikes"));
 			}
-			else // two handed weapon
+			else if (mainhandItem.isItemType(::Const.Items.ItemType.TwoHanded) && ::Reforged.Items.isDuelistValid(mainhandItem))
+			{
+				this.m.Skills.add(::new("scripts/skills/perks/perk_duelist"));
+			}
+			else
 			{
 				this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_polearm"));
 				this.m.Skills.add(::new("scripts/skills/perks/perk_rf_formidable_approach"));

--- a/scripts/entity/tactical/enemies/rf_bandit_killer.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_killer.nut
@@ -83,7 +83,6 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 					"scripts/items/weapons/rf_poleflail",
 					"scripts/items/weapons/pike",
 					"scripts/items/weapons/spetum",
-					"scripts/items/weapons/rf_two_handed_falchion",
 					"scripts/items/weapons/warbrand"
 				]);
 			}

--- a/scripts/entity/tactical/enemies/rf_bandit_killer.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_killer.nut
@@ -62,7 +62,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 
 	function assignRandomEquipment()
 	{
-		if (this.m.HasNet == true && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
+		if (this.m.HasNet && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
 
@@ -77,39 +77,39 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 				this.m.Items.equip(::new(weapon));
 			}
 		}
-		else
+		else if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-			{
-				local weapon = ::MSU.Class.WeightedContainer([
-					[1, "scripts/items/weapons/arming_sword"],
-					[1, "scripts/items/weapons/boar_spear"],
-					[1, "scripts/items/weapons/rondel_dagger"],
-					[1, "scripts/items/weapons/scramasax"],
+			local weapon = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/arming_sword"],
+				[1, "scripts/items/weapons/boar_spear"],
+				[1, "scripts/items/weapons/rondel_dagger"],
+				[1, "scripts/items/weapons/scramasax"],
 
-					[1, "scripts/items/weapons/billhook"],
-					[1, "scripts/items/weapons/rf_poleflail"],
-					[1, "scripts/items/weapons/pike"],
-					[1, "scripts/items/weapons/spetum"],
-					[1, "scripts/items/weapons/rf_two_handed_falchion"],
-					[1, "scripts/items/weapons/warbrand"]
-				]).roll();
-				this.m.Items.equip(::new(weapon));
-			}
-		}
-
-		if (this.m.IsRegularThrower == true)
-		{
-			local throwingWeapon = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/javelin"],
-				[1, "scripts/items/weapons/throwing_axe"]
+				[1, "scripts/items/weapons/billhook"],
+				[1, "scripts/items/weapons/rf_poleflail"],
+				[1, "scripts/items/weapons/pike"],
+				[1, "scripts/items/weapons/spetum"],
+				[1, "scripts/items/weapons/rf_two_handed_falchion"],
+				[1, "scripts/items/weapons/warbrand"]
 			]).roll();
-
-			this.m.Items.addToBag(::new(throwingWeapon));
+			this.m.Items.equip(::new(weapon));
 		}
-		else if (this.m.IsSpearThrower == true)
+
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))
 		{
-			this.m.Items.addToBag(::new("scripts/items/weapons/throwing_spear"));
+			if (this.m.IsRegularThrower)
+			{
+				local throwingWeapon = ::MSU.Class.WeightedContainer([
+					[1, "scripts/items/weapons/javelin"],
+					[1, "scripts/items/weapons/throwing_axe"]
+				]).roll();
+
+				this.m.Items.addToBag(::new(throwingWeapon));
+			}
+			else if (this.m.IsSpearThrower)
+			{
+				this.m.Items.addToBag(::new("scripts/items/weapons/throwing_spear"));
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
@@ -141,7 +141,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 
 	function onSetupEntity()
 	{
-		if (this.m.HasNet == true) //rolled throwing net
+		if (this.m.HasNet)
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_angler"));
 		}
@@ -171,7 +171,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 			}
 		}
 
-		if (this.m.IsRegularThrower == true || this.m.IsSpearThrower == true)
+		if (this.m.IsRegularThrower || this.m.IsSpearThrower)
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_throwing"));
 			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_opportunist"));

--- a/scripts/entity/tactical/enemies/rf_bandit_killer.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_killer.nut
@@ -65,34 +65,30 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 		if (this.m.HasNet && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
-
-			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-			{
-				local weapon = ::MSU.Class.WeightedContainer([
-					[1, "scripts/items/weapons/boar_spear"],
-					[1, "scripts/items/weapons/rondel_dagger"],
-					[1, "scripts/items/weapons/arming_sword"],
-					[1, "scripts/items/weapons/scramasax"],
-				]).roll();
-				this.m.Items.equip(::new(weapon));
-			}
 		}
-		else if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-		{
-			local weapon = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/arming_sword"],
-				[1, "scripts/items/weapons/boar_spear"],
-				[1, "scripts/items/weapons/rondel_dagger"],
-				[1, "scripts/items/weapons/scramasax"],
 
-				[1, "scripts/items/weapons/billhook"],
-				[1, "scripts/items/weapons/rf_poleflail"],
-				[1, "scripts/items/weapons/pike"],
-				[1, "scripts/items/weapons/spetum"],
-				[1, "scripts/items/weapons/rf_two_handed_falchion"],
-				[1, "scripts/items/weapons/warbrand"]
-			]).roll();
-			this.m.Items.equip(::new(weapon));
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
+		{
+			local weapons = ::MSU.Class.WeightedContainer.addMany(1, [
+				"scripts/items/weapons/boar_spear",
+				"scripts/items/weapons/rondel_dagger",
+				"scripts/items/weapons/arming_sword",
+				"scripts/items/weapons/scramasax",
+			]);
+
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)) // both hands free
+			{
+				weapons.addMany(1, [
+					"scripts/items/weapons/billhook",
+					"scripts/items/weapons/rf_poleflail",
+					"scripts/items/weapons/pike",
+					"scripts/items/weapons/spetum",
+					"scripts/items/weapons/rf_two_handed_falchion",
+					"scripts/items/weapons/warbrand"
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))

--- a/scripts/entity/tactical/enemies/rf_bandit_killer.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_killer.nut
@@ -69,7 +69,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapons = ::MSU.Class.WeightedContainer.addMany(1, [
+			local weapons = ::MSU.Class.WeightedContainer().addMany(1, [
 				"scripts/items/weapons/boar_spear",
 				"scripts/items/weapons/rondel_dagger",
 				"scripts/items/weapons/arming_sword",

--- a/scripts/entity/tactical/enemies/rf_bandit_killer.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_killer.nut
@@ -1,8 +1,8 @@
 this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 	m = {
-		HasNet = 0, // 33% chance
-		IsRegularThrower = 0, // 50% chance
-		IsSpearThrower = 0 // 25% chance. only rolled if not regular thrower.
+		HasNet = false, // 33% chance
+		IsRegularThrower = false, // 50% chance
+		IsSpearThrower = false // 25% chance. only rolled if not regular thrower.
 	},
 	function create()
 	{
@@ -45,12 +45,12 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 		this.m.Skills.add(::new("scripts/skills/perks/perk_quick_hands"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_skirmisher"));
 
-		this.m.HasNet = ::Math.rand(0, 2); // 2 has net
-		this.m.IsRegularThrower = ::Math.rand(0, 1); // 1 is regular thrower
+		this.m.HasNet = ::Math.rand(1, 3) == 3; // 33% chance
+		this.m.IsRegularThrower = ::Math.rand(1, 2) == 2;  // 50% chance
 
-		if (this.m.IsRegularThrower != 1)
+		if (this.m.IsRegularThrower == false)
 		{
-			this.m.IsSpearThrower = ::Math.rand(0, 3); // 3 is spear thrower
+			this.m.IsSpearThrower = ::Math.rand(1, 4) == 4; // 25% chance
 		}
 	}
 
@@ -62,7 +62,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 
 	function assignRandomEquipment()
 	{
-		if (this.m.HasNet == 2 && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
+		if (this.m.HasNet == true && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
 
@@ -98,7 +98,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 			}
 		}
 
-		if (this.m.IsRegularThrower == 1)
+		if (this.m.IsRegularThrower == true)
 		{
 			local throwingWeapon = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/javelin"],
@@ -107,7 +107,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 
 			this.m.Items.addToBag(::new(throwingWeapon));
 		}
-		else if (this.m.IsSpearThrower == 3)
+		else if (this.m.IsSpearThrower == true)
 		{
 			this.m.Items.addToBag(::new("scripts/items/weapons/throwing_spear"));
 		}
@@ -141,7 +141,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 
 	function onSetupEntity()
 	{
-		if (this.m.HasNet == 2) //rolled throwing net
+		if (this.m.HasNet == true) //rolled throwing net
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_angler"));
 		}
@@ -171,7 +171,7 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 			}
 		}
 
-		if (this.m.IsRegularThrower == 1 || this.m.IsSpearThrower == 3)
+		if (this.m.IsRegularThrower == true || this.m.IsSpearThrower == true)
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_throwing"));
 			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_opportunist"));

--- a/scripts/entity/tactical/enemies/rf_bandit_robber.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_robber.nut
@@ -1,7 +1,7 @@
 this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 	m = {
-		HasNet = 0, // 20% chance
-		IsThrower = 0 // 50% chance
+		HasNet = false,
+		IsThrower = false
 	},
 	function create()
 	{
@@ -41,8 +41,8 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 		this.m.Skills.add(::new("scripts/skills/perks/perk_relentless"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_quick_hands"));
 
-		this.m.HasNet = ::Math.rand(0, 4); // 4 has net
-		this.m.IsThrower = ::Math.rand(0, 1); // 1 is thrower
+		this.m.HasNet = ::Math.rand(1, 5) == 5; // 20% chance
+		this.m.IsThrower = ::Math.rand(1, 2) == 2; // 50% chance
 	}
 
 	function onAppearanceChanged( _appearance, _setDirty = true )
@@ -53,7 +53,7 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 
 	function assignRandomEquipment()
 	{
-		if (this.m.HasNet == 4 && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
+		if (this.m.HasNet == true && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
 
@@ -87,7 +87,7 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 			}
 		}
 
-		if (this.m.IsThrower == 1)
+		if (this.m.IsThrower == true)
 		{
 			local throwingWeapon = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/javelin"],

--- a/scripts/entity/tactical/enemies/rf_bandit_robber.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_robber.nut
@@ -56,32 +56,28 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 		if (this.m.HasNet && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
-
-			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-			{
-				local weapon = ::MSU.Class.WeightedContainer([
-					[1, "scripts/items/weapons/boar_spear"],
-					[1, "scripts/items/weapons/dagger"],
-					[1, "scripts/items/weapons/falchion"],
-					[1, "scripts/items/weapons/scramasax"],
-				]).roll();
-				this.m.Items.equip(::new(weapon));
-			}
 		}
-		else if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-		{
-			local weapon = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/boar_spear"],
-				[1, "scripts/items/weapons/dagger"],
-				[1, "scripts/items/weapons/falchion"],
-				[1, "scripts/items/weapons/scramasax"],
 
-				[1, "scripts/items/weapons/hooked_blade"],
-				[1, "scripts/items/weapons/pike"],
-				[1, "scripts/items/weapons/rf_reinforced_wooden_poleflail"],
-				[1, "scripts/items/weapons/warfork"]
-			]).roll();
-			this.m.Items.equip(::new(weapon));
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
+		{
+			local weapons = ::MSU.Class.WeightedContainer.addMany(1, [
+				"scripts/items/weapons/boar_spear",
+				"scripts/items/weapons/dagger",
+				"scripts/items/weapons/falchion",
+				"scripts/items/weapons/scramasax",
+			]);
+
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)) // both hands free
+			{
+				weapons.addMany(1, [
+					"scripts/items/weapons/hooked_blade",
+					"scripts/items/weapons/pike",
+					"scripts/items/weapons/rf_reinforced_wooden_poleflail",
+					"scripts/items/weapons/warfork"
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.IsThrower && this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))

--- a/scripts/entity/tactical/enemies/rf_bandit_robber.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_robber.nut
@@ -60,7 +60,7 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapons = ::MSU.Class.WeightedContainer.addMany(1, [
+			local weapons = ::MSU.Class.WeightedContainer().addMany(1, [
 				"scripts/items/weapons/boar_spear",
 				"scripts/items/weapons/dagger",
 				"scripts/items/weapons/falchion",

--- a/scripts/entity/tactical/enemies/rf_bandit_robber.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_robber.nut
@@ -53,7 +53,7 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 
 	function assignRandomEquipment()
 	{
-		if (this.m.HasNet == true && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
+		if (this.m.HasNet && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
 
@@ -68,26 +68,23 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 				this.m.Items.equip(::new(weapon));
 			}
 		}
-		else
+		else if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-			{
-				local weapon = ::MSU.Class.WeightedContainer([
-					[1, "scripts/items/weapons/boar_spear"],
-					[1, "scripts/items/weapons/dagger"],
-					[1, "scripts/items/weapons/falchion"],
-					[1, "scripts/items/weapons/scramasax"],
+			local weapon = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/boar_spear"],
+				[1, "scripts/items/weapons/dagger"],
+				[1, "scripts/items/weapons/falchion"],
+				[1, "scripts/items/weapons/scramasax"],
 
-					[1, "scripts/items/weapons/hooked_blade"],
-					[1, "scripts/items/weapons/pike"],
-					[1, "scripts/items/weapons/rf_reinforced_wooden_poleflail"],
-					[1, "scripts/items/weapons/warfork"]
-				]).roll();
-				this.m.Items.equip(::new(weapon));
-			}
+				[1, "scripts/items/weapons/hooked_blade"],
+				[1, "scripts/items/weapons/pike"],
+				[1, "scripts/items/weapons/rf_reinforced_wooden_poleflail"],
+				[1, "scripts/items/weapons/warfork"]
+			]).roll();
+			this.m.Items.equip(::new(weapon));
 		}
 
-		if (this.m.IsThrower == true)
+		if (this.m.IsThrower && this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))
 		{
 			local throwingWeapon = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/javelin"],

--- a/scripts/entity/tactical/enemies/rf_bandit_robber.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_robber.nut
@@ -1,6 +1,7 @@
 this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 	m = {
-		MyVariant = 0
+		HasNet = 0, // 20% chance
+		IsThrower = 0 // 50% chance
 	},
 	function create()
 	{
@@ -40,7 +41,8 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 		this.m.Skills.add(::new("scripts/skills/perks/perk_relentless"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_quick_hands"));
 
-		this.m.MyVariant = ::Math.rand(0, 1); // 1 is Thrower
+		this.m.HasNet = ::Math.rand(0, 4); // 4 has net
+		this.m.IsThrower = ::Math.rand(0, 1); // 1 is thrower
 	}
 
 	function onAppearanceChanged( _appearance, _setDirty = true )
@@ -51,45 +53,48 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 
 	function assignRandomEquipment()
 	{
-		if (::Math.rand (1, 100) < 20 && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
+		if (this.m.HasNet == 4 && (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)))
 		{
 			this.m.Items.equip(::new("scripts/items/tools/throwing_net"))
+
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
+			{
+				local weapon = ::MSU.Class.WeightedContainer([
+					[1, "scripts/items/weapons/boar_spear"],
+					[1, "scripts/items/weapons/dagger"],
+					[1, "scripts/items/weapons/falchion"],
+					[1, "scripts/items/weapons/scramasax"],
+				]).roll();
+				this.m.Items.equip(::new(weapon));
+			}
+		}
+		else
+		{
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
+			{
+				local weapon = ::MSU.Class.WeightedContainer([
+					[1, "scripts/items/weapons/boar_spear"],
+					[1, "scripts/items/weapons/dagger"],
+					[1, "scripts/items/weapons/falchion"],
+					[1, "scripts/items/weapons/scramasax"],
+
+					[1, "scripts/items/weapons/hooked_blade"],
+					[1, "scripts/items/weapons/pike"],
+					[1, "scripts/items/weapons/rf_reinforced_wooden_poleflail"],
+					[1, "scripts/items/weapons/warfork"]
+				]).roll();
+				this.m.Items.equip(::new(weapon));
+			}
 		}
 
-		if (this.m.MyVariant == 1) // Thrower
+		if (this.m.IsThrower == 1)
 		{
 			local throwingWeapon = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/javelin"],
 				[1, "scripts/items/weapons/throwing_axe"]
 			]).roll();
 
-			this.m.Items.equip(::new(throwingWeapon));
-		}
-
-		local weapon = ::MSU.Class.WeightedContainer([
-			[1, "scripts/items/weapons/boar_spear"],
-			[1, "scripts/items/weapons/dagger"],
-			[1, "scripts/items/weapons/falchion"],
-			[1, "scripts/items/weapons/scramasax"],
-
-			[1, "scripts/items/weapons/hooked_blade"],
-			[1, "scripts/items/weapons/pike"],
-			[1, "scripts/items/weapons/reinforced_wooden_flail"],
-			[1, "scripts/items/weapons/warfork"]
-		]).roll();
-
-		weapon = ::new(weapon);
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand) && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand)) // both hands free
-		{
-			this.m.Items.equip(weapon);
-		}
-		else if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand) && weapon.isItemType(::Const.Items.ItemType.OneHanded)) // mainhand free and rolled 1h melee weapon
-		{
-			this.m.Items.equip(weapon);
-		}
-		else  // cannot equip melee weapon to hands
-		{
-			this.m.Items.addToBag(weapon);
+			this.m.Items.addToBag(::new(throwingWeapon));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
@@ -122,7 +127,7 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 	function onSetupEntity()
 	{
 		local mainhandItem = this.getMainhandItem();
-		if (mainhandItem != null && !mainhandItem.isItemType(::Const.Items.ItemType.RangedWeapon)) // Rolled and equipped melee weapon. Did not roll throwing.
+		if (mainhandItem != null)
 		{
 			if (mainhandItem.isWeaponType(::Const.Items.WeaponType.Dagger))
 			{
@@ -138,28 +143,6 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 			else
 			{
 				::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 3);
-			}
-		}
-
-		foreach (item in this.m.Items.getAllItemsAtSlot(::Const.ItemSlot.Bag)) // Check all bag slots for items. Melee weapon in bag
-		{
-			if (item.isItemType(::Const.Items.ItemType.MeleeWeapon))
-			{
-				if (item.isWeaponType(::Const.Items.WeaponType.Dagger))
-				{
-					::Reforged.Skills.addPerkGroupOfWeapon(this, item, 3);
-					this.m.Skills.add(::new("scripts/skills/perks/perk_backstabber"));
-					this.m.Skills.add(::new("scripts/skills/perks/perk_rf_cheap_trick"));
-					this.m.Skills.add(::new("scripts/skills/perks/perk_overwhelm"));
-				}
-				else if (item.isWeaponType(::Const.Items.WeaponType.Polearm))
-				{
-					::Reforged.Skills.addPerkGroupOfWeapon(this, item, 4);
-				}
-				else
-				{
-					::Reforged.Skills.addPerkGroupOfWeapon(this, item, 3);
-				}
 			}
 		}
 	}

--- a/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
@@ -64,14 +64,16 @@ this.rf_bandit_vandal <- ::inherit("scripts/entity/tactical/human", {
 			this.m.Items.equip(::new(weapon));
 		}
 
-		local throwing = ::MSU.Class.WeightedContainer([
-			[1, "scripts/items/weapons/throwing_spear"]
-		]).rollChance(33);
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))
+		{
+			local throwing = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/throwing_spear"]
+			]).rollChance(33);
 
-		if (throwing != null) this.m.Items.addToBag(::new(throwing));
+			if (throwing != null) this.m.Items.addToBag(::new(throwing));
+		}
 
-		local weapon = this.getMainhandItem();
-		if (weapon.isItemType(::Const.Items.ItemType.OneHanded))
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			local shield = ::MSU.Class.WeightedContainer([
 				[3, "scripts/items/shields/wooden_shield"],

--- a/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
@@ -34,6 +34,7 @@ this.rf_bandit_vandal <- ::inherit("scripts/entity/tactical/human", {
 		this.getSprite("shield_icon").setBrightness(0.85);
 
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_bully"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_quick_hands"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rotation"));
 	}
 
@@ -47,37 +48,29 @@ this.rf_bandit_vandal <- ::inherit("scripts/entity/tactical/human", {
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local throwing = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/throwing_spear"]
-			]).rollChance(33);
+			local weapon = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/boar_spear"],
+				[1, "scripts/items/weapons/falchion"],
+				[1, "scripts/items/weapons/flail"],
+				[1, "scripts/items/weapons/hand_axe"],
+				[1, "scripts/items/weapons/military_pick"],
+				[1, "scripts/items/weapons/morning_star"],
+				[1, "scripts/items/weapons/scramasax"],
+				[1, "scripts/items/weapons/shortsword"],
 
-			if (throwing != null) this.m.Items.equip(::new(throwing));
+				[1, "scripts/items/weapons/rf_two_handed_falchion"],
+				[1, "scripts/items/weapons/warbrand"]
+			]).roll();
+			this.m.Items.equip(::new(weapon));
 		}
 
-		local weapon = ::MSU.Class.WeightedContainer([
-			[1, "scripts/items/weapons/boar_spear"],
-			[1, "scripts/items/weapons/falchion"],
-			[1, "scripts/items/weapons/flail"],
-			[1, "scripts/items/weapons/hand_axe"],
-			[1, "scripts/items/weapons/military_pick"],
-			[1, "scripts/items/weapons/morning_star"],
-			[1, "scripts/items/weapons/scramasax"],
-			[1, "scripts/items/weapons/shortsword"],
+		local throwing = ::MSU.Class.WeightedContainer([
+			[1, "scripts/items/weapons/throwing_spear"]
+		]).rollChance(33);
 
-			[1, "scripts/items/weapons/rf_two_handed_falchion"],
-			[1, "scripts/items/weapons/warbrand"]
-		]).roll();
-		weapon = ::new(weapon);
+		if (throwing != null) this.m.Items.addToBag(::new(throwing));
 
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
-		{
-			this.m.Items.equip(weapon);
-		}
-		else
-		{
-			this.m.Items.addToBag(weapon);
-		}
-
+		local weapon = this.getMainhandItem();
 		if (weapon.isItemType(::Const.Items.ItemType.OneHanded))
 		{
 			local shield = ::MSU.Class.WeightedContainer([
@@ -118,20 +111,9 @@ this.rf_bandit_vandal <- ::inherit("scripts/entity/tactical/human", {
 	function onSetupEntity()
 	{
 		local mainhandItem = this.getMainhandItem();
-		if (mainhandItem != null && mainhandItem.isItemType(::Const.Items.ItemType.MeleeWeapon)) // melee weapon equipped
+		if (mainhandItem != null)
 		{
 			::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 3);
-		}
-		else // melee weapon in bag
-		{
-			foreach (item in this.m.Items.getAllItemsAtSlot(::Const.ItemSlot.Bag))
-			{
-				if (item.isItemType(::Const.Items.ItemType.Weapon))
-				{
-					::Reforged.Skills.addPerkGroupOfWeapon(this, item, 3);
-					break;
-				}
-			}
 		}
 	}
 });


### PR DESCRIPTION
equip throwing weapons to bag
give vandal, raider and highwayman quick hands
remove longsword from killer

Code on fast bandits can probably be further improved by adding to a single list for weapon rolls depending on getting throwing net or not, but I don't recall the code for this and don't know where a reference is.
![image](https://github.com/user-attachments/assets/a0a29d10-b9b3-4437-894d-02c3f183f76d)
