### PR TITLE
Improve racial tooltips

### DIFF
--- a/mod_reforged/hooks/skills/racial/alp_racial.nut
+++ b/mod_reforged/hooks/skills/racial/alp_racial.nut
@@ -39,7 +39,7 @@
 				id = 20,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Not affected by nighttime penalties"
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Nighttime|Skill+night_effect]")
 			},
 			{
 				id = 21,
@@ -69,7 +69,7 @@
 				id = 25,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Immune to being disarmed"
+				text = ::Reforged.Mod.Tooltips.parseString("Immune to being [disarmed|Skill+disarmed_effect]")
 			}
 		]);
 		return ret;

--- a/mod_reforged/hooks/skills/racial/ghost_racial.nut
+++ b/mod_reforged/hooks/skills/racial/ghost_racial.nut
@@ -23,7 +23,7 @@
 				id = 20,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Not affected by nighttime penalties"
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Nighttime|Skill+night_effect]")
 			},
 			{
 				id = 21,
@@ -59,7 +59,7 @@
 				id = 26,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Immune to being disarmed"
+				text = ::Reforged.Mod.Tooltips.parseString("Immune to being [disarmed|Skill+disarmed_effect]")
 			},
 
 			{

--- a/mod_reforged/hooks/skills/racial/ghost_racial.nut
+++ b/mod_reforged/hooks/skills/racial/ghost_racial.nut
@@ -73,6 +73,12 @@
 				type = "text",
 				icon = "ui/icons/special.png",
 				text = ::Reforged.Mod.Tooltips.parseString("Immune to being [stunned|Skill+stunned_effect]")
+			},
+			{
+				id = 29,
+				type = "text",
+				icon = "ui/icons/morale.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Morale|Concept.Morale]")
 			}
 		]);
 		return ret;
@@ -80,8 +86,10 @@
 
 	q.onAdded <- function()
 	{
-		local baseProperties = this.getContainer().getActor().getBaseProperties();
+		local actor = this.getContainer().getActor();
+		actor.m.MoraleState = ::Const.MoraleState.Ignore;
 
+		local baseProperties = actor.getBaseProperties();
 		baseProperties.IsAffectedByInjuries = false;
 		baseProperties.IsAffectedByNight = false;
 		baseProperties.IsImmuneToBleeding = true;

--- a/mod_reforged/hooks/skills/racial/golem_racial.nut
+++ b/mod_reforged/hooks/skills/racial/golem_racial.nut
@@ -64,7 +64,7 @@
 				id = 26,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Immune to being disarmed"
+				text = ::Reforged.Mod.Tooltips.parseString("Immune to being [disarmed|Skill+disarmed_effect]")
 			},
 			{
 				id = 27,

--- a/mod_reforged/hooks/skills/racial/golem_racial.nut
+++ b/mod_reforged/hooks/skills/racial/golem_racial.nut
@@ -71,6 +71,12 @@
 				type = "text",
 				icon = "ui/icons/special.png",
 				text = ::Reforged.Mod.Tooltips.parseString("Immune to being [stunned|Skill+stunned_effect]")
+			},
+			{
+				id = 28,
+				type = "text",
+				icon = "ui/icons/morale.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Morale|Concept.Morale]")
 			}
 		]);
 		return ret;
@@ -78,8 +84,10 @@
 
 	q.onAdded <- function()
 	{
-		local baseProperties = this.getContainer().getActor().getBaseProperties();
+		local actor = this.getContainer().getActor();
+		actor.m.MoraleState = ::Const.MoraleState.Ignore;
 
+		local baseProperties = actor.getBaseProperties();
 		baseProperties.IsAffectedByInjuries = false;
 		baseProperties.IsAffectedByNight = false;
 		baseProperties.IsImmuneToBleeding = true;

--- a/mod_reforged/hooks/skills/racial/lindwurm_racial.nut
+++ b/mod_reforged/hooks/skills/racial/lindwurm_racial.nut
@@ -25,7 +25,7 @@
 				id = 20,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Not affected by nighttime penalties"
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Nighttime|Skill+night_effect]")
 			},
 			{
 				id = 24,
@@ -37,7 +37,7 @@
 				id = 26,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Immune to being disarmed"
+				text = ::Reforged.Mod.Tooltips.parseString("Immune to being [disarmed|Skill+disarmed_effect]")
 			},
 			{
 				id = 27,

--- a/mod_reforged/hooks/skills/racial/schrat_racial.nut
+++ b/mod_reforged/hooks/skills/racial/schrat_racial.nut
@@ -44,7 +44,7 @@
 				id = 20,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Not affected by nighttime penalties"
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Nighttime|Skill+night_effect]")
 			},
 			{
 				id = 21,
@@ -74,7 +74,7 @@
 				id = 25,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Immune to being disarmed"
+				text = ::Reforged.Mod.Tooltips.parseString("Immune to being [disarmed|Skill+disarmed_effect]")
 			},
 			{
 				id = 26,

--- a/mod_reforged/hooks/skills/racial/serpent_racial.nut
+++ b/mod_reforged/hooks/skills/racial/serpent_racial.nut
@@ -29,13 +29,13 @@
 				id = 20,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Not affected by nighttime penalties"
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Nighttime|Skill+night_effect]")
 			},
 			{
 				id = 23,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Immune to being disarmed"
+				text = ::Reforged.Mod.Tooltips.parseString("Immune to being [disarmed|Skill+disarmed_effect]")
 			}
 		]);
 		return ret;

--- a/mod_reforged/hooks/skills/racial/skeleton_racial.nut
+++ b/mod_reforged/hooks/skills/racial/skeleton_racial.nut
@@ -54,6 +54,13 @@
 				type = "text",
 				icon = "ui/icons/special.png",
 				text = ::Reforged.Mod.Tooltips.parseString("Immune to Poison")
+			},
+			{
+				id = 24,
+				type = "text",
+				icon = "ui/icons/morale.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Morale|Concept.Morale]")
+
 			}
 		]);
 		return ret;
@@ -61,8 +68,10 @@
 
 	q.onAdded <- function()
 	{
-		local baseProperties = this.getContainer().getActor().getBaseProperties();
+		local actor = this.getContainer().getActor();
+		actor.m.MoraleState = ::Const.MoraleState.Ignore;
 
+		local baseProperties = actor.getBaseProperties();
 		baseProperties.IsAffectedByInjuries = false;
 		baseProperties.IsAffectedByNight = false;
 		baseProperties.IsImmuneToBleeding = true;

--- a/mod_reforged/hooks/skills/racial/skeleton_racial.nut
+++ b/mod_reforged/hooks/skills/racial/skeleton_racial.nut
@@ -35,7 +35,7 @@
 				id = 20,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Not affected by nighttime penalties"
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Nighttime|Skill+night_effect]")
 			},
 			{
 				id = 21,

--- a/mod_reforged/hooks/skills/racial/spider_racial.nut
+++ b/mod_reforged/hooks/skills/racial/spider_racial.nut
@@ -31,7 +31,7 @@
 				id = 20,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Not affected by nighttime penalties"
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Nighttime|Skill+night_effect]")
 			},
 			{
 				id = 21,
@@ -43,7 +43,7 @@
 				id = 23,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Immune to being disarmed"
+				text = ::Reforged.Mod.Tooltips.parseString("Immune to being [disarmed|Skill+disarmed_effect]")
 			}
 		]);
 		return ret;

--- a/mod_reforged/hooks/skills/racial/vampire_racial.nut
+++ b/mod_reforged/hooks/skills/racial/vampire_racial.nut
@@ -40,6 +40,12 @@
 				type = "text",
 				icon = "ui/icons/special.png",
 				text = "Immune to Poison"
+			},
+			{
+				id = 23,
+				type = "text",
+				icon = "ui/icons/morale.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Morale|Concept.Morale]")
 			}
 		]);
 		return ret;
@@ -47,8 +53,10 @@
 
 	q.onAdded <- function()
 	{
-		local baseProperties = this.getContainer().getActor().getBaseProperties();
+		local actor = this.getContainer().getActor();
+		actor.m.MoraleState = ::Const.MoraleState.Ignore;
 
+		local baseProperties = actor.getBaseProperties();
 		baseProperties.IsAffectedByInjuries = false;
 		baseProperties.IsAffectedByNight = false;
 		baseProperties.IsImmuneToPoison = true;

--- a/mod_reforged/hooks/skills/racial/vampire_racial.nut
+++ b/mod_reforged/hooks/skills/racial/vampire_racial.nut
@@ -27,7 +27,7 @@
 				id = 20,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = "Not affected by nighttime penalties"
+				text = ::Reforged.Mod.Tooltips.parseString("Not affected by [Nighttime|Skill+night_effect]")
 			},
 			{
 				id = 21,

--- a/scripts/skills/racial/rf_zombie_racial.nut
+++ b/scripts/skills/racial/rf_zombie_racial.nut
@@ -76,7 +76,7 @@ this.rf_zombie_racial <- ::inherit("scripts/skills/skill", {
 			{
 				id = 24,
 				type = "text",
-				icon = "ui/icons/special.png",
+				icon = "ui/icons/morale.png",
 				text = ::Reforged.Mod.Tooltips.parseString("Unaffected by [Morale|Concept.Morale]")
 			}
 		]);


### PR DESCRIPTION
This PR does
- Add hyperlinks for existing tooltip lines of racial effects
- Add new hyperlinked tooltip line for morale immunity to racial effects

I confirmed the new hyperlinks in the following screenshots working correctly.
I haven't checked the other entities, where I only added hyperlinks.

![image](https://github.com/user-attachments/assets/bf1d6de7-d6a8-4e8d-a7cf-88031550f8a0)

![image](https://github.com/user-attachments/assets/2463317d-8fd7-4875-b1b7-8084b1b3e6c1)

![image](https://github.com/user-attachments/assets/fa07e99b-d4eb-479b-ad6b-bad52a862a4a)

![image](https://github.com/user-attachments/assets/c8647f50-f2f6-4399-a679-e7c454ea528c)
