### PR TITLE
fix: add safety check for skill containers before spinning the flail

### DIFF
--- a/scripts/skills/perks/perk_rf_flail_spinner.nut
+++ b/scripts/skills/perks/perk_rf_flail_spinner.nut
@@ -87,7 +87,11 @@ this.perk_rf_flail_spinner <- ::inherit("scripts/skills/skill", {
 	{
 		if (this.isEnabled() && _skill.isAttack() && _skill.m.IsWeaponSkill)
 		{
-			this.spinFlail(_skill, _targetTile);
+			// Our character might have perished from something like a counter attack
+			if (!::MSU.isNull(this.getContainer()) && !::MSU.isNull(this.getContainer().getActor()))
+			{
+				this.spinFlail(_skill, _targetTile);
+			}
 		}
 	}
 });

--- a/scripts/skills/perks/perk_rf_flail_spinner.nut
+++ b/scripts/skills/perks/perk_rf_flail_spinner.nut
@@ -44,7 +44,7 @@ this.perk_rf_flail_spinner <- ::inherit("scripts/skills/skill", {
 				this.getContainer().setBusy(true);
 				::Time.scheduleEvent(::TimeUnit.Virtual, 300, function ( perk )
 				{
-					if (targetEntity.isAlive())
+					if (user.isAlive() && targetEntity.isAlive())
 					{
 						this.logDebug("[" + user.getName() + "] is Spinning The Flail on target [" + targetEntity.getName() + "] with skill [" + _skill.getName() + "]");
 						if (!user.isHiddenToPlayer() && _targetTile.IsVisibleForPlayer)
@@ -63,7 +63,7 @@ this.perk_rf_flail_spinner <- ::inherit("scripts/skills/skill", {
 			}
 			else
 			{
-				if (targetEntity.isAlive())
+				if (user.isAlive() && targetEntity.isAlive())
 				{
 					this.logDebug("[" + user.getName() + "] is Spinning The Flail on target [" + targetEntity.getName() + "] with skill [" + _skill.getName() + "]");
 					this.m.IsSpinningFlail = true;
@@ -87,11 +87,7 @@ this.perk_rf_flail_spinner <- ::inherit("scripts/skills/skill", {
 	{
 		if (this.isEnabled() && _skill.isAttack() && _skill.m.IsWeaponSkill)
 		{
-			// Our character might have perished from something like a counter attack
-			if (!::MSU.isNull(this.getContainer()) && !::MSU.isNull(this.getContainer().getActor()))
-			{
-				this.spinFlail(_skill, _targetTile);
-			}
+			this.spinFlail(_skill, _targetTile);
 		}
 	}
 });

--- a/scripts/skills/perks/perk_rf_whirling_death.nut
+++ b/scripts/skills/perks/perk_rf_whirling_death.nut
@@ -144,7 +144,7 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 			this.getContainer().setBusy(true);
 			::Time.scheduleEvent(::TimeUnit.Virtual, 100, function ( _perk )
 			{
-				if (target.isAlive())
+				if (user.isAlive() && target.isAlive())
 				{
 					::logDebug("[" + user.getName() + "] is attacking [" + target.getName() + "] with skill [" + _skill.getName() + "] due to " + _perk.m.Name);
 					if (!user.isHiddenToPlayer() && targetTile.IsVisibleForPlayer)
@@ -162,7 +162,7 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 		}
 		else
 		{
-			if (target.isAlive())
+			if (user.isAlive() && target.isAlive())
 			{
 				::logDebug("[" + user.getName() + "] is attacking [" + target.getName() + "] with skill [" + _skill.getName() + "] due to " + this.m.Name);
 


### PR DESCRIPTION
In a recent bug report the user crashed when a Fallen Hero spun the flail.
According to the log it looks like the Fallen Hero died to Riposte/Rebuke while spinning the flail.

![image](https://github.com/user-attachments/assets/70d062cd-cb3f-48a5-a488-a819214879d7)

If a dying actor instantly uncoupled from its skill container and/or deconstructs its actor object then that would explain, why we crash during the `onVerifyTarget` function.
That function assumes this skill to be attached to a skill container and that container to be attached to an actor.

![image](https://github.com/user-attachments/assets/99b5131d-b60d-46e2-aa17-3cbd83305c38)

My solution is to check for the coupling of the container before spinning the flail