### PR TITLE
refactor: rework tempo to lose initiative upon ap recovery

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1991,7 +1991,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 				Type = ::UPD.EffectType.Passive,
 				Description = [
 					"Every hit or miss against any target increases your [Initiative|Concept.Initiative] by " + ::MSU.Text.colorPositive("+15") + ". This bonus is carried over into your next [turn|Concept.Turn] but only until the first skill used or upon [waiting|Concept.Wait] that [turn.|Concept.Turn]",
-					"The first two hits against opponents who act after you in the current [round|Concept.Round] recover " + ::MSU.Text.colorPositive("2") + " [Action Points|Concept.ActionPoints] each. A miss against any target or a hit against a target who acted before you increments the counter, but does not recover any [Action Points.|Concept.ActionPoints]"
+					"The first two hits against opponents who act after you in the current [round|Concept.Round] recover " + ::MSU.Text.colorPositive("2") + " [Action Points|Concept.ActionPoints] each but cause the [Initiative|Concept.Initiative] bonus to expire."
 				]
 			}
 		]

--- a/scripts/skills/perks/perk_rf_tempo.nut
+++ b/scripts/skills/perks/perk_rf_tempo.nut
@@ -52,7 +52,7 @@ this.perk_rf_tempo <- ::inherit("scripts/skills/skill", {
 				id = 11,
 				type = "text",
 				icon = "ui/icons/action_points.png",
-				text = ::Reforged.Mod.Tooltips.parseString("The next " + this.m.AttacksRemaining + " hit(s) against a target that acts after you in this [round|Concept.Round] will recover " + ::MSU.Text.colorPositive(this.m.APRecovery) + " [Action Points|Concept.ActionPoints]")
+				text = ::Reforged.Mod.Tooltips.parseString("The next " + this.m.AttacksRemaining + " hit(s) against a target that acts after you in this [round|Concept.Round] will recover " + ::MSU.Text.colorPositive(this.m.APRecovery) + " [Action Points|Concept.ActionPoints] but cause the [Initiative|Concept.Initiative] bonus to expire")
 			});
 		}
 
@@ -110,6 +110,8 @@ this.perk_rf_tempo <- ::inherit("scripts/skills/skill", {
 			{
 				local actor = this.getContainer().getActor();
 				actor.setActionPoints(::Math.min(actor.getActionPointsMax(), actor.getActionPoints() + this.m.APRecovery));
+				this.m.Stacks = 0;
+				return;
 			}
 		}
 
@@ -122,8 +124,6 @@ this.perk_rf_tempo <- ::inherit("scripts/skills/skill", {
 			return;
 
 		this.gainStackIfApplicable(_skill, _targetEntity);
-		if (this.m.AttacksRemaining > 0 && ::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()))
-			this.m.AttacksRemaining--;
 	}
 
 	// Lose all bonus upon equipping an invalid weapon


### PR DESCRIPTION
- The first 2 hits during a turn recover 2 AP each but cause the Initiative bonus to expire.
- Missed attacks no longer consume the attacks for AP recovery.