### PR TITLE
feat: add mod setting to control visibility of blueprints in taxidermist

### DIFF
--- a/mod_reforged/hooks/crafting/blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprint.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/crafting/blueprint", function(q) {
+// New Functions
+	// Return true, if the player has at least one ingredient needed for this blueprint
+	q.isPartlyCraftable <- function()
+	{
+		foreach (item in ::World.Assets.getStash().getItems())
+		{
+			if (item == null) continue;
+
+			foreach (c in this.m.PreviewComponents)
+			{
+				if (item.getID() == c.Instance.getID())
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+});

--- a/mod_reforged/hooks/crafting/crafting_manager.nut
+++ b/mod_reforged/hooks/crafting/crafting_manager.nut
@@ -1,0 +1,79 @@
+::Reforged.HooksMod.hook("scripts/crafting/crafting_manager", function(q) {
+	q.getQualifiedBlueprints = @(__original) function()
+	{
+		local settingValue = ::Reforged.Mod.ModSettings.getSetting("CraftingBlueprintVisibility").getValue();
+		switch (settingValue)
+		{
+			case "Vanilla":
+			{
+				return __original();
+			}
+			case "Always":
+			{
+				local ret = [];
+				foreach (b in this.m.Blueprints)
+				{
+					local oldTimesCrafted = b.m.TimesCrafted;
+					b.m.TimesCrafted = 1;	// We want to show all recipes and by setting TimesCrafted to 1, we trick Vanilla to do just that
+					if (b.isQualified())
+					{
+						ret.push(b);
+					}
+					b.m.TimesCrafted = oldTimesCrafted;
+				}
+				return ret;
+			}
+			case "One Ingredient Available":
+			{
+				local ret = [];
+				foreach (b in this.m.Blueprints)
+				{
+					if (b.isPartlyCraftable())
+					{
+						local oldTimesCrafted = b.m.TimesCrafted;
+						b.m.TimesCrafted = 1;	// We want to force-show this recipe, unless there is another custom visibilty rule
+						if (b.isQualified())
+						{
+							ret.push(b);
+						}
+						b.m.TimesCrafted = oldTimesCrafted;
+					}
+				}
+				return ret;
+			}
+			case "All Ingredients Available":
+			{
+				local ret = [];
+				foreach (b in this.m.Blueprints)
+				{
+					local oldTimesCrafted = b.m.TimesCrafted;
+					b.m.TimesCrafted = 0;	// We do not want to show recipes, just because we crafted them once before, so we trick Vanilla to not show those
+					if (b.isQualified())
+					{
+						ret.push(b);
+					}
+					b.m.TimesCrafted = oldTimesCrafted;
+				}
+				return ret;
+			}
+			default:
+			{
+				throw "Unknown setting value: " + settingValue;
+			}
+		}
+	}
+
+	// Rewrite Vanilla function to re-use the logic of getQualifiedBlueprints, instead of re-implementing it
+	q.getQualifiedBlueprintsForUI = @() function()
+	{
+		local ret = [];
+
+		foreach (blueprint in this.getQualifiedBlueprints())
+		{
+			ret.push(blueprint.getUIData());
+		}
+		ret.sort(this.onSortBlueprints);
+
+		return ret;
+	}
+});

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -14,6 +14,11 @@ tacticalTooltipPage.addBooleanSetting("TacticalTooltip_CollapseAsText", false, "
 tacticalTooltipPage.addBooleanSetting("ShowStatusPerkAndEffect", true, "Show Status Perk And Effect", "Some Perks are also Status Effects. Usually their Effect is hidden until some condition is fulfilled. When this setting is enabled, these perks show up in the Perks category even when they show up under Effects (e.g. when their effect is active). When disabled, when they appear under Effects, they will be hidden from the Perks category. This can help save space on the tooltip.");
 tacticalTooltipPage.addBooleanSetting("HeaderForEmptyCategories", false, "Show Header for empty categories");
 
+{	// Misc
+	local miscTooltipPage = ::Reforged.Mod.ModSettings.addPage("Misc");
+	miscTooltipPage.addEnumSetting("CraftingBlueprintVisibility", "One Ingredient Available", ["Always", "One Ingredient Available", "All Ingredients Available", "Vanilla"], "Blueprints Visible When", "Crafting Recipes in the Taxidermist will be displayed when this condition is met.\nNote that individual Blueprints (like Snake Oil) may still have custom rules preventing them from being shown.\n\n\'Vanilla\' means that the visibility behavior is unchanged from how it works in the base game.");
+}
+
 ::Reforged.Mod.Keybinds.addSQKeybind("Tactical_WaitRound", "h", ::MSU.Key.State.Tactical, function()
 {
 	if (this.m.MenuStack.hasBacksteps() || this.isInputLocked() || this.isInCharacterScreen())


### PR DESCRIPTION
**Always** treats all Blueprints in the game as if you've already crafted them once before
**One Ingredient Available** treats all Blueprints in the game, for which you have at least one Ingredient, as if you've already crafted them once before
**All Ingredient Available** treats all Blueprints in the game, as if you've never crafted them once before
**Vanilla** applies the Vanilla filtering behavior

This hook preserves any overwritten Qualified-behavior like that of Snake Oil. 
Those recipes will not show up, no matter what setting is active, if those overwritten rules forbid it.