### PR TITLE
feat: assign default reach depending on weapon type for modded weapons

### DIFF
--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -1,5 +1,16 @@
+::Reforged.HooksMod.hookTree("scripts/items/weapons/weapon", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		if (this.m.Reach == null)
+		{
+			this.assignDefaultReach();
+		}
+	}
+});
+
 ::Reforged.HooksMod.hook("scripts/items/weapons/weapon", function(q) {
-	q.m.Reach <- 1;
+	q.m.Reach <- null;
 
 	q.getTooltip = @(__original) function()
 	{
@@ -57,8 +68,99 @@
 		}
 	}
 
+// New Functions
 	q.getReach <- function()
 	{
 		return this.m.Reach;
+	}
+
+	q.assignDefaultReach <- function()
+	{
+		if (this.isItemType(this.Const.Items.ItemType.MeleeWeapon))
+		{
+			if (this.isItemType(::Const.Items.ItemType.OneHanded))
+			{
+				if (this.isWeaponType(::Const.Items.WeaponType.Axe))
+				{
+					this.m.Reach = 3;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Cleaver))
+				{
+					this.m.Reach = 4;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Dagger))
+				{
+					this.m.Reach = 1;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Flail))
+				{
+					this.m.Reach = 4;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Hammer))
+				{
+					this.m.Reach = 3;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Mace))
+				{
+					this.m.Reach = 3;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Spear))
+				{
+					this.m.Reach = 5;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Sword))
+				{
+					this.m.Reach = 4;
+				}
+			}
+			else if (this.isItemType(::Const.Items.ItemType.TwoHanded))
+			{
+				if (this.isWeaponType(::Const.Items.WeaponType.Axe))
+				{
+					this.m.Reach = (this.m.RangeMax == 2) ? 6 : 5;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Cleaver))
+				{
+					this.m.Reach = (this.m.RangeMax == 2) ? 6 : 4;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Dagger))
+				{
+					this.m.Reach = 4;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Flail))
+				{
+					this.m.Reach = (this.m.RangeMax == 2) ? 6 : 5;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Hammer))
+				{
+					this.m.Reach = (this.m.RangeMax == 2) ? 6 : 4;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Mace))
+				{
+					this.m.Reach = (this.m.RangeMax == 2) ? 6 : 5;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Polearm))
+				{
+					this.m.Reach = 7;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Spear))
+				{
+					this.m.Reach = (this.m.RangeMax == 2) ? 6 : 5;
+				}
+				else if (this.isWeaponType(::Const.Items.WeaponType.Sword))
+				{
+					this.m.Reach = (this.m.RangeMax == 2) ? 6 : 6;
+				}
+			}
+
+			if (this.m.Reach == null)
+			{
+				this.m.Reach = 3;
+			}
+		}
+		else
+		{
+			this.m.Reach = 0;	// e.g. Ranged weapons
+		}
 	}
 });


### PR DESCRIPTION
When someone uses a vanilla mod, which adds new weapons, those will usually all have 1 Reach as that was our current default.
This branch employs simple weapon type and weapon range rules to assign much better reach values for unknown weapons.