### PR TITLE
balance: add soul link to necromancer

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/necromancer.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/necromancer.nut
@@ -22,6 +22,7 @@
 		this.m.Skills.add(::Reforged.new("scripts/skills/perks/perk_inspiring_presence", function(o) {
 			o.m.IsForceEnabled = true;
 		}));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_soul_link"));
 	}
 
 	q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )


### PR DESCRIPTION
Because with Take Aim now being given with crossbow mastery, it makes sniping them too easy without this change.