### PR TITLE
fix: ghostlike not removing the enemy with delayed attacks

### DIFF
--- a/scripts/skills/perks/perk_rf_ghostlike.nut
+++ b/scripts/skills/perks/perk_rf_ghostlike.nut
@@ -153,11 +153,18 @@ this.perk_rf_ghostlike <- ::inherit("scripts/skills/skill", {
 		}
 	}
 
-	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
+	function onTargetHit( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
 	{
-		if (_targetEntity == null)
-			return;
+		this.removeEnemy(_targetEntity);
+	}
 
+	function onTargetMissed( _skill, _targetEntity )
+	{
+		this.removeEnemy(_targetEntity);
+	}
+
+	function removeEnemy( _entity )
+	{
 		local idx = this.m.Enemies.find(_targetEntity.getID());
 		if (idx != null)
 			this.m.Enemies.remove(idx);


### PR DESCRIPTION
E.g. Lunge. Because you remove the enemy in onAnySkillExecuted but he gets added back in onMovementFinished.