### PR TITLE
Refactor starting brother weapon group

### DIFF
--- a/mod_reforged/hooks/misc.nut
+++ b/mod_reforged/hooks/misc.nut
@@ -1,6 +1,41 @@
+::Reforged.Const <- {};
+
+::Reforged.Const.WeaponTypeToPerkGroupsMap <- {};
+
+// This needs to be adjusted if mods introduce or change weapon types and perk groups for those types
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Axe] <- "pg.rf_axe";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Bow] <- "pg.rf_bow";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Cleaver] <- "pg.rf_cleaver";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Dagger] <- "pg.rf_dagger";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Flail] <- "pg.rf_flail";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Hammer] <- "pg.rf_hammer";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Mace] <- "pg.rf_mace";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Polearm] <- "pg.rf_polearm";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Spear] <- "pg.rf_spear";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Sword] <- "pg.rf_sword";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Throwing] <- "pg.rf_throwing";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Crossbow] <- "pg.rf_crossbow";
+::Reforged.Const.WeaponTypeToPerkGroupsMap[::Const.Items.WeaponType.Firearm] <- "pg.rf_crossbow";
+
 ::Reforged.new <- function( _script, _function = null )
 {
 	local obj = ::new(_script);
 	if (_function != null) _function(obj);
 	return obj;
+}
+
+// Return a list with ids of all weapon perk groups belonging to the given _weapon
+// @param _weapon must be an instance or weakref of an item with the itemtype Weapon
+::Reforged.getWeaponPerkGroups <- function( _weapon )
+{
+	local ids = [];
+	foreach (weaponType, perkGroup in ::Reforged.Const.WeaponTypeToPerkGroupsMap)
+	{
+		if (_weapon.isWeaponType(weaponType))
+		{
+			ids.push(perkGroup);
+		}
+	}
+
+	return ids;
 }

--- a/mod_reforged/hooks/mods/mod_dpf/classes/perk_tree.nut
+++ b/mod_reforged/hooks/mods/mod_dpf/classes/perk_tree.nut
@@ -3,59 +3,9 @@
 	{
 		__original(_multipliers);
 		local weapon = this.getActor().getMainhandItem();
-		if (weapon != null)
+		if (!::MSU.isNull(weapon) && weapon.isItemType(::Const.Items.ItemType.Weapon))
 		{
-			local ids = [];
-
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Axe))
-			{
-				ids.push("pg.rf_axe");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Bow))
-			{
-				ids.push("pg.rf_bow");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Cleaver))
-			{
-				ids.push("pg.rf_cleaver");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Crossbow) || weapon.isWeaponType(::Const.Items.WeaponType.Firearm))
-			{
-				ids.push("pg.rf_crossbow");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Dagger))
-			{
-				ids.push("pg.rf_dagger");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Flail))
-			{
-				ids.push("pg.rf_flail");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Hammer))
-			{
-				ids.push("pg.rf_hammer");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Mace))
-			{
-				ids.push("pg.rf_mace");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Polearm))
-			{
-				ids.push("pg.rf_polearm");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Spear))
-			{
-				ids.push("pg.rf_spear");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Sword))
-			{
-				ids.push("pg.rf_sword");
-			}
-			if (weapon.isWeaponType(::Const.Items.WeaponType.Throwing))
-			{
-				ids.push("pg.rf_throwing");
-			}
-
+			local ids = ::Reforged.getWeaponPerkGroups(weapon);
 			switch (ids.len())
 			{
 				case 0:

--- a/mod_reforged/hooks/scenarios/world/starting_scenario.nut
+++ b/mod_reforged/hooks/scenarios/world/starting_scenario.nut
@@ -1,0 +1,43 @@
+::Reforged.HooksMod.hookTree("scripts/scenarios/world/starting_scenario", function(q) {
+	q.onSpawnAssets = @(__original) function()
+	{
+		__original();
+
+		// The following code will guarantee that every starting brother has at least one weapon group corresponding to their currently equipped weapon
+		// However it might overwrite another weapon group that was given to that background specifically or which was highly likely to be on it
+		foreach (brother in ::World.getPlayerRoster().getAll())
+		{
+			local weapon = brother.getMainhandItem();
+			if (::MSU.isNull(weapon) || !weapon.isItemType(::Const.Items.ItemType.Weapon))
+			{
+				continue;
+			}
+
+			local perkGroupIds = ::Reforged.getWeaponPerkGroups(weapon);
+			if (perkGroupIds.len() == 0) // The weapon had no weapon groups associated with it (e.g. Lute)
+			{
+				continue;
+			}
+
+			local newPerkGroupId = ::MSU.Array.rand(perkGroupIds);	// We choose one random weapon group belonging to our currently equipped weapon
+			local perkTree = brother.getPerkTree();
+			if (perkTree.hasPerkGroup(newPerkGroupId))	// If we already have that weapon group, we are done and do nothing
+			{
+				continue;
+			}
+
+			local existingWeaponGroups = [];
+			local category = ::DynamicPerks.PerkGroupCategories.findById("pgc.rf_weapon");
+			foreach (groupID in category.getGroups())
+			{
+				if (perkTree.hasPerkGroup(groupID)) existingWeaponGroups.push(groupID);
+			}
+
+			if (existingWeaponGroups.len() != 0)	// If an origin character does not have any weapon group to begin, we will keep it that way. It was probably for good reason
+			{
+				perkTree.removePerkGroup(::MSU.Array.rand(existingWeaponGroups));
+				perkTree.addPerkGroup(newPerkGroupId);
+			}
+		}
+	}
+});


### PR DESCRIPTION
The first commit is just refactoring, by encapsulating the weapon group identification logic, into a helper function.

The second commit will guarantee that all starting brothers from origins have at least one weapon group that works with their equipped weapon.
This approach makes sure that most custom perk tree changes by that origin are preserved.