### PR TITLE
fix(vanilla): missing isNull check during querySortedByItems

### DIFF
--- a/mod_reforged/hooks/skills/skill_container.nut
+++ b/mod_reforged/hooks/skills/skill_container.nut
@@ -31,4 +31,21 @@
 	{
 		this.callSkillsFunctionWhenAlive("onSkillsUpdated", null, false);
 	}
+
+	// Vanilla Fix: A missing 'isNull' in Vanillas implementation causes crashes and glitchy behavior in some situations
+	q.querySortedByItems = @(__original) function( _filter, _notFilter = 0 )
+	{
+		// Instead of overwriting the original function, we clean the WeakTableRefs in every skill, that are no longer valid anyways
+		foreach (skill in this.m.Skills)
+		{
+			if (::MSU.isNull(skill.getItem()))
+			{
+				// Vanilla only ever checks for '!= null' so that's what we prepare for them here
+				// We can't use the setItem function, because some skills have an inferior implementation, that wraps 'null' into a WeakTableRef again
+				skill.m.Item = null;
+			}
+		}
+
+		return __original(_filter, _notFilter);
+	}
 });


### PR DESCRIPTION
This fixes glitchy behavior when swapping equipped bandages This also fixes a rare crash during battle, when opening the inventory