### PR TITLE
refactor: rename ranged perk group and exclusive and shared collections

### DIFF
--- a/scripts/mods/mod_reforged/perk_group_collections/pgc_rf_exclusive_1.nut
+++ b/scripts/mods/mod_reforged/perk_group_collections/pgc_rf_exclusive_1.nut
@@ -3,7 +3,7 @@ this.pgc_rf_exclusive_1 <- ::inherit(::DynamicPerks.Class.PerkGroupCollection, {
 	function create()
 	{
 		this.m.ID = "pgc.rf_exclusive_1";
-		this.m.Name = "Profession";
+		this.m.Name = "Exclusive";
 		this.m.OrderOfAssignment = 1;
 		this.m.Min = 0;
 		this.m.TooltipPrefix = "%name%";

--- a/scripts/mods/mod_reforged/perk_group_collections/pgc_rf_shared_1.nut
+++ b/scripts/mods/mod_reforged/perk_group_collections/pgc_rf_shared_1.nut
@@ -3,7 +3,7 @@ this.pgc_rf_shared_1 <- ::inherit(::DynamicPerks.Class.PerkGroupCollection, {
 	function create()
 	{
 		this.m.ID = "pgc.rf_shared_1";
-		this.m.Name = "Trait";
+		this.m.Name = "Shared";
 		this.m.OrderOfAssignment = 2;
 		this.m.Min = 2;
 		this.m.TooltipPrefix = "He";

--- a/scripts/mods/mod_reforged/perk_groups/pg_rf_ranged.nut
+++ b/scripts/mods/mod_reforged/perk_groups/pg_rf_ranged.nut
@@ -3,7 +3,7 @@ this.pg_rf_ranged <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 	function create()
 	{
 		this.m.ID = "pg.rf_ranged";
-		this.m.Name = "Ranged Weapons";
+		this.m.Name = "Ranged Combat";
 		this.m.Icon = "ui/perk_groups/rf_ranged.png";
 		this.m.Tree = [
 			[],


### PR DESCRIPTION
This is a small change to the names of the ranged and shield perk groups.

I suggest Ranged Weapons be renamed to Ranged Fighting and Shield be renamed to Shield Fighting

I think this style of group name fits better with the other two groups in this category, Swift Strikes and Powerful Strikes.