### PR TITLE
refactor: play additional delayed sfx, on a multi hit with hail/cascade

### DIFF
--- a/mod_reforged/hooks/skills/actives/cascade_skill.nut
+++ b/mod_reforged/hooks/skills/actives/cascade_skill.nut
@@ -37,6 +37,16 @@
 		local ret = this.attackEntity(_user, target);
 		this.m.IsAttacking = false;
 		this.m.IsUsingHitchance = true;
+
+		// Play an additional sound effect, if we hit more than once
+		if (ret && this.m.RerollDamageMult > 0.5)
+		{
+			::Time.scheduleEvent(::TimeUnit.Virtual, 100, this.onPlayHitSound.bindenv(this), {
+				Sound = ::MSU.Array.rand(this.m.SoundOnHit),
+				Pos = target.getPos()
+			});
+		}
+
 		return ret;
 	}
 

--- a/mod_reforged/hooks/skills/actives/hail_skill.nut
+++ b/mod_reforged/hooks/skills/actives/hail_skill.nut
@@ -37,6 +37,16 @@
 		local ret = this.attackEntity(_user, target);
 		this.m.IsAttacking = false;
 		this.m.IsUsingHitchance = true;
+
+		// Play an additional sound effect, if we hit more than once
+		if (ret && this.m.RerollDamageMult > 0.5)
+		{
+			::Time.scheduleEvent(::TimeUnit.Virtual, 100, this.onPlayHitSound.bindenv(this), {
+				Sound = ::MSU.Array.rand(this.m.SoundOnHit),
+				Pos = target.getPos()
+			});
+		}
+
 		return ret;
 	}
 


### PR DESCRIPTION
The purpose of this change is to 
- give the player (who plays with audio) a bit more feedback about how many attacks did hit
- bring back a little bit of the original flavour of those skills, by making them seem to be multi-hits

I tried playing an sfx for each additionl hit, but they did completely overlap when the game briefly lags after killing someone. So I went with a single sfx as "good enough"