### PR TITLE
refactor: replace morale progressbar on turn sequence bar with reach

### DIFF
--- a/mod_reforged/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/mod_reforged/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -23,6 +23,22 @@
 		__original();
 	}
 
+	q.convertEntityToUIData = @(__original) function( _entity, isLastEntity = false )
+	{
+		local ret = __original(_entity, isLastEntity);
+
+		// Replace Morale values with Reach values. Morale is no longer displayed as a bar
+		local currentProperties = _entity.getCurrentProperties();
+		local reach = currentProperties.getReach();
+		local reachAtk = currentProperties.OffensiveReachIgnore;
+		local reachDef = currentProperties.DefensiveReachIgnore;
+		ret.morale = reach;
+		ret.moraleMax = 15; // arbitrary maximum value
+		ret.moraleLabel = reach + " (" + reachAtk + ", " + reachDef + ")";
+
+		return ret;
+	}
+
 	// We replace the vanilla function for performance reason and because it is a simple function. We don't want to query an entitys skills twice for no reason.
 	q.convertEntityStatusEffectsToUIData = @() function( _entity )
 	{

--- a/ui/mods/mod_reforged/generic.css
+++ b/ui/mods/mod_reforged/generic.css
@@ -205,7 +205,9 @@
 .ui-control-stats-progressbar.rf_reach,
 .ui-control-stats-progressbar-preview.rf_reach
 {
-	background-color: #7a1e12;
+    background-image: url("coui://gfx/ui/skin/inventory_bar_fill_neutral_127.png");
+    background-size: 12.7rem 2.2rem;
+    background-repeat: no-repeat;
 }
 .ui-control.progressbar.rf_reach .normal-bar,
 .ui-control.progressbar.rf_reach .preview-bar

--- a/ui/mods/mod_reforged/js_hooks/screens/tactical/modules/tactical_screen_turnsequencebar/turnsequencebar_module.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/tactical/modules/tactical_screen_turnsequencebar/turnsequencebar_module.js
@@ -1,6 +1,9 @@
 Reforged.Hooks.TacticalScreenTurnSequenceBarModule_createDIV = TacticalScreenTurnSequenceBarModule.prototype.createDIV;
 TacticalScreenTurnSequenceBarModule.prototype.createDIV = function (_parentDiv)
 {
+	this.mLeftStatsRows["Morale"].ImagePath = Path.GFX + Asset.rf_Reach;
+	this.mLeftStatsRows["Morale"].StyleName = ProgressbarStyleIdentifier.rf_Reach;
+
 	Reforged.Hooks.TacticalScreenTurnSequenceBarModule_createDIV.call(this, _parentDiv);
 
 	// Declare Variables
@@ -52,6 +55,16 @@ TacticalScreenTurnSequenceBarModule.prototype.bindTooltips = function ()
 {
 	this.mWaitTurnAllButton.bindTooltip({ contentType: 'msu-generic', modId: Reforged.ID, elementId: "Tactical.Button.WaitTurnAllButton" });
 	Reforged.Hooks.TacticalScreenTurnSequenceBarModule_bindTooltips.call(this);
+
+	$.each(this.mLeftStatsRows, function (_key, _value)
+	{
+		if (_value.StyleName == ProgressbarStyleIdentifier.rf_Reach)
+		{
+			_value.Row.unbindTooltip();
+			_value.Row.bindTooltip({ contentType: 'msu-generic', modId: Reforged.ID, elementId: "Concept.Reach" });
+			return false;	// break out of the for loop early as we are done
+		}
+	});
 }
 
 Reforged.Hooks.TacticalScreenTurnSequenceBarModule_unbindTooltips = TacticalScreenTurnSequenceBarModule.prototype.unbindTooltips;


### PR DESCRIPTION
When Taro did the same for the character screen he opted to send new Reach entries via the data structure to js.
For this change I decided to instead replace the existing morale values as I found that easier to implement and unlikely to cause issues.

This is how it looks now with this PR:
![image](https://github.com/user-attachments/assets/faf5daea-78eb-4249-a6c3-7fc59af8930f)

Here is how it lookes after doing Bagels issue
![image](https://github.com/user-attachments/assets/7cb222b7-7653-4e5d-9f57-ddf303b3a669)

Here Reach looks in the character screen (before this PR):
![image](https://github.com/user-attachments/assets/7785becb-f985-4417-9a4f-a82200c8c5ec)



