### PR TITLE
refactor(balance): reduce idealsize of barbarian parties by 20%

### DIFF
--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/barbarian_parties.nut
@@ -11,7 +11,15 @@ local parties = [
 			{ BaseID = "UnitBlock.RF.BarbarianSupport", RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
 			{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
 			{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
-		]
+		],
+		generateIdealSize = function()
+		{
+			if (!("Assets" in ::World) || ::World.Assets == null) return ::DynamicSpawns.Const.MainMenuIdealSize;	// fix for when we test this framework in the main menu
+
+			local maximumFieldableBrothers = ::Math.min(::World.getPlayerRoster().getAll().len(), ::World.Assets.getBrothersMaxInCombat());
+			local cappedBrotherAmount = ::Math.max(8, maximumFieldableBrothers * 0.8);
+			return ::Math.ceil(maximumFieldableBrothers);
+		}
 	},
 	{
 		ID = "BarbarianHunters",
@@ -23,7 +31,15 @@ local parties = [
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
 			{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.20, RatioMax = 0.45 }
-		]
+		],
+		generateIdealSize = function()
+		{
+			if (!("Assets" in ::World) || ::World.Assets == null) return ::DynamicSpawns.Const.MainMenuIdealSize;	// fix for when we test this framework in the main menu
+
+			local maximumFieldableBrothers = ::Math.min(::World.getPlayerRoster().getAll().len(), ::World.Assets.getBrothersMaxInCombat());
+			local cappedBrotherAmount = ::Math.max(8, maximumFieldableBrothers * 0.8);
+			return ::Math.ceil(maximumFieldableBrothers);
+		}
 	},
 	{
 		ID = "BarbarianKing",


### PR DESCRIPTION
This is one method of addressing the barbarian spawn behavior

In Essence this change reduces the idealsize of barbarian parties by 20%.

However it also partially fixes a bug in the dynamic spawn framework. Because currently EVERY party has an idealsize of 12 (or 14/16 for manhunter/militia) and then 50% more for locations.
Idealsize was meant to be at most that number, but at least how many brothers the player actually has.

