### PR TITLE
fix: barbarian unholds spawning in the wrong order

### DIFF
--- a/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
@@ -43,28 +43,28 @@ local units = [
 	{
 		ID = "Unit.RF.BarbarianBeastmasterU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 15,
+		Cost = 15, // Diversified Beastmaster costs because all of them having the same cost was leading these spawns to have an undefined upgrade path. Result being an armored unhold always spawning on low (250) resources and a normal unhold on high (555+) resources.
 		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
 		SubPartyDef = {BaseID = "OneUnhold", IsUsingTopPartyResources = false }
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterUU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 17,
+		Cost = 17, // Diversified Beastmaster costs because all of them having the same cost was leading these spawns to have an undefined upgrade path. Result being an armored unhold always spawning on low (250) resources and a normal unhold on high (555+) resources.
 		StartingResourceMin = 400, // In Vanilla they appear in a group of 400 cost
 		SubPartyDef = {BaseID = "TwoUnhold", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 16,
+		Cost = 16, // Diversified Beastmaster costs because all of them having the same cost was leading these spawns to have an undefined upgrade path. Result being an armored unhold always spawning on low (250) resources and a normal unhold on high (555+) resources.
 		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
 		SubPartyDef = {BaseID = "OneFrostUnhold", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterFF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 18,
+		Cost = 18, // Diversified Beastmaster costs because all of them having the same cost was leading these spawns to have an undefined upgrade path. Result being an armored unhold always spawning on low (250) resources and a normal unhold on high (555+) resources.
 		StartingResourceMin = 430, // In Vanilla they appear in a group of 430 cost
 		SubPartyDef = {BaseID = "TwoFrostUnhold", IsUsingTopPartyResources = false}
 	}

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/barbarian_units.nut
@@ -50,21 +50,21 @@ local units = [
 	{
 		ID = "Unit.RF.BarbarianBeastmasterUU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 15,
+		Cost = 17,
 		StartingResourceMin = 400, // In Vanilla they appear in a group of 400 cost
 		SubPartyDef = {BaseID = "TwoUnhold", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 15,
+		Cost = 16,
 		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
 		SubPartyDef = {BaseID = "OneFrostUnhold", IsUsingTopPartyResources = false}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterFF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
-		Cost = 15,
+		Cost = 18,
 		StartingResourceMin = 430, // In Vanilla they appear in a group of 430 cost
 		SubPartyDef = {BaseID = "TwoFrostUnhold", IsUsingTopPartyResources = false}
 	}


### PR DESCRIPTION
Currently Armored Unholds spawn early and normal Unholds spawn late.
That is likely because all 4 options cost the same amount of resources. When they get sorted, their order is undefined.

This is a bandaid fix that solves the issue by giving them all slightly different costs to preserve the correct order.

This fix might just bury the underlying problem.
I don't know how the subparty system was supposed to work and currently works. Maybe it was supposed to raise the cost of the individual unit options by the cost of their subparties during sorting, which would have solved this issue.