### PR TITLE
Uber rattle buff

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1725,8 +1725,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Every hit applies the [Rattled|Skill+rf_rattled_effect] effect for one [turn.|Concept.Turn]",
-				"Does not work against targets immune to being [stunned|Skill+stunned_effect] or [dazed.|Skill+dazed_effect]"
+				"Every hit applies the [Rattled|Skill+rf_rattled_effect] effect for one [turn.|Concept.Turn]"
 			]
 		}]
 	}),

--- a/scripts/skills/effects/rf_rattled_effect.nut
+++ b/scripts/skills/effects/rf_rattled_effect.nut
@@ -1,6 +1,6 @@
 this.rf_rattled_effect <- ::inherit("scripts/skills/skill", {
 	m = {
-		ReachModifier = -2
+		ReachModifier = -3
 	},
 	function create()
 	{

--- a/scripts/skills/perks/perk_rf_rattle.nut
+++ b/scripts/skills/perks/perk_rf_rattle.nut
@@ -17,7 +17,7 @@ this.perk_rf_rattle <- ::inherit("scripts/skills/skill", {
 
 	function onTargetHit( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
 	{
-		if (!_targetEntity.isAlive() || _targetEntity.getCurrentProperties().IsImmuneToStun || _targetEntity.getCurrentProperties().IsImmuneToDaze || !this.isSkillValid(_skill))
+		if (!_targetEntity.isAlive() || !this.isSkillValid(_skill))
 			return;
 
 		_targetEntity.getSkills().add(::new("scripts/skills/effects/rf_rattled_effect"));


### PR DESCRIPTION
removing stun and daze as exceptions is necessary because the perk is just too stinky otherwise.

The reach modifier increase to 3 is a bit more experimental. I think we should probably instead have rattled reduce matk/mdef by 10 and ratk/rdef by 20 instead as it's useful in more situations and better than reach, but since we're on a time crunch this is okay for now unless you agree and wanted to do it quick.