### PR TITLE
refactor: add range tooltip line for many enemy-only skills

### DIFF
--- a/mod_reforged/hooks/skills/actives/charm_skill.nut
+++ b/mod_reforged/hooks/skills/actives/charm_skill.nut
@@ -16,6 +16,12 @@
 			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("Will trigger up to " + ::MSU.Text.colorNegative("2") + " [morale checks|Concept.Morale] on the target and if any are successful, the target gains the [Charmed|Skill+charmed_effect] effect")
 		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/fire_mortar_skill.nut
+++ b/mod_reforged/hooks/skills/actives/fire_mortar_skill.nut
@@ -17,6 +17,12 @@
 			text = ::Reforged.Mod.Tooltips.parseString("Will mark a tile and its surrounding tiles for impact for this character\'s next [turn|Concept.Turn]. Upon impact, characters in the tiles take damage and may be [Shellshocked|Skill+shellshocked_effect]")
 		});
 		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
+		ret.push({
 			id = 20,
 			type = "text",
 			icon = "ui/icons/warning.png",

--- a/mod_reforged/hooks/skills/actives/goblin_whip.nut
+++ b/mod_reforged/hooks/skills/actives/goblin_whip.nut
@@ -16,6 +16,12 @@
 			icon = "ui/icons/bravery.png",
 			text = ::Reforged.Mod.Tooltips.parseString("Raises the target\'s [morale|Concept.Morale] to Confident unless they are Fleeing in which case raises it to Steady instead")
 		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/grant_night_vision_skill.nut
+++ b/mod_reforged/hooks/skills/actives/grant_night_vision_skill.nut
@@ -16,6 +16,12 @@
 			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("The target and allies adjacent to the target will no longer be affected by [Nighttime|Skill+night_effect] for the course of this battle")
 		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/hex_skill.nut
+++ b/mod_reforged/hooks/skills/actives/hex_skill.nut
@@ -16,6 +16,12 @@
 			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("The target gains the [Hex|Skill+hex_slave_effect]")
 		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/horrific_scream.nut
+++ b/mod_reforged/hooks/skills/actives/horrific_scream.nut
@@ -16,6 +16,14 @@
 			icon = "ui/icons/bravery.png",
 			text = ::Reforged.Mod.Tooltips.parseString("The target receives " + ::MSU.Text.colorNegative(4) + " mental [morale checks|Concept.Morale]")
 		});
+
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
+
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/insects_skill.nut
+++ b/mod_reforged/hooks/skills/actives/insects_skill.nut
@@ -16,6 +16,12 @@
 			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("The target gains the [Swarm of Insects|Skill+insect_swarm_effect] effect")
 		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/miasma_skill.nut
+++ b/mod_reforged/hooks/skills/actives/miasma_skill.nut
@@ -28,6 +28,12 @@
 			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("Blows away existing tile effects like Fire or Smoke")
 		});
+		ret.push({
+			id = 13,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/nightmare_skill.nut
+++ b/mod_reforged/hooks/skills/actives/nightmare_skill.nut
@@ -11,6 +11,12 @@
 	{
 		local ret = this.skill.getDefaultTooltip();
 		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
+		ret.push({
 			id = 20,
 			type = "text",
 			icon = "ui/icons/warning.png",

--- a/mod_reforged/hooks/skills/actives/possess_undead_skill.nut
+++ b/mod_reforged/hooks/skills/actives/possess_undead_skill.nut
@@ -16,6 +16,12 @@
 			icon = "ui/icons/warning.png",
 			text = ::Reforged.Mod.Tooltips.parseString("You gain the [Possessing Undead|Skill+possessing_undead_effect] effect and the target gains the [Possessed Undead|Skill+possessed_undead_effect] effect")
 		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		if (this.getContainer().getActor().isEngagedInMelee())
 		{
 			ret.push({

--- a/mod_reforged/hooks/skills/actives/raise_undead.nut
+++ b/mod_reforged/hooks/skills/actives/raise_undead.nut
@@ -17,6 +17,12 @@
 			icon = "ui/icons/warning.png",
 			text = ::Reforged.Mod.Tooltips.parseString("Raises the targeted resurrectable corpse as a wiederganger")
 		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/root_skill.nut
+++ b/mod_reforged/hooks/skills/actives/root_skill.nut
@@ -19,6 +19,12 @@
 			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("The target and all adjacent enemies receive the [Rooted|Skill+rooted_effect] effect")
 		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		return ret;
 	}
 

--- a/mod_reforged/hooks/skills/actives/sleep_skill.nut
+++ b/mod_reforged/hooks/skills/actives/sleep_skill.nut
@@ -16,6 +16,12 @@
 			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("The target receives a mental [morale check|Concept.Morale] with a greater penalty to [Resolve|Concept.Bravery] the closer they are to you. If successful, the target falls [asleep|Skill+sleeping_effect]")
 		});
+		ret.push({
+			id = 11,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
+		});
 		return ret;
 	}
 });

--- a/mod_reforged/hooks/skills/actives/throw_golem_skill.nut
+++ b/mod_reforged/hooks/skills/actives/throw_golem_skill.nut
@@ -23,6 +23,12 @@
 				type = "text",
 				icon = "ui/icons/special.png",
 				text = ::Reforged.Mod.Tooltips.parseString("Will reduce your size and spawn two " + ::Const.Strings.EntityNamePlural[entityType] + " of this size adjacent to you")
+			},
+			{
+				id = 12,
+				type = "text",
+				icon = "ui/icons/vision.png",
+				text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
 			}
 		]);
 		return ret;

--- a/mod_reforged/hooks/skills/actives/unstoppable_charge_skill.nut
+++ b/mod_reforged/hooks/skills/actives/unstoppable_charge_skill.nut
@@ -23,6 +23,12 @@
 				type = "text",
 				icon = "ui/icons/special.png",
 				text = ::Reforged.Mod.Tooltips.parseString("Knocked back targets will lose the [Shieldwall|Skill+shieldwall_effect], [Spearwall|Skill+spearwall_effect] and [Riposte|Skill+riposte_effect] effects")
+			},
+			{
+				id = 12,
+				type = "text",
+				icon = "ui/icons/vision.png",
+				text = "Has a range of " + ::MSU.Text.colorizeValue(this.getMaxRange()) + " tiles"
 			}
 		]);
 		return ret;


### PR DESCRIPTION
I only verified the tooltip working correctly for a Geist, but the code is copy-pasted to all other places so I assume all of them work correctly.