### PR TITLE
feat: add automatic assignment of default reach for weapons

### DIFF
--- a/mod_reforged/config/reach.nut
+++ b/mod_reforged/config/reach.nut
@@ -18,6 +18,21 @@
 		Medium_2H = 6,
 		Long_2H = 7
 	},
+	WeaponTypeDefault = {
+		Axe = 3,
+		Bow = 0,
+		Cleaver = 4,
+		Crossbow = 0,
+		Dagger = 1,
+		Firearm = 0,
+		Flail = 4,
+		Hammer = 3,
+		Mace = 3,
+		Polearm = 7,
+		Spear = 5,
+		Sword = 4
+		Throwing = 0
+	},
 
 	function hasLineOfSight( _actor1, _actor2 )
 	{

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -99,17 +99,17 @@
 		}
 		else
 		{
-			ret = ::Math.round(this.m.Reach / count);
+			ret = ::Math.round(ret / count);
 		}
 
 		if (this.isItemType(::Const.Items.ItemType.MeleeWeapon))
 		{
-			if (this.m.Reach < 5 && this.isItemType(::Const.Items.ItemType.TwoHanded))
+			if (ret < 5 && this.isItemType(::Const.Items.ItemType.TwoHanded))
 			{
 				ret = 5;
 			}
 
-			if (this.isAoE() || (this.getRangeMax() > 1 && this.m.Reach < 6))
+			if (this.isAoE() || (this.getRangeMax() > 1 && ret < 6))
 			{
 				ret += 1;
 			}

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		if (this.m.Reach == 0 && this.isItemType(::Const.Items.ItemType.MeleeWeapon))
+		if (this.m.Reach == null)
 		{
 			this.assignDefaultReach();
 		}
@@ -10,7 +10,7 @@
 });
 
 ::Reforged.HooksMod.hook("scripts/items/weapons/weapon", function(q) {
-	q.m.Reach <- 0;
+	q.m.Reach <- null;
 
 	q.getTooltip = @(__original) function()
 	{
@@ -75,6 +75,8 @@
 
 	q.assignDefaultReach <- function()
 	{
+		this.m.Reach = 0;
+
 		local count = 0.0;
 		foreach (weaponType, reach in ::Reforged.Reach.WeaponTypeDefault)
 		{

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -4,7 +4,8 @@
 		__original();
 		if (this.m.Reach < 0)
 		{
-			this.m.Reach += ::Math.max(0, 999 + this.getDefaultReach());
+			this.m.Reach += 999 + this.getDefaultReach();
+			this.m.Reach = ::Math.max(0, this.m.Reach);
 		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -2,15 +2,15 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		if (this.m.Reach == null)
+		if (this.m.Reach < 0)
 		{
-			this.assignDefaultReach();
+			this.m.Reach += ::Math.max(0, 999 + this.getDefaultReach());
 		}
 	}
 });
 
 ::Reforged.HooksMod.hook("scripts/items/weapons/weapon", function(q) {
-	q.m.Reach <- null;
+	q.m.Reach <- -999;
 
 	q.getTooltip = @(__original) function()
 	{
@@ -73,9 +73,9 @@
 		return this.m.Reach;
 	}
 
-	q.assignDefaultReach <- function()
+	q.getDefaultReach <- function()
 	{
-		this.m.Reach = 0;
+		local ret = 0;
 
 		local count = 0.0;
 		foreach (weaponType, reach in ::Reforged.Reach.WeaponTypeDefault)
@@ -83,33 +83,37 @@
 			if (this.isWeaponType(::Const.Items.WeaponType[weaponType]))
 			{
 				count++;
-				this.m.Reach += reach;
+				ret += reach;
 			}
 		}
 
+		// If this weapon is of a weapontype for which we don't have a default
+		// reach defined, then fallback to certain hardcoded reach values
 		if (count == 0)
 		{
 			if (this.isItemType(::Const.Items.ItemType.MeleeWeapon))
 			{
-				this.m.Reach = this.isItemType(::Const.Items.ItemType.TwoHanded) ? 5 : 4;
+				ret = this.isItemType(::Const.Items.ItemType.TwoHanded) ? 5 : 4;
 			}
 		}
 		else
 		{
-			this.m.Reach = ::Math.round(this.m.Reach / count);
+			ret = ::Math.round(this.m.Reach / count);
 		}
 
 		if (this.isItemType(::Const.Items.ItemType.MeleeWeapon))
 		{
 			if (this.m.Reach < 5 && this.isItemType(::Const.Items.ItemType.TwoHanded))
 			{
-				this.m.Reach = 5;
+				ret = 5;
 			}
 
 			if (this.isAoE() || (this.getRangeMax() > 1 && this.m.Reach < 6))
 			{
-				this.m.Reach += 1;
+				ret += 1;
 			}
 		}
+
+		return ret;
 	}
 });

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -85,7 +85,17 @@
 			}
 		}
 
-		this.m.Reach = ::Math.round(this.m.Reach / count);
+		if (count == 0)
+		{
+			if (this.isItemType(::Const.Items.ItemType.MeleeWeapon))
+			{
+				this.m.Reach = this.isItemType(::Const.Items.ItemType.TwoHanded) ? 5 : 4;
+			}
+		}
+		else
+		{
+			this.m.Reach = ::Math.round(this.m.Reach / count);
+		}
 
 		if (this.isItemType(::Const.Items.ItemType.MeleeWeapon))
 		{

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -1,5 +1,16 @@
+::Reforged.HooksMod.hookTree("scripts/items/weapons/weapon", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		if (this.m.Reach == 0 && this.isItemType(::Const.Items.ItemType.MeleeWeapon))
+		{
+			this.assignDefaultReach();
+		}
+	}
+});
+
 ::Reforged.HooksMod.hook("scripts/items/weapons/weapon", function(q) {
-	q.m.Reach <- 1;
+	q.m.Reach <- 0;
 
 	q.getTooltip = @(__original) function()
 	{
@@ -60,5 +71,33 @@
 	q.getReach <- function()
 	{
 		return this.m.Reach;
+	}
+
+	q.assignDefaultReach <- function()
+	{
+		local count = 0.0;
+		foreach (weaponType, reach in ::Reforged.Reach.WeaponTypeDefault)
+		{
+			if (this.isWeaponType(::Const.Items.WeaponType[weaponType]))
+			{
+				count++;
+				this.m.Reach += reach;
+			}
+		}
+
+		this.m.Reach = ::Math.round(this.m.Reach / count);
+
+		if (this.isItemType(::Const.Items.ItemType.MeleeWeapon))
+		{
+			if (this.m.Reach < 5 && this.isItemType(::Const.Items.ItemType.TwoHanded))
+			{
+				this.m.Reach = 5;
+			}
+
+			if (this.isAoE() || (this.getRangeMax() > 1 && this.m.Reach < 6))
+			{
+				this.m.Reach += 1;
+			}
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -11,6 +11,8 @@
 });
 
 ::Reforged.HooksMod.hook("scripts/items/weapons/weapon", function(q) {
+	// We use an arbitrary large negative number (instead of e.g. null) so that
+	// arithmetic operations can be performed by mods on individual weapons.
 	q.m.Reach <- -999;
 
 	q.getTooltip = @(__original) function()


### PR DESCRIPTION
This should cover all melee weapons added by mods (unless they use a WeaponType we are not aware of) and assign them an appropriate Reach value.

In my testing this produced very similar results for Reach for all weapons as to what we have manually set currently in Reforged.