### PR TITLE
fix: crash when viewing tooltip while the entity is moving

### DIFF
--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -44,6 +44,18 @@
 		return ret;
 	}
 
+	q.tactical_helper_findGroundItem = @(__original) function( _entity, _itemId )
+	{
+		if (_entity.isPlacedOnMap())
+		{
+			return __original(_entity, _itemId);
+		}
+		else	// This can happen under Reforged, when the player views a combat tooltip while the targeted character is moving (e.g. using Rotate)
+		{
+			return null;	// Fix a crash, when accessing ground items under moving entities
+		}
+	}
+
 // New Functions
 	q.getBaseAttributesTooltip <- function( _entityId, _elementId, _elementOwner )
 	{


### PR DESCRIPTION
This fix is in reponse to the discord post: https://discord.com/channels/1006908336991645757/1283857645492502549/1302361610764947557

> I got this crash. Crashed right as the Ancient Dead used rotation, and I think what caused it is that I happened to have my cursor (with the tooltip open) when they did the Rotation.
![image](https://github.com/user-attachments/assets/df6cf8eb-de0e-47ec-9587-aa4e333b90ed)

---

Unfortunately the user did not provide a log. I don't know what the root cause of this issue is.
One of the issues here is that the vanilla function `tactical_helper_findGroundItem` is being called with an `_entity`, which is currently moving. That will cause a crash because vanilla does a `.getTile()` call on the entity.
That symptom __might__ be fixed with this PR.

It would be cleaner if we [also] add a `isPlacedOnMap` check further up the chain of function calls.
But we have not enough information to know where it started. the `getTooltip` function from the actor can't be the beginning, because we also do a `isPlacedOnMap check there: 

![image](https://github.com/user-attachments/assets/cefce8e1-d944-491c-ad4e-158083ebe906)