### PR TITLE
balance: remove throw dirt from nomad background and allow knave group

### DIFF
--- a/mod_reforged/hooks/skills/backgrounds/nomad_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/nomad_background.nut
@@ -17,7 +17,10 @@
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
-					"pg.rf_raider"
+					::MSU.Class.WeightedContainer([
+						[50, "pg.rf_knave"],
+						[50, "pg.rf_raider"]
+					])
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],
@@ -33,63 +36,6 @@
 		{
 			case "pgc.rf_fighting_style":
 				return _collection.getMin() + 1;
-		}
-	}
-
-	q.getTooltip = @(__original) function()
-	{
-		local ret = __original();
-		ret.push({
-			id = 10,
-			type = "text",
-			icon = "ui/icons/special.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Can use the [Throw Dirt|Skill+throw_dirt_skill] skill once per [turn|Concept.Turn]")
-		});
-		return ret;
-	}
-
-	q.onAdded = @(__original) function()
-	{
-		__original();
-		this.getContainer().add(::new("scripts/skills/actives/throw_dirt_skill"));
-	}
-
-	q.onRemoved = @(__original) function()
-	{
-		__original();
-		this.getContainer().removeByID("actives.throw_dirt");
-	}
-
-	q.onAnySkillExecuted = @(__original) function( _skill, _targetTile, _targetEntity, _forFree )
-	{
-		__original(_skill, _targetTile, _targetEntity, _forFree);
-		if (_skill.getID() == "actives.throw_dirt")
-		{
-			_skill.m.IsUsable = false;
-		}
-	}
-
-	q.onTurnStart = @(__original) function()
-	{
-		__original();
-		local throwDirt = this.getContainer().getSkillByID("actives.throw_dirt");
-		if (throwDirt != null)
-		{
-			throwDirt.m.IsUsable = true;
-		}
-	}
-
-	q.onQueryTooltip = @(__original) function( _skill, _tooltip )
-	{
-		__original(_skill, _tooltip);
-		if (_skill.getID() == "actives.throw_dirt" && !_skill.m.IsUsable)
-		{
-			_tooltip.push({
-				id = 20,
-				type = "text",
-				icon = "ui/icons/warning.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorNegative("Can only be used once per [turn|Concept.Turn]"))
-			});
 		}
 	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/nomad_ranged_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/nomad_ranged_background.nut
@@ -14,7 +14,10 @@
 		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({
 			DynamicMap = {
 				"pgc.rf_exclusive_1": [
-					"pg.rf_raider"
+					::MSU.Class.WeightedContainer([
+						[50, "pg.rf_knave"],
+						[50, "pg.rf_raider"]
+					])
 				],
 				"pgc.rf_shared_1": [],
 				"pgc.rf_weapon": [],


### PR DESCRIPTION
I decided to just remove all code related to throw dirt on nomad background instead of commenting out those sections. It's easy enough to look up the history of the file if we ever decide to revert it. If my logic is flawed please let me know.