### PR TITLE
refactor: prevent schrat shield from triggering during users turn

### DIFF
--- a/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
@@ -17,14 +17,14 @@
 			id = 10,
 			type = "text",
 			icon = "ui/icons/special.png",
-			text = "When hit while having at least " + ::MSU.Text.colorPositive(this.m.SpawnSaplingConditionThreshold) + " durability, spawns a small " + ::Const.Strings.EntityName[::Const.EntityType.Schrat] + " on an adjacent tile, losing " + ::MSU.Text.colorNegative(this.m.SpawnSaplingConditionLoss) + " points of durability"
+			text = "When hit while having at least " + ::MSU.Text.colorPositive(this.m.SpawnSaplingConditionThreshold) + " durability, spawns a small " + ::Const.Strings.EntityName[::Const.EntityType.Schrat] + " on an adjacent tile, losing " + ::MSU.Text.colorNegative(this.m.SpawnSaplingConditionLoss) + " points of durability. Does not work during your turn."
 		});
 		return ret;
 	}
 
 	q.onShieldHit = @() function( _attacker, _skill )
 	{
-		if (this.getCondition() >= this.m.SpawnSaplingConditionThreshold && this.getCondition() > this.m.SpawnSaplingConditionLoss)
+		if (!::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()) && this.getCondition() >= this.m.SpawnSaplingConditionThreshold && this.getCondition() > this.m.SpawnSaplingConditionLoss)
 		{
 			this.spawnSapling();
 		}


### PR DESCRIPTION
Currently there is this bug when you move to another tile while in ZOC and while you have the craftable Schrat shield equipped.
An enemy tries to hit you, misses and damages your shield. Then a Sapling will spawn and randomly chooses the tile you are currently moving into.
Your movement finishes and now you and your sapling occupy the same tile, causing undefined behavior in combat.

I tested this fix out ingame and the scecnario I describe no longer happens, while you still spawn saplings during enemies turns