### PR TITLE
Fix addsign change aftermath

### DIFF
--- a/mod_reforged/hooks/ambitions/ambition.nut
+++ b/mod_reforged/hooks/ambitions/ambition.nut
@@ -28,7 +28,7 @@
 					id = 6,
 					type = "text",
 					icon = "ui/icons/ambition_tooltip.png",
-					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getRenownOnSuccess()) + " [Renown|Concept.BusinessReputation]")
+					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getRenownOnSuccess(), {AddSign = true}) + " [Renown|Concept.BusinessReputation]")
 				});
 			}
 			return ret;

--- a/mod_reforged/hooks/items/accessory/accessory.nut
+++ b/mod_reforged/hooks/items/accessory/accessory.nut
@@ -13,7 +13,7 @@
 				}
 				else
 				{
-					entry.text = "Maximum Fatigue " + ::MSU.Text.colorizeValue(this.getStaminaModifier())
+					entry.text = "Maximum Fatigue " + ::MSU.Text.colorizeValue(this.getStaminaModifier(), {AddSign = true})
 				}
 				break;
 			}

--- a/mod_reforged/hooks/items/accessory/falcon_item.nut
+++ b/mod_reforged/hooks/items/accessory/falcon_item.nut
@@ -20,7 +20,7 @@
 				id = 10,
 				type = "text",
 				icon = "ui/icons/initiative.png",
-				text = ::MSU.Text.colorizeValue(this.m.InitiativeBonus) + " Initiative"
+				text = ::MSU.Text.colorizeValue(this.m.InitiativeBonus, {AddSign = true}) + " Initiative"
 			});
 		}
 

--- a/mod_reforged/hooks/skills/effects/taunted_effect.nut
+++ b/mod_reforged/hooks/skills/effects/taunted_effect.nut
@@ -45,7 +45,7 @@
 						id = 10,
 						type = "text",
 						icon = "ui/icons/melee_defense.png",
-						text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getMeleeDefenseModifier()) + " [Melee Defense|Concept.MeleeDefense]")
+						text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getMeleeDefenseModifier(), {AddSign = true}) + " [Melee Defense|Concept.MeleeDefense]")
 					});
 				}
 				if (this.getRangedDefenseModifier() != 0)
@@ -54,7 +54,7 @@
 						id = 11,
 						type = "text",
 						icon = "ui/icons/ranged_defense.png",
-						text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getRangedDefenseModifier()) + " [Ranged Defense|Concept.RangeDefense]")
+						text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getRangedDefenseModifier(), {AddSign = true}) + " [Ranged Defense|Concept.RangeDefense]")
 					});
 				}
 			}

--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -62,7 +62,7 @@
 						id = 3,
 						type = "text",
 						icon = "/ui/icons/melee_skill.png",
-						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().MeleeSkill, {AddSign = false})
+						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().MeleeSkill)
 					},
 					{
 						id = 4,
@@ -77,7 +77,7 @@
 						id = 3,
 						type = "text",
 						icon = "/ui/icons/ranged_skill.png",
-						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().RangedSkill, {AddSign = false})
+						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().RangedSkill)
 					},
 					{
 						id = 4,
@@ -92,7 +92,7 @@
 						id = 3,
 						type = "text",
 						icon = "/ui/icons/melee_defense.png",
-						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().MeleeDefense, {AddSign = false})
+						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().MeleeDefense)
 					},
 					{
 						id = 4,
@@ -107,7 +107,7 @@
 						id = 3,
 						type = "text",
 						icon = "/ui/icons/ranged_defense.png",
-						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().RangedDefense, {AddSign = false})
+						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().RangedDefense)
 					},
 					{
 						id = 4,
@@ -122,7 +122,7 @@
 						id = 3,
 						type = "text",
 						icon = "ui/icons/health.png",
-						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().Hitpoints, {AddSign = false})
+						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().Hitpoints)
 					},
 					{
 						id = 4,
@@ -137,7 +137,7 @@
 						id = 3,
 						type = "text",
 						icon = "ui/icons/fatigue.png",
-						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().Stamina, {AddSign = false})
+						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().Stamina)
 					},
 					{
 						id = 4,
@@ -165,7 +165,7 @@
 						id = 3,
 						type = "text",
 						icon = "ui/icons/initiative.png",
-						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().Initiative, {AddSign = false})
+						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().Initiative)
 					},
 					{
 						id = 4,
@@ -180,7 +180,7 @@
 						id = 3,
 						type = "text",
 						icon = "ui/icons/bravery.png",
-						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().Bravery, {AddSign = false})
+						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().Bravery)
 					},
 					{
 						id = 4,

--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -68,7 +68,7 @@
 						id = 4,
 						type = "text",
 						icon = "/ui/icons/melee_skill.png",
-						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getMeleeSkill() - entity.getBaseProperties().MeleeSkill)
+						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getMeleeSkill() - entity.getBaseProperties().MeleeSkill, {AddSign = true})
 					}
 				];
 			case "character-stats.RangeSkill":
@@ -83,7 +83,7 @@
 						id = 4,
 						type = "text",
 						icon = "/ui/icons/ranged_skill.png",
-						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getRangedSkill() - entity.getBaseProperties().RangedSkill)
+						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getRangedSkill() - entity.getBaseProperties().RangedSkill, {AddSign = true})
 					}
 				];
 			case "character-stats.MeleeDefense":
@@ -98,7 +98,7 @@
 						id = 4,
 						type = "text",
 						icon = "/ui/icons/melee_defense.png",
-						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getMeleeDefense() - entity.getBaseProperties().MeleeDefense)
+						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getMeleeDefense() - entity.getBaseProperties().MeleeDefense, {AddSign = true})
 					}
 				];
 			case "character-stats.RangeDefense":
@@ -113,7 +113,7 @@
 						id = 4,
 						type = "text",
 						icon = "/ui/icons/ranged_defense.png",
-						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getRangedDefense() - entity.getBaseProperties().RangedDefense)
+						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getRangedDefense() - entity.getBaseProperties().RangedDefense, {AddSign = true})
 					}
 				];
 			case "character-stats.Hitpoints":
@@ -128,7 +128,7 @@
 						id = 4,
 						type = "text",
 						icon = "ui/icons/health.png",
-						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getHitpointsMax() - entity.getBaseProperties().Hitpoints)
+						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getHitpointsMax() - entity.getBaseProperties().Hitpoints, {AddSign = true})
 					}
 				];
 			case "character-stats.Fatigue":
@@ -143,14 +143,14 @@
 						id = 4,
 						type = "text",
 						icon = "ui/icons/fatigue.png",
-						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getFatigueMax() - entity.getBaseProperties().Stamina)
+						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getFatigueMax() - entity.getBaseProperties().Stamina, {AddSign = true})
 					},
 					{
 
 						id = 5,
 						type = "text",
 						icon = "ui/icons/fatigue.png",
-						text = "Fatigue Recovery: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getFatigueRecoveryRate())
+						text = "Fatigue Recovery: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getFatigueRecoveryRate(), {AddSign = true})
 					},
 					{
 						id = 6,
@@ -171,7 +171,7 @@
 						id = 4,
 						type = "text",
 						icon = "ui/icons/initiative.png",
-						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getInitiative() - entity.getBaseProperties().Initiative)
+						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getInitiative() - entity.getBaseProperties().Initiative, {AddSign = true})
 					}
 				];
 			case "character-stats.Bravery":
@@ -186,7 +186,7 @@
 						id = 4,
 						type = "text",
 						icon = "ui/icons/bravery.png",
-						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getBravery() - entity.getBaseProperties().Bravery)
+						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getBravery() - entity.getBaseProperties().Bravery, {AddSign = true})
 					}
 				];
 		}

--- a/scripts/items/armor_upgrades/rf_heraldic_cape_upgrade.nut
+++ b/scripts/items/armor_upgrades/rf_heraldic_cape_upgrade.nut
@@ -39,13 +39,13 @@ this.rf_heraldic_cape_upgrade <- ::inherit("scripts/items/armor_upgrades/armor_u
 			id = 14,
 			type = "text",
 			icon = "ui/icons/armor_body.png",
-			text = ::MSU.Text.colorizeValue(this.m.ConditionModifier) + " Durability"
+			text = ::MSU.Text.colorizeValue(this.m.ConditionModifier, {AddSign = true}) + " Durability"
 		});
 		result.push({
 			id = 15,
 			type = "text",
 			icon = "ui/icons/bravery.png",
-			text = ::MSU.Text.colorizeValue(this.m.ResolveModifier) + " Resolve"
+			text = ::MSU.Text.colorizeValue(this.m.ResolveModifier, {AddSign = true}) + " Resolve"
 		});
 
 		if (this.m.StaminaModifier != 0)
@@ -54,7 +54,7 @@ this.rf_heraldic_cape_upgrade <- ::inherit("scripts/items/armor_upgrades/armor_u
 				id = 16,
 				type = "text",
 				icon = "ui/icons/fatigue.png",
-				text = ::MSU.Text.colorizeValue(-1 * this.m.StaminaModifier) + " Maximum Fatigue"
+				text = ::MSU.Text.colorizeValue(-1 * this.m.StaminaModifier, {AddSign = true}) + " Maximum Fatigue"
 			});
 		}
 
@@ -67,7 +67,7 @@ this.rf_heraldic_cape_upgrade <- ::inherit("scripts/items/armor_upgrades/armor_u
 			id = 14,
 			type = "text",
 			icon = "ui/icons/bravery.png",
-			text = ::MSU.Text.colorizeValue(this.m.ResolveModifier) + " Resolve"
+			text = ::MSU.Text.colorizeValue(this.m.ResolveModifier, {AddSign = true}) + " Resolve"
 		});
 	}
 

--- a/scripts/skills/actives/rf_bestial_vigor_skill.nut
+++ b/scripts/skills/actives/rf_bestial_vigor_skill.nut
@@ -47,7 +47,7 @@ this.rf_bestial_vigor_skill <- ::inherit("scripts/skills/skill", {
 				id = 11,
 				type = "text",
 				icon = "ui/icons/action_points.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Gain " + ::MSU.Text.colorizeValue(this.m.ActionPointsGained) + " [Action Points|Concept.ActionPoints] for this [turn|Concept.Turn]")
+				text = ::Reforged.Mod.Tooltips.parseString("Gain " + ::MSU.Text.colorizeValue(this.m.ActionPointsGained, {AddSign = true}) + " [Action Points|Concept.ActionPoints] for this [turn|Concept.Turn]")
 			},
 			{
 				id = 20,

--- a/scripts/skills/actives/rf_encourage_skill.nut
+++ b/scripts/skills/actives/rf_encourage_skill.nut
@@ -39,7 +39,7 @@ this.rf_encourage_skill <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/bravery.png",
-				text = ::Reforged.Mod.Tooltips.parseString(format("Trigger a positive [Morale Check|Concept.Morale] for the target with a bonus of %s (%s) of your [Resolve|Concept.Bravery]", ::MSU.Text.colorizePct(this.m.EncourageBonusFraction), ::MSU.Text.colorizeValue(this.getEncourageBonus())))
+				text = ::Reforged.Mod.Tooltips.parseString(format("Trigger a positive [Morale Check|Concept.Morale] for the target with a bonus of %s (%s) of your [Resolve|Concept.Bravery]", ::MSU.Text.colorizePct(this.m.EncourageBonusFraction), ::MSU.Text.colorizeValue(this.getEncourageBonus(), {AddSign = true})))
 			},
 			{
 				id = 15,

--- a/scripts/skills/actives/rf_kata_step_skill.nut
+++ b/scripts/skills/actives/rf_kata_step_skill.nut
@@ -37,8 +37,8 @@ this.rf_kata_step_skill <- ::inherit("scripts/skills/skill", {
 		if (this.getContainer().getActor().isPlacedOnMap())
 			return this.skill.getCostString();
 
-		local ret = "Costs " + (this.m.APCostModifier == 0 ? "+0" : ::MSU.Text.colorizeValue(this.m.APCostModifier, {InvertColor = true})) + " [Action Points|Concept.ActionPoints] and builds ";
-		ret += (this.m.FatigueCostModifier == 0 ? "+0" : ::MSU.Text.colorizeValue(this.m.FatigueCostModifier, {InvertColor = true})) + " [Fatigue|Concept.Fatigue] compared to the movement costs of the starting tile";
+		local ret = "Costs " + (this.m.APCostModifier == 0 ? "+0" : ::MSU.Text.colorizeValue(this.m.APCostModifier, {AddSign = true, InvertColor = true})) + " [Action Points|Concept.ActionPoints] and builds ";
+		ret += (this.m.FatigueCostModifier == 0 ? "+0" : ::MSU.Text.colorizeValue(this.m.FatigueCostModifier, {AddSign = true, InvertColor = true})) + " [Fatigue|Concept.Fatigue] compared to the movement costs of the starting tile";
 		return ::Reforged.Mod.Tooltips.parseString(ret);
 	}
 

--- a/scripts/skills/effects/rf_centurion_command_effect.nut
+++ b/scripts/skills/effects/rf_centurion_command_effect.nut
@@ -20,7 +20,7 @@ this.rf_centurion_command_effect <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/initiative.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.InitiativeBonus) + " [Initiative|Concept.Initiative]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.InitiativeBonus, {AddSign = true}) + " [Initiative|Concept.Initiative]")
 		});
 
 		return ret;

--- a/scripts/skills/effects/rf_covering_ally_effect.nut
+++ b/scripts/skills/effects/rf_covering_ally_effect.nut
@@ -29,28 +29,28 @@ this.rf_covering_ally_effect <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/melee_defense.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.SelfDefenseMalus) + " [Melee Defense|Concept.MeleeDefense]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.SelfDefenseMalus, {AddSign = true}) + " [Melee Defense|Concept.MeleeDefense]")
 		});
 
 		ret.push({
 			id = 11,
 			type = "text",
 			icon = "ui/icons/ranged_defense.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.SelfDefenseMalus) + " [Ranged Defense|Concept.RangeDefense]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.SelfDefenseMalus, {AddSign = true}) + " [Ranged Defense|Concept.RangeDefense]")
 		});
 
 		ret.push({
 			id = 12,
 			type = "text",
 			icon = "ui/icons/melee_skill.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.SelfSkillMalus) + " [Melee Skill|Concept.MeleeSkill]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.SelfSkillMalus, {AddSign = true}) + " [Melee Skill|Concept.MeleeSkill]")
 		});
 
 		ret.push({
 			id = 13,
 			type = "text",
 			icon = "ui/icons/ranged_skill.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.SelfSkillMalus) + " [Ranged Skill|Concept.RangeSkill]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.SelfSkillMalus, {AddSign = true}) + " [Ranged Skill|Concept.RangeSkill]")
 		});
 
 		return ret;

--- a/scripts/skills/effects/rf_hold_steady_effect.nut
+++ b/scripts/skills/effects/rf_hold_steady_effect.nut
@@ -23,13 +23,13 @@ this.rf_hold_steady_effect <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/melee_defense.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(10) + " [Melee Defense|Concept.MeleeDefense]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(10, {AddSign = true}) + " [Melee Defense|Concept.MeleeDefense]")
 			},
 			{
 				id = 11,
 				type = "text",
 				icon = "ui/icons/ranged_defense.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(10) + " [Ranged Defense|Concept.RangeDefense]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(10, {AddSign = true}) + " [Ranged Defense|Concept.RangeDefense]")
 			},
 			{
 				id = 12,

--- a/scripts/skills/effects/rf_hooked_shield_effect.nut
+++ b/scripts/skills/effects/rf_hooked_shield_effect.nut
@@ -36,13 +36,13 @@ this.rf_hooked_shield_effect <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/melee_defense.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(-::Math.floor(shield.getMeleeDefenseBonus() * 0.75)) + " [Melee Defense|Concept.MeleeDefense] from equipped shield")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(-::Math.floor(shield.getMeleeDefenseBonus() * 0.75), {AddSign = true}) + " [Melee Defense|Concept.MeleeDefense] from equipped shield")
 			});
 			ret.push({
 				id = 11,
 				type = "text",
 				icon = "ui/icons/ranged_defense.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(-::Math.floor(shield.getRangedDefenseBonus() * 0.75)) + " [Ranged Defense|Concept.RangeDefense] from equipped shield")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(-::Math.floor(shield.getRangedDefenseBonus() * 0.75), {AddSign = true}) + " [Ranged Defense|Concept.RangeDefense] from equipped shield")
 			});
 		}
 		ret.push({

--- a/scripts/skills/effects/rf_legatus_command_effect.nut
+++ b/scripts/skills/effects/rf_legatus_command_effect.nut
@@ -35,7 +35,7 @@ this.rf_legatus_command_effect <- ::inherit("scripts/skills/skill", {
 				id = 12,
 				type = "text",
 				icon = "ui/icons/bravery.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.ResolveBonus) + " [Resolve|Concept.Bravery]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.ResolveBonus, {AddSign = true}) + " [Resolve|Concept.Bravery]")
 			}
 		]);
 

--- a/scripts/skills/effects/rf_mentors_presence_effect.nut
+++ b/scripts/skills/effects/rf_mentors_presence_effect.nut
@@ -80,7 +80,7 @@ this.rf_mentors_presence_effect <- ::inherit("scripts/skills/skill", {
 					id = 14,
 					type = "text",
 					icon = "ui/icons/bravery.png",
-					text = ::Reforged.Mod.Tooltips.parseString("Will lose " + ::MSU.Text.colorizeValue(this.m.MoraleStateOnMentorDeathAdd, {AddSign = false}) + " levels of [morale|Concept.Morale] upon the mentor\'s death")
+					text = ::Reforged.Mod.Tooltips.parseString("Will lose " + ::MSU.Text.colorizeValue(this.m.MoraleStateOnMentorDeathAdd) + " levels of [morale|Concept.Morale] upon the mentor\'s death")
 				}
 			]);
 		}

--- a/scripts/skills/effects/rf_mentors_presence_effect.nut
+++ b/scripts/skills/effects/rf_mentors_presence_effect.nut
@@ -51,19 +51,19 @@ this.rf_mentors_presence_effect <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/melee_skill.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.MeleeSkillAdd) + " [Melee Skill|Concept.MeleeSkill]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.MeleeSkillAdd, {AddSign = true}) + " [Melee Skill|Concept.MeleeSkill]")
 			},
 			{
 				id = 11,
 				type = "text",
 				icon = "ui/icons/melee_defense.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.MeleeDefenseAdd) + " [Melee Defense|Concept.MeleeDefense]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.MeleeDefenseAdd, {AddSign = true}) + " [Melee Defense|Concept.MeleeDefense]")
 			},
 			{
 				id = 12,
 				type = "text",
 				icon = "ui/icons/bravery.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.BraveryAdd) + " [Resolve|Concept.Bravery]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.BraveryAdd, {AddSign = true}) + " [Resolve|Concept.Bravery]")
 			}
 		]);
 

--- a/scripts/skills/effects/rf_onslaught_effect.nut
+++ b/scripts/skills/effects/rf_onslaught_effect.nut
@@ -25,13 +25,13 @@ this.rf_onslaught_effect <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/melee_skill.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(10) + " [Melee Skill|Concept.MeleeSkill]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(10, {AddSign = true}) + " [Melee Skill|Concept.MeleeSkill]")
 			},
 			{
 				id = 11,
 				type = "text",
 				icon = "ui/icons/initiative.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(20) + " [Initiative|Concept.Initiative]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(20, {AddSign = true}) + " [Initiative|Concept.Initiative]")
 			},
 			{
 				id = 12,

--- a/scripts/skills/effects/rf_rattled_effect.nut
+++ b/scripts/skills/effects/rf_rattled_effect.nut
@@ -22,7 +22,7 @@ this.rf_rattled_effect <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/rf_reach.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.ReachModifier) + " [Reach|Concept.Reach]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.ReachModifier, {AddSign = true}) + " [Reach|Concept.Reach]")
 		});
 		
 		return ret;

--- a/scripts/skills/effects/rf_trip_artist_effect.nut
+++ b/scripts/skills/effects/rf_trip_artist_effect.nut
@@ -71,7 +71,7 @@ this.rf_trip_artist_effect <- ::inherit("scripts/skills/skill", {
 						id = 11,
 						type = "text",
 						icon = "ui/icons/special.png",
-						text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(4 - weapon.getReach()) + " [Reach|Concept.Reach]")
+						text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(4 - weapon.getReach(), {AddSign = true}) + " [Reach|Concept.Reach]")
 					});
 				}
 			}

--- a/scripts/skills/injury/rf_dislocated_jaw_injury.nut
+++ b/scripts/skills/injury/rf_dislocated_jaw_injury.nut
@@ -28,7 +28,7 @@ this.rf_dislocated_jaw_injury <- ::inherit("scripts/skills/injury/injury", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/fatigue.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.FatigueRecoveryModifier) + " [Fatigue Recovery|Concept.FatigueRecovery]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.FatigueRecoveryModifier, {AddSign = true}) + " [Fatigue Recovery|Concept.FatigueRecovery]")
 			});
 		}
 

--- a/scripts/skills/perks/perk_rf_decisive.nut
+++ b/scripts/skills/perks/perk_rf_decisive.nut
@@ -43,7 +43,7 @@ this.perk_rf_decisive <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/bravery.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(resolveModifier) + " [Resolve|Concept.Bravery]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(resolveModifier, {AddSign = true}) + " [Resolve|Concept.Bravery]")
 			});
 		}
 
@@ -54,7 +54,7 @@ this.perk_rf_decisive <- ::inherit("scripts/skills/skill", {
 				id = 11,
 				type = "text",
 				icon = "ui/icons/initiative.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(initiativeModifier) + " [Initiative|Concept.Initiative]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(initiativeModifier, {AddSign = true}) + " [Initiative|Concept.Initiative]")
 			});
 		}
 

--- a/scripts/skills/perks/perk_rf_dynamic_duo_abstract.nut
+++ b/scripts/skills/perks/perk_rf_dynamic_duo_abstract.nut
@@ -58,7 +58,7 @@ this.perk_rf_dynamic_duo_abstract <- ::inherit("scripts/skills/skill", {
 				id = 11,
 				type = "text",
 				icon = "ui/icons/bravery.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.BraveryModifier) + " [Resolve|Concept.Bravery]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.BraveryModifier, {AddSign = true}) + " [Resolve|Concept.Bravery]")
 			});
 		}
 
@@ -68,7 +68,7 @@ this.perk_rf_dynamic_duo_abstract <- ::inherit("scripts/skills/skill", {
 				id = 12,
 				type = "text",
 				icon = "ui/icons/initiative.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.InitiativeModifier) + " [Initiative|Concept.Initiative]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.InitiativeModifier, {AddSign = true}) + " [Initiative|Concept.Initiative]")
 			});
 		}
 
@@ -81,7 +81,7 @@ this.perk_rf_dynamic_duo_abstract <- ::inherit("scripts/skills/skill", {
 					id = 13,
 					type = "text",
 					icon = "ui/icons/melee_skill.png",
-					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.MeleeSkillModifier) + " [Melee Skill|Concept.MeleeSkill] this [turn|Concept.Turn] against:"),
+					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.MeleeSkillModifier, {AddSign = true}) + " [Melee Skill|Concept.MeleeSkill] this [turn|Concept.Turn] against:"),
 					children = attackBonusEnemies.map(@(_a) { id = 10, type = "text", icon = "ui/orientation/" + _a.getOverlayImage() + ".png", text = _a.getName() })
 				});
 			}
@@ -96,7 +96,7 @@ this.perk_rf_dynamic_duo_abstract <- ::inherit("scripts/skills/skill", {
 					id = 14,
 					type = "text",
 					icon = "ui/icons/melee_defense.png",
-					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.MeleeDefenseModifier) + " [Melee Defense|Concept.MeleeDefense] this [turn|Concept.Turn] against:"),
+					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.MeleeDefenseModifier, {AddSign = true}) + " [Melee Defense|Concept.MeleeDefense] this [turn|Concept.Turn] against:"),
 					children = defenseBonusEnemies.map(@(_a) { id = 10, type = "text", icon = "ui/orientation/" + _a.getOverlayImage() + ".png", text = _a.getName() })
 				});
 			}

--- a/scripts/skills/perks/perk_rf_feral_rage.nut
+++ b/scripts/skills/perks/perk_rf_feral_rage.nut
@@ -54,19 +54,19 @@ this.perk_rf_feral_rage <- ::inherit("scripts/skills/skill", {
 				id = 12,
 				type = "text",
 				icon = "ui/icons/bravery.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.RageStacks * this.m.PerStackBraveryModifier) + " [Resolve|Concept.Bravery]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.RageStacks * this.m.PerStackBraveryModifier, {AddSign = true}) + " [Resolve|Concept.Bravery]")
 			},
 			{
 				id = 13,
 				type = "text",
 				icon = "ui/icons/initiative.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.RageStacks * this.m.PerStackInitiativeModifier) + " [Initiative|Concept.Initiative]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.RageStacks * this.m.PerStackInitiativeModifier, {AddSign = true}) + " [Initiative|Concept.Initiative]")
 			},
 			{
 				id = 13,
 				type = "text",
 				icon = "ui/icons/melee_defense.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.RageStacks * this.m.PerStackMeleeDefenseModifier) + " [Melee Defense|Concept.MeleeDefense]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.RageStacks * this.m.PerStackMeleeDefenseModifier, {AddSign = true}) + " [Melee Defense|Concept.MeleeDefense]")
 			}
 		]);
 

--- a/scripts/skills/perks/perk_rf_phalanx.nut
+++ b/scripts/skills/perks/perk_rf_phalanx.nut
@@ -23,7 +23,7 @@ this.perk_rf_phalanx <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/rf_reach.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getCount()) + " [Reach|Concept.Reach] when attacking or defending in melee")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getCount(), {AddSign = true}) + " [Reach|Concept.Reach] when attacking or defending in melee")
 		});
 
 		if (this.hasAdjacentShieldwall() || this.getContainer().getActor().getID() == ::MSU.getDummyPlayer().getID())

--- a/scripts/skills/perks/perk_rf_sweeping_strikes.nut
+++ b/scripts/skills/perks/perk_rf_sweeping_strikes.nut
@@ -27,7 +27,7 @@ this.perk_rf_sweeping_strikes <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/rf_reach.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.ReachBonus) + " [Reach|Concept.Reach]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.ReachBonus, {AddSign = true}) + " [Reach|Concept.Reach]")
 		});
 
 		local enemyList = [];
@@ -50,7 +50,7 @@ this.perk_rf_sweeping_strikes <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/rf_reach.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.ReachBonus) + " [Reach|Concept.Reach] against attacks from:")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.ReachBonus, {AddSign = true}) + " [Reach|Concept.Reach] against attacks from:")
 				children = enemyList
 			});
 		}

--- a/scripts/skills/perks/perk_rf_swordmaster_precise.nut
+++ b/scripts/skills/perks/perk_rf_swordmaster_precise.nut
@@ -25,7 +25,7 @@ this.perk_rf_swordmaster_precise <- ::inherit("scripts/skills/perks/perk_rf_swor
 				id = 10,
 				type = "text",
 				icon = "ui/icons/melee_skill.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(skillModifier) + " [Melee Skill|Concept.MeleeSkill]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(skillModifier, {AddSign = true}) + " [Melee Skill|Concept.MeleeSkill]")
 			});
 		}
 
@@ -36,7 +36,7 @@ this.perk_rf_swordmaster_precise <- ::inherit("scripts/skills/perks/perk_rf_swor
 				id = 11,
 				type = "text",
 				icon = "ui/icons/melee_defense.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(defenseModifier) + " [Melee Defense|Concept.MeleeDefense]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(defenseModifier, {AddSign = true}) + " [Melee Defense|Concept.MeleeDefense]")
 			});
 		}
 

--- a/scripts/skills/perks/perk_rf_tempo.nut
+++ b/scripts/skills/perks/perk_rf_tempo.nut
@@ -42,7 +42,7 @@ this.perk_rf_tempo <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/initiative.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getBonus()) + " [Initiative|Concept.Initiative]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getBonus(), {AddSign = true}) + " [Initiative|Concept.Initiative]")
 			});
 		}
 

--- a/scripts/skills/perks/perk_rf_unstoppable.nut
+++ b/scripts/skills/perks/perk_rf_unstoppable.nut
@@ -45,7 +45,7 @@ this.perk_rf_unstoppable <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/action_points.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getAPBonus()) + " [Action Points|Concept.ActionPoints]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getAPBonus(), {AddSign = true}) + " [Action Points|Concept.ActionPoints]")
 			});
 		}
 
@@ -55,7 +55,7 @@ this.perk_rf_unstoppable <- ::inherit("scripts/skills/skill", {
 				id = 11,
 				type = "text",
 				icon = "ui/icons/initiative.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getInitiativeBonus()) + " [Initiative|Concept.Initiative]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.getInitiativeBonus(), {AddSign = true}) + " [Initiative|Concept.Initiative]")
 			});
 		}
 

--- a/scripts/skills/perks/perk_rf_vigilant.nut
+++ b/scripts/skills/perks/perk_rf_vigilant.nut
@@ -25,7 +25,7 @@ this.perk_rf_vigilant <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/action_points.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.CurrBonus) + " [Action Points|Concept.ActionPoints]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.CurrBonus, {AddSign = true}) + " [Action Points|Concept.ActionPoints]")
 		});
 
 		return ret;

--- a/scripts/skills/perks/perk_rf_whirling_death.nut
+++ b/scripts/skills/perks/perk_rf_whirling_death.nut
@@ -28,7 +28,7 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/rf_reach.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.Stacks) + " [Reach|Concept.Reach]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.Stacks, {AddSign = true}) + " [Reach|Concept.Reach]")
 		});
 		ret.push({
 			id = 20,

--- a/scripts/skills/special/rf_first_turn_initiative.nut
+++ b/scripts/skills/special/rf_first_turn_initiative.nut
@@ -29,7 +29,7 @@ this.rf_first_turn_initiative <- ::inherit("scripts/skills/skill", {
 	{
 		local ret = this.skill.getDescription();
 
-		ret += "\nThis character gains 1 [Action Point|Concept.ActionPoints] for every " + ::MSU.Text.colorPositive(this.m.InitiativePerAP) + " [Initiative|Concept.Initiative] which is then modified by a flat " + ::MSU.Text.colorizeValue(this.m.FlatAPBonus) + " [Action Points.|Concept.ActionPoints]";
+		ret += "\nThis character gains 1 [Action Point|Concept.ActionPoints] for every " + ::MSU.Text.colorPositive(this.m.InitiativePerAP) + " [Initiative|Concept.Initiative] which is then modified by a flat " + ::MSU.Text.colorizeValue(this.m.FlatAPBonus, {AddSign = true}) + " [Action Points.|Concept.ActionPoints]";
 
 		return ::Reforged.Mod.Tooltips.parseString(ret);
 	}
@@ -42,7 +42,7 @@ this.rf_first_turn_initiative <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/action_points.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.CurrentAPBonus) + " [Action Point(s)|Concept.ActionPoints] for this [turn|Concept.Turn]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeValue(this.m.CurrentAPBonus, {AddSign = true}) + " [Action Point(s)|Concept.ActionPoints] for this [turn|Concept.Turn]")
 		});
 
 		return ret;

--- a/scripts/skills/special/rf_polearm_adjacency.nut
+++ b/scripts/skills/special/rf_polearm_adjacency.nut
@@ -8,7 +8,7 @@ this.rf_polearm_adjacency <- ::inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "special.rf_polearm_adjacency";
 		this.m.Name = "Crowded";
-		this.m.Description = "Long range melee weapons are harder to use in a crowded environment. When using such weapons, any melee attack with a base range of 2 or more tiles has its hit chance reduced by " + ::MSU.Text.colorizeValue(-this.m.MalusPerAlly) + " per adjacent ally (ignoring the first two adjacent allies) and " + ::MSU.Text.colorizeValue(-this.m.MalusPerEnemy, {AddSign = true, AddPercent = true}) + " per adjacent enemy.";
+		this.m.Description = "Long range melee weapons are harder to use in a crowded environment. When using such weapons, any melee attack with a base range of 2 or more tiles has its hit chance reduced by " + ::MSU.Text.colorizeValue(-this.m.MalusPerAlly, {AddSign = true, AddPercent = true}) + " per adjacent ally (ignoring the first two adjacent allies) and " + ::MSU.Text.colorizeValue(-this.m.MalusPerEnemy, {AddSign = true, AddPercent = true}) + " per adjacent enemy.";
 		this.m.Type = ::Const.SkillType.Special;
 		this.m.IsHidden = true;
 		this.m.IsSerialized = false;


### PR DESCRIPTION
When colorizeValue was moved over to MSU the default for `AddSign` was turned into `false` when it was `true` while in reforged.

As a result we need to manually add `AddSign = true` in many places in reforged, which previously relied on that default.
And in other places, which don't want a sign, we can remove the `AddSign = false` because it's redundant now.