### PR TITLE
Fix flaming arrow fire damage

### DIFF
--- a/mod_reforged/hooks/config/tactical_entity_common.nut
+++ b/mod_reforged/hooks/config/tactical_entity_common.nut
@@ -1,5 +1,6 @@
 // We overwrite the vanilla function to remove all damage multiplier and add the burning damage type
-::Const.Tactical.Common.onApplyFire = function( _tile, _entity )
+// We add a new optional parameter so that the fire damage can sometimes be attributed to its source
+::Const.Tactical.Common.onApplyFire = function( _tile, _entity, _attacker = null )
 {
 	if (_entity.getCurrentProperties().IsImmuneToFire) return;
 
@@ -22,7 +23,7 @@
 	hitInfo.FatalityChanceMult = 0.0;
 	hitInfo.Injuries = ::Const.Injury.Burning;
 	hitInfo.IsPlayingArmorSound = false;
-	_entity.onDamageReceived(_entity, null, hitInfo);
+	_entity.onDamageReceived(_attacker, null, hitInfo);
 
 	if ((!_entity.isAlive() || _entity.isDying()) && !_entity.isPlayerControlled() && (_tile.Properties.Effect == null || _tile.Properties.Effect.IsByPlayer))
 	{

--- a/scripts/skills/perks/perk_rf_flaming_arrows.nut
+++ b/scripts/skills/perks/perk_rf_flaming_arrows.nut
@@ -154,7 +154,7 @@ this.perk_rf_flaming_arrows <- ::inherit("scripts/skills/skill", {
 
 			if (tile.IsOccupiedByActor)
 			{
-				::Const.Tactical.Common.onApplyFire(tile, tile.getEntity());
+				::Const.Tactical.Common.onApplyFire(tile, tile.getEntity(), _data.User);
 			}
 		}
 


### PR DESCRIPTION
Currently the fire damage inflicted on impact by the flaming arrow perk does not know who caused it.
With this fix we can pass an optional third argument to onApplyFire, which is the _attacker that this damage should be attributed to.
This fix will now allow kills with the fire portion of flaming arrow to trigger Killing Frenzy or Berserk.

On the flipside this breaks the vanilla convention a little bit, where the source of the fire damage was always equal to the receiver of the fire damage.
I argue that this makes no sense though. I rather have the source be null, than someone unrelated. The mortar impact damage source is also null so it's not like this breaks any mods