### PR TITLE
feat: attribute projection setting and attribute base range display

### DIFF
--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -179,5 +179,7 @@
 		__original(_v);
 		local discoveredTalent = this.getSkills().getSkillByID("perk.rf_discovered_talent");
 		if (discoveredTalent != null) discoveredTalent.addStars();
+
+		this.getFlags().set("RF_HasSpentLevelUp", true);
 	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/character_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/character_background.nut
@@ -60,11 +60,15 @@
 	{
 		local ret = __original();
 
-		local player = this.getContainer().getActor();
-		if (::Const.XP.MaxLevelWithPerkpoints - player.getLevel() + player.getLevelUps() > 0)
+		if (::Reforged.Mod.ModSettings.getSetting("CharacterScreen_ShowAttributeProjection").getValue())
 		{
-			ret.extend(this.getProjectedAttributesTooltip());
+			local player = this.getContainer().getActor();
+			if (::Const.XP.MaxLevelWithPerkpoints - player.getLevel() + player.getLevelUps() > 0)
+			{
+				ret.extend(this.getProjectedAttributesTooltip());
+			}
 		}
+
 		return ret;
 	}
 })

--- a/mod_reforged/hooks/skills/backgrounds/character_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/character_background.nut
@@ -1,4 +1,16 @@
 ::Reforged.HooksMod.hook("scripts/skills/backgrounds/character_background", function(q) {
+	// Private
+	q.m.BaseAttributes <- {		// In Vanilla these are currently only defined within the buildAttributes() function of this class
+		Hitpoints = 	[50, 60],
+		Bravery = 		[30, 40],
+		Stamina = 		[90, 100],
+		MeleeSkill = 	[47, 57],
+		RangedSkill = 	[32, 42],
+		MeleeDefense = 	[0, 5],
+		RangedDefense = [0, 5],
+		Initiative = 	[100, 110],
+	}
+
 	q.create = @(__original) function()
 	{
 		__original();
@@ -53,12 +65,71 @@
 
 		return ret;
 	}
+
+	// If _hideRolledValues is true, then the actual base roll is hidden. This is important to not spoil the base roll information to the player during hiring
+	q.getBaseAttributesTooltip <- function( _hideRolledValues )
+	{
+		local baseProperties = this.getContainer().getActor().getBaseProperties();
+		local baseAttr = this.m.BaseAttributes;
+		local change = this.onChangeAttributes();
+
+		local function formatString( _img, _attrName )
+		{
+			local baseValue = _hideRolledValues ? "" : baseProperties[_attrName].tostring();
+			local minValue = baseAttr[_attrName][0] + change[_attrName][0];
+			local maxValue = baseAttr[_attrName][1] + change[_attrName][1];
+			return format("<span class='attributePredictionItem'><img src='coui://%s'/> <span class='attributePredictionSingle'>%s</span> <span class='attributePredictionRange'>[%i - %i]</span></span>", _img, baseValue, minValue, maxValue);
+		}
+
+		local html = "<div class='attributePredictionHeader'>Base Attribute Ranges for this Background:</div>";
+		html += "<div class='attributePredictionContainer'>";
+		html += formatString("gfx/ui/icons/health.png", "Hitpoints");
+		html += formatString("gfx/ui/icons/melee_skill.png", "MeleeSkill");
+		html += formatString("gfx/ui/icons/fatigue.png", "Stamina");
+		html += formatString("gfx/ui/icons/ranged_skill.png", "RangedSkill");
+		html += formatString("gfx/ui/icons/bravery.png", "Bravery");
+		html += formatString("gfx/ui/icons/melee_defense.png", "MeleeDefense");
+		html += formatString("gfx/ui/icons/initiative.png", "Initiative");
+		html += formatString("gfx/ui/icons/ranged_defense.png", "RangedDefense");
+
+		return [{
+			id = 4,
+			type = "description",
+			rawHTMLInText = true,
+			text = html,
+		}];
+	}
 });
 
 ::Reforged.HooksMod.hookTree("scripts/skills/backgrounds/character_background", function(q) {
+	q.getGenericTooltip = @(__original) function()
+	{
+		local ret = __original();
+
+		if (::Reforged.Mod.ModSettings.getSetting("CharacterScreen_ShowBaseAttributeRangesHiring").getValue())
+		{
+			ret.extend(this.getBaseAttributesTooltip(true));	// During hiring we only want to show the minimum and maximum range. Not the rolled value
+		}
+
+		return ret;
+	}
+
 	q.getTooltip = @(__original) function()
 	{
 		local ret = __original();
+
+		local showBaseAttributeRangeRegular = ::Reforged.Mod.ModSettings.getSetting("CharacterScreen_ShowBaseAttributeRangesRegular").getValue();
+		if (showBaseAttributeRangeRegular == "Always")
+		{
+			ret.extend(this.getBaseAttributesTooltip(false));
+		}
+		else if (showBaseAttributeRangeRegular == "Only New Recruits")
+		{
+			if (!this.getContainer().getActor().getFlags().has("RF_HasSpentLevelUp"))
+			{
+				ret.extend(this.getBaseAttributesTooltip(false));
+			}
+		}
 
 		if (::Reforged.Mod.ModSettings.getSetting("CharacterScreen_ShowAttributeProjection").getValue())
 		{

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -2,6 +2,10 @@
 	local characterScreenPage = ::Reforged.Mod.ModSettings.addPage("Character Screen");
 
 	characterScreenPage.addBooleanSetting("CharacterScreen_ShowAttributeProjection", true, "Show Attribute Projection", "If enabled, the character background tooltip will display projected attribute values, estimating how much each attribute could grow if all level-ups are invested into that attribute.");
+
+	characterScreenPage.addDivider("MiscDivider1");
+	characterScreenPage.addBooleanSetting("CharacterScreen_ShowBaseAttributeRangesHiring", true, "Show Base Attribute Ranges (Hiring)", "If enabled, the maximum and minimum Base Attribute Ranges for every background is displayed during Hiring, when hovering over the background icon.");
+	characterScreenPage.addEnumSetting("CharacterScreen_ShowBaseAttributeRangesRegular", "Only New Recruits", ["Always", "Only New Recruits", "Never"], "Show Base Attribute Ranges (Regular)", "When this condition is met, the minimum and maximum Base Attribute Ranges for backgrounds are displayed, when looking at their tooltips. \'Only New Recruits\' stops displaying the info, once you have spent one level-up.");
 }
 
 {	// Tactical Tooltips

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -1,22 +1,26 @@
-local characterScreenPage = ::Reforged.Mod.ModSettings.addPage("Character Screen");
+{	// Character Screen
+	local characterScreenPage = ::Reforged.Mod.ModSettings.addPage("Character Screen");
 
-characterScreenPage.addBooleanSetting("CharacterScreen_ShowAttributeProjection", true, "Show Attribute Projection", "If enabled, the character background tooltip will display projected attribute values, estimating how much each attribute could grow if all level-ups are invested into that attribute.");
+	characterScreenPage.addBooleanSetting("CharacterScreen_ShowAttributeProjection", true, "Show Attribute Projection", "If enabled, the character background tooltip will display projected attribute values, estimating how much each attribute could grow if all level-ups are invested into that attribute.");
+}
 
-local tacticalTooltipPage = ::Reforged.Mod.ModSettings.addPage("Tactical Tooltips");
+{	// Tactical Tooltips
+	local tacticalTooltipPage = ::Reforged.Mod.ModSettings.addPage("Tactical Tooltips");
 
-tacticalTooltipPage.addEnumSetting("TacticalTooltip_Attributes", "All", ["All", "AI Only", "Player Only", "None"], "Show Attributes", "Show attributes such as Melee Skill, Melee Defense etc. for entities in the Tactical Tooltip.");
-tacticalTooltipPage.addEnumSetting("TacticalTooltip_Effects", "All", ["All", "AI Only", "Player Only", "None"], "Show Effects", "Show status effects for entities in the Tactical Tooltip.");
-tacticalTooltipPage.addEnumSetting("TacticalTooltip_Perks", "All", ["All", "AI Only", "Player Only", "None"], "Show Perks", "Show perks for entities in the Tactical Tooltip.");
-tacticalTooltipPage.addEnumSetting("TacticalTooltip_EquippedItems", "All", ["All", "AI Only", "Player Only", "None"], "Show Equipped Items", "Show equipped items for entities in the Tactical Tooltip.");
-tacticalTooltipPage.addEnumSetting("TacticalTooltip_BagItems", "All", ["All", "AI Only", "Player Only", "None"], "Show Bag Items", "Show items in bag for entities in the Tactical Tooltip.");
-tacticalTooltipPage.addEnumSetting("TacticalTooltip_ActiveSkills", "All", ["All", "AI Only", "Player Only", "None"], "Show Active Skills", "Show all the usable active skills for entities in the Tactical Tooltip.");
+	tacticalTooltipPage.addEnumSetting("TacticalTooltip_Attributes", "All", ["All", "AI Only", "Player Only", "None"], "Show Attributes", "Show attributes such as Melee Skill, Melee Defense etc. for entities in the Tactical Tooltip.");
+	tacticalTooltipPage.addEnumSetting("TacticalTooltip_Effects", "All", ["All", "AI Only", "Player Only", "None"], "Show Effects", "Show status effects for entities in the Tactical Tooltip.");
+	tacticalTooltipPage.addEnumSetting("TacticalTooltip_Perks", "All", ["All", "AI Only", "Player Only", "None"], "Show Perks", "Show perks for entities in the Tactical Tooltip.");
+	tacticalTooltipPage.addEnumSetting("TacticalTooltip_EquippedItems", "All", ["All", "AI Only", "Player Only", "None"], "Show Equipped Items", "Show equipped items for entities in the Tactical Tooltip.");
+	tacticalTooltipPage.addEnumSetting("TacticalTooltip_BagItems", "All", ["All", "AI Only", "Player Only", "None"], "Show Bag Items", "Show items in bag for entities in the Tactical Tooltip.");
+	tacticalTooltipPage.addEnumSetting("TacticalTooltip_ActiveSkills", "All", ["All", "AI Only", "Player Only", "None"], "Show Active Skills", "Show all the usable active skills for entities in the Tactical Tooltip.");
 
-tacticalTooltipPage.addRangeSetting("CollapseEffectsWhenX", 5, 0, 20, 1, "Collapse Effects When", "While the number of effects is below this value all effects display their icon and use a separate line. Otherwise they combine into a single block of text in order to save space.");
-tacticalTooltipPage.addRangeSetting("CollapsePerksWhenX", 5, 0, 20, 1, "Collapse Perks When", "While the number of perks is below this value all perks display their icon and use a separate line. Otherwise they combine into a single block of text in order to save space.");
-tacticalTooltipPage.addRangeSetting("CollapseActivesWhenX", 5, 0, 20, 1, "Collapse Actives When", "While the number of active skills is below this value they display their icon and use a separate line. Otherwise they combine into a single block of text in order to save space.");
-tacticalTooltipPage.addBooleanSetting("TacticalTooltip_CollapseAsText", false, "Collapse as Text", "If enabled, then skills collapse using their names as text, otherwise they collapse using their icons.");
-tacticalTooltipPage.addBooleanSetting("ShowStatusPerkAndEffect", true, "Show Status Perk And Effect", "Some Perks are also Status Effects. Usually their Effect is hidden until some condition is fulfilled. When this setting is enabled, these perks show up in the Perks category even when they show up under Effects (e.g. when their effect is active). When disabled, when they appear under Effects, they will be hidden from the Perks category. This can help save space on the tooltip.");
-tacticalTooltipPage.addBooleanSetting("HeaderForEmptyCategories", false, "Show Header for empty categories");
+	tacticalTooltipPage.addRangeSetting("CollapseEffectsWhenX", 5, 0, 20, 1, "Collapse Effects When", "While the number of effects is below this value all effects display their icon and use a separate line. Otherwise they combine into a single block of text in order to save space.");
+	tacticalTooltipPage.addRangeSetting("CollapsePerksWhenX", 5, 0, 20, 1, "Collapse Perks When", "While the number of perks is below this value all perks display their icon and use a separate line. Otherwise they combine into a single block of text in order to save space.");
+	tacticalTooltipPage.addRangeSetting("CollapseActivesWhenX", 5, 0, 20, 1, "Collapse Actives When", "While the number of active skills is below this value they display their icon and use a separate line. Otherwise they combine into a single block of text in order to save space.");
+	tacticalTooltipPage.addBooleanSetting("TacticalTooltip_CollapseAsText", false, "Collapse as Text", "If enabled, then skills collapse using their names as text, otherwise they collapse using their icons.");
+	tacticalTooltipPage.addBooleanSetting("ShowStatusPerkAndEffect", true, "Show Status Perk And Effect", "Some Perks are also Status Effects. Usually their Effect is hidden until some condition is fulfilled. When this setting is enabled, these perks show up in the Perks category even when they show up under Effects (e.g. when their effect is active). When disabled, when they appear under Effects, they will be hidden from the Perks category. This can help save space on the tooltip.");
+	tacticalTooltipPage.addBooleanSetting("HeaderForEmptyCategories", false, "Show Header for empty categories");
+}
 
 {	// Misc
 	local miscTooltipPage = ::Reforged.Mod.ModSettings.addPage("Misc");

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -1,3 +1,7 @@
+local characterScreenPage = ::Reforged.Mod.ModSettings.addPage("Character Screen");
+
+characterScreenPage.addBooleanSetting("CharacterScreen_ShowAttributeProjection", true, "Show Attribute Projection", "If enabled, the character background tooltip will display projected attribute values, estimating how much each attribute could grow if all level-ups are invested into that attribute.");
+
 local tacticalTooltipPage = ::Reforged.Mod.ModSettings.addPage("Tactical Tooltips");
 
 tacticalTooltipPage.addEnumSetting("TacticalTooltip_Attributes", "All", ["All", "AI Only", "Player Only", "None"], "Show Attributes", "Show attributes such as Melee Skill, Melee Defense etc. for entities in the Tactical Tooltip.");


### PR DESCRIPTION
This PR does two things
- Add a Mod Setting for the already existing "Attribute Projection" tooltip in character backgrounds. With this the player can turn it on and off
- Add a new Base Attribute Range tooltip for backgrounds showing the minimum and maximum range of each Attribute. After hiring this will also show the current base attribute. In the Mod Settings the display can be changed.

## Mod Settings
![image](https://github.com/user-attachments/assets/a201098a-7bf7-4d8a-a45a-0dd6f39f8dab)

## Base Attribute Range:
### During Hiring
![image](https://github.com/user-attachments/assets/c26042d3-7e24-4c04-8065-cdf30fb7f541)

### After Hiring / Character Screen
![image](https://github.com/user-attachments/assets/746563a2-6bfd-4814-b3b3-b8fa7c641e3c)