### PR TITLE
feat: generate a basic dynamic perk tree for all backgrounds by default

### DIFF
--- a/mod_reforged/hooks/skills/backgrounds/character_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/character_background.nut
@@ -1,4 +1,10 @@
 ::Reforged.HooksMod.hook("scripts/skills/backgrounds/character_background", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({});
+	}
+
 	q.isHired <- function()
 	{
 		return !::MSU.isNull(this.getContainer()) && !::MSU.isNull(this.getContainer().getActor()) && this.getContainer().getActor().isHired();


### PR DESCRIPTION
This should cover all backgrounds added by mods which do not have their own custom perk tree logic defined.