### PR TITLE
refactor: rework opportunist to reduce ap cost instead of ap recovery

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1652,8 +1652,8 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"The first 2 throwing attacks during a combat have their [Action Point|Concept.ActionPoints] costs " + ::MSU.Text.colorPositive("halved") + ".",
-				"When using a throwing weapon which uses ammo, every time you stand over an enemy\'s corpse during your [turn,|Concept.Turn] gain " + ::MSU.Text.colorPositive(1) + " ammo and restore " + ::MSU.Text.colorPositive(4) + " [Action Points.|Concept.ActionPoints] Afterward, the next throwing attack has its [Fatigue|Concept.Fatigue] cost " + ::MSU.Text.colorPositive("halved") + ".",
+				"Throwing attacks during the first [round|Concept.Round] of battle hvae their [Action Point|Concept.ActionPoints] costs " + ::MSU.Text.colorPositive("halved") + ".",
+				"When using a throwing weapon which uses ammo, whenever you end your movement over an enemy\'s corpse during your [turn,|Concept.Turn] recover " + ::MSU.Text.colorPositive(1) + " ammo. Immediately afterward, the next throwing attack costs " + ::MSU.Text.colorPositive("no") + " [ActionPoints|Concept.ActionPoints] and builds " + ::MSU.Text.colorPositive("50%") + " less [Fatigue.|Concept.Fatigue]",
 				"A corpse can only be used once per combat and cannot be used by multiple characters with this perk."
 			]
 		}]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1652,7 +1652,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Throwing attacks during the first [round|Concept.Round] of battle hvae their [Action Point|Concept.ActionPoints] costs " + ::MSU.Text.colorPositive("halved") + ".",
+				"The first two throwing attacks during a battle have their [Action Point|Concept.ActionPoints] costs " + ::MSU.Text.colorPositive("halved") + ". This effect only lasts until the end of your second [turn.|Concept.Turn]",
 				"When using a throwing weapon which uses ammo, whenever you end your movement over an enemy\'s corpse during your [turn,|Concept.Turn] recover " + ::MSU.Text.colorPositive(1) + " ammo. Immediately afterward, the next throwing attack costs " + ::MSU.Text.colorPositive("no") + " [ActionPoints|Concept.ActionPoints] and builds " + ::MSU.Text.colorPositive("50%") + " less [Fatigue.|Concept.Fatigue]",
 				"A corpse can only be used once per combat and cannot be used by multiple characters with this perk."
 			]

--- a/scripts/skills/perks/perk_rf_opportunist.nut
+++ b/scripts/skills/perks/perk_rf_opportunist.nut
@@ -124,7 +124,7 @@ this.perk_rf_opportunist <- ::inherit("scripts/skills/skill", {
 
 	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
 	{
-		if (this.m.AttacksRemaining != 0 && this.isSkillValid(_skill) && _skill.getActionPointCost() != 0 && !_forFree)
+		if (this.m.AttacksRemaining != 0 && this.isSkillValid(_skill))
 		{
 			this.m.AttacksRemaining--;
 		}

--- a/scripts/skills/perks/perk_rf_opportunist.nut
+++ b/scripts/skills/perks/perk_rf_opportunist.nut
@@ -18,7 +18,7 @@ this.perk_rf_opportunist <- ::inherit("scripts/skills/skill", {
 
 	function isHidden()
 	{
-		return !this.m.IsPrimed && (this.m.AttacksRemaining == 0 || this.m.TurnsRemaining == 0);
+		return !this.getContainer().getActor().isPlacedOnMap() || (!this.m.IsPrimed && (this.m.AttacksRemaining == 0 || this.m.TurnsRemaining == 0));
 	}
 
 	function getTooltip()


### PR DESCRIPTION
- Instead of halving the AP cost of the first 2 throwing attacks in the battle, it now halves the cost of all throwing attacks but only during the first round of battle.
- Instead of recovering 4 AP after stepping on a corpse, it now makes the next throwing attack cost no AP. (Still reduces its Fatigue cost by 50% like before).

The first point is somewhat of a sidegrade as you can now potentially unleash 4 throwing attacks during the first turn if you want if you don't move from your position. But it makes more sense thematically to me as an "opportunistic" playstyle and doesn't suffer from the weird situation we have currently where you are fatigued out after 4 rounds and still have the halved AP cost for the throwing attacks.

The second point reduces the silly chain of corpse hopping that can lead to extremely long turns as you keep recovering Action Points and may have other perks which reduce the cost of your attacks.