### PR TITLE
Feat reach base modifier values

### DIFF
--- a/mod_reforged/config/z_nested_tooltips.nut
+++ b/mod_reforged/config/z_nested_tooltips.nut
@@ -93,7 +93,24 @@ local getThresholdForInjury = function( _script )
 		InjuryTemporary = ::MSU.Class.BasicTooltip("Temporary Injury", ::Reforged.Mod.Tooltips.parseString("Temporary injuries are received during combat when the damage to [Hitpoints|Concept.Hitpoints] received by a character exceeds the injury threshold. These injuries heal over time, but can be treated at a Temple for faster healing."))
 		InjuryPermanent = ::MSU.Class.BasicTooltip("Permanent Injury", ::Reforged.Mod.Tooltips.parseString("Permanent injuries are received when a character is \'struck down\' during combat instead of being killed. These injuries, and the maluses they incur, are forever.")),
 		InjuryThreshold = ::MSU.Class.BasicTooltip("Injury Threshold", ::Reforged.Mod.Tooltips.parseString("If the damage received to [Hitpoints|Concept.Hitpoints] is at least " + ::MSU.Text.colorNegative(::Const.Combat.InjuryMinDamage) + " and is greater than a certain percentage of the current [Hitpoints,|Concept.Hitpoints] the character receives an [injury.|Concept.InjuryTemporary] This percentage can be modified by certain [perks|Concept.Perk] or traits of both the attacker and the target.\n\nCertain [injuries|Concept.InjuryTemporary] require this percentage to be at least a certain value before they can be inflicted, with heavier [injuries|Concept.InjuryTemporary] requiring a higher percentage.\n\nFor example the threshold for [Cut Arm|Skill+cut_arm_injury] is " + ::MSU.Text.colorNegative(getThresholdForInjury("injury/cut_arm_injury") + "%") + " and that of [Split Hand|Skill+split_hand_injury] is " + ::MSU.Text.colorNegative(getThresholdForInjury("injury/split_hand_injury") + "%") + ".")),
-		Reach = ::MSU.Class.BasicTooltip("Reach", ::Reforged.Mod.Tooltips.parseString("Reach is a depiction of how far a character\'s attacks can reach, making melee combat easier against targets with shorter reach.\n\n[Melee skill|Concept.MeleeSkill] is increased when attacking opponents with shorter reach, and reduced against opponents with longer reach. Reach has diminishing returns, starting at " + ::Reforged.Reach.BonusPerReach + " and dropping by 1 to a minimum of 1. It only applies when attacking a target adjacent to you or up to 2 tiles away with nothing between you and the target.\n\nAfter a successful hit, the target\'s [Reach Advantage|Concept.ReachAdvantage] is lost until the attacker waits or ends their turn.\n\nShields can negate some or all of the target\'s [Reach Advantage.|Concept.ReachAdvantage] Characters who are rooted have their Reach halved. Those without an [attack of opportunity|Concept.ZoneOfControl] have no Reach.")),
+		Reach = ::MSU.Class.CustomTooltip(function(_data){
+			local ret = [
+			{
+				id = 1,
+				type = "title",
+				text = "Reach"
+			},
+			{
+				id = 2,
+				type = "description",
+				text = ::Reforged.Mod.Tooltips.parseString("Reach is a depiction of how far a character\'s attacks can reach, making melee combat easier against targets with shorter reach.\n\n[Melee skill|Concept.MeleeSkill] is increased when attacking opponents with shorter reach, and reduced against opponents with longer reach. Reach has diminishing returns, starting at " + ::Reforged.Reach.BonusPerReach + " and dropping by 1 to a minimum of 1. It only applies when attacking a target adjacent to you or up to 2 tiles away with nothing between you and the target.\n\nAfter a successful hit, the target\'s [Reach Advantage|Concept.ReachAdvantage] is lost until the attacker waits or ends their turn.\n\nShields can negate some or all of the target\'s [Reach Advantage.|Concept.ReachAdvantage] Characters who are rooted have their Reach halved. Those without an [attack of opportunity|Concept.ZoneOfControl] have no Reach.")
+			}]
+			if ("entityId" in _data && "TooltipEvents" in this.getroottable())
+			{
+				ret.extend(::TooltipEvents.getBaseAttributesTooltip( _data.entityId, _data.elementId, null));
+			}
+			return ret;
+		}),
 		ReachIgnoreOffensive = ::MSU.Class.BasicTooltip("Offensive Reach Ignore", ::Reforged.Mod.Tooltips.parseString(@"This represents the amount of [Reach Disadvantage|Concept.ReachDisadvantage] that a character can ignore when attacking a target with higher [Reach.|Concept.Reach]")),
 		ReachIgnoreDefensive = ::MSU.Class.BasicTooltip("Defensive Reach Ignore", ::Reforged.Mod.Tooltips.parseString(@"This represents the amount of [Reach Disadvantage|Concept.ReachDisadvantage] that a character can ignore when defending against an attacker who has higher [Reach.|Concept.Reach]")),
 		ReachAdvantage = ::MSU.Class.BasicTooltip("Reach Advantage", ::Reforged.Mod.Tooltips.parseString("A character is considered to have Reach Advantage when their [Reach|Concept.Reach] is greater than that of the other character during an attack. The Reach Advantage in this case refers to the difference in the two characters' [Reach|Concept.Reach] values.\n\nIf a character has a shield equipped, the shield can help negate the Reach Advantage of an attacker, and with the [Duelist|Perk+perk_duelist] perk, can also help negate that of a target.")),

--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -44,6 +44,20 @@
 		return ret;
 	}
 
+// MSU Functions
+	q.onQueryMSUTooltipData = @(__original) function( _data )
+	{
+		local ret = __original(_data);
+
+		if (ret != null)
+		{
+			local entity = "entityId" in _data ? _data.entityId : null;	// Some MSU tooltips have no entity
+			ret.extend(this.getBaseAttributesTooltip( entity, _data.elementId, null ));
+		}
+
+		return ret;
+	}
+
 // New Functions
 	q.getBaseAttributesTooltip <- function( _entityId, _elementId, _elementOwner )
 	{
@@ -187,6 +201,42 @@
 						type = "text",
 						icon = "ui/icons/bravery.png",
 						text = "Modifier: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().getBravery() - entity.getBaseProperties().Bravery, {AddSign = true})
+					}
+				];
+			case "Concept.Reach":
+				local weapon = entity.getMainhandItem();
+				local weaponReach = weapon == null ? 0 : weapon.getReach();
+				local reachModifier = entity.getCurrentProperties().getReach() - entity.getBaseProperties().Reach - weaponReach;
+				return [
+					{
+						id = 3,
+						type = "text",
+						icon = "ui/icons/rf_reach.png",
+						text = "Base: " + ::MSU.Text.colorizeValue(entity.getBaseProperties().Reach)
+					},
+					{
+						id = 3,
+						type = "text",
+						icon = "ui/icons/rf_reach.png",
+						text = "Weapon: " + ::MSU.Text.colorizeValue(weaponReach)
+					},
+					{
+						id = 3,
+						type = "text",
+						icon = "ui/icons/rf_reach.png",
+						text = "Modifier: " + ::MSU.Text.colorizeValue(reachModifier, {AddSign = true})
+					},
+					{
+						id = 4,
+						type = "text",
+						icon = "ui/icons/rf_reach_attack.png",
+						text = "Offensive: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().OffensiveReachIgnore, {AddSign = true})
+					},
+					{
+						id = 5,
+						type = "text",
+						icon = "ui/icons/rf_reach_defense.png",
+						text = "Defensive: " + ::MSU.Text.colorizeValue(entity.getCurrentProperties().DefensiveReachIgnore, {AddSign = true})
 					}
 				];
 		}

--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -44,20 +44,6 @@
 		return ret;
 	}
 
-// MSU Functions
-	q.onQueryMSUTooltipData = @(__original) function( _data )
-	{
-		local ret = __original(_data);
-
-		if (ret != null)
-		{
-			local entity = "entityId" in _data ? _data.entityId : null;	// Some MSU tooltips have no entity
-			ret.extend(this.getBaseAttributesTooltip( entity, _data.elementId, null ));
-		}
-
-		return ret;
-	}
-
 // New Functions
 	q.getBaseAttributesTooltip <- function( _entityId, _elementId, _elementOwner )
 	{

--- a/ui/mods/mod_reforged/js_hooks/screens/character/modules/character_screen_left_panel/character_screen_stats_module.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/character/modules/character_screen_left_panel/character_screen_stats_module.js
@@ -19,13 +19,13 @@ CharacterScreenStatsModule.prototype.setProgressbarValues = function (_data)
 		}
 		else
 		{
-			_value.Row.bindTooltip({ entityId: entityID, contentType: 'ui-element', elementId: _value.TooltipId });
+			_value.Row.bindTooltip({ contentType: 'ui-element', elementId: _value.TooltipId, entityId: entityID });
 		}
 	});
 
 	$.each(this.mMiddleStatsRows, function (_key, _value)
 	{
-		_value.Row.bindTooltip({ entityId: entityID, contentType: 'ui-element', elementId: _value.TooltipId });
+		_value.Row.bindTooltip({ contentType: 'ui-element', elementId: _value.TooltipId, entityId: entityID });
 	});
 }
 

--- a/ui/mods/mod_reforged/js_hooks/screens/character/modules/character_screen_left_panel/character_screen_stats_module.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/character/modules/character_screen_left_panel/character_screen_stats_module.js
@@ -15,12 +15,12 @@ CharacterScreenStatsModule.prototype.setProgressbarValues = function (_data)
 	{
 		if (_value.TooltipId == "character-stats.Morale")
 		{
-			_value.Row.bindTooltip({ contentType: 'msu-generic', modId: Reforged.ID, elementId: "Concept.Reach" });
+			_value.Row.bindTooltip({ contentType: 'msu-generic', modId: Reforged.ID, elementId: "Concept.Reach", entityId: entityID });
 		}
 		else
 		{
 			_value.Row.bindTooltip({ entityId: entityID, contentType: 'ui-element', elementId: _value.TooltipId });
-		}		
+		}
 	});
 
 	$.each(this.mMiddleStatsRows, function (_key, _value)

--- a/ui/mods/mod_reforged/js_hooks/screens/character/modules/character_screen_left_panel/character_screen_stats_module.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/character/modules/character_screen_left_panel/character_screen_stats_module.js
@@ -36,18 +36,3 @@ CharacterScreenStatsModule.prototype.createDIV = function (_parentDiv)
 	this.mLeftStatsRows["Morale"].StyleName = ProgressbarStyleIdentifier.rf_Reach;
 	Reforged.Hooks.CharacterScreenStatsModule_createDIV.call(this, _parentDiv);
 }
-
-Reforged.Hooks.CharacterScreenStatsModule_setupEventHandler = CharacterScreenStatsModule.prototype.setupEventHandler;
-CharacterScreenStatsModule.prototype.setupEventHandler = function ()
-{
-	Reforged.Hooks.CharacterScreenStatsModule_setupEventHandler.call(this);
-	$.each(this.mLeftStatsRows, function (_key, _value)
-	{
-		if (_value.StyleName == ProgressbarStyleIdentifier.rf_Reach)
-		{
-			_value.Row.unbindTooltip();
-			_value.Row.bindTooltip({ contentType: 'msu-generic', modId: Reforged.ID, elementId: "Concept.Reach" });
-			return false;
-		}
-	});
-};


### PR DESCRIPTION
Just like for the other attributes in the characterscreen before, this PR aims to add information about base Reach, weapon Reach, Reach Modifier and Offensive/Defensive Reachignore to the tooltip for Reach.

- For that, we need to send the entityID as an argument into the bindTooltip.
- I also had to remove an old, seemingly redundant bindTooltip for Reach, that would have otherwise overwritten my adjust bindTooltip with the entityID.
- Finally I hooked the MSU function `onQueryMSUTooltipData` because tooltips like that for Reach pass through that event, where I can then add my additional info to them

I have not tested whether the Reach Modifier field works, but the other four seem to work fine.

![image](https://github.com/user-attachments/assets/28ddff65-c7e0-4554-b87c-c904d40e9c77)
