### PR TITLE
fix: error when fetching tooltip for strenght in numbers

### DIFF
--- a/scripts/skills/perks/perk_rf_strength_in_numbers.nut
+++ b/scripts/skills/perks/perk_rf_strength_in_numbers.nut
@@ -16,7 +16,7 @@ this.perk_rf_strength_in_numbers <- ::inherit("scripts/skills/skill", {
 
 	function isHidden()
 	{
-		return !this.getContainer().getActor().isPlacedOnMap() || (this.getSkillBonus() == 0 && this.getResolveBonus() == 0);
+		return (this.getSkillBonus() == 0 && this.getResolveBonus() == 0);
 	}
 
 	function getTooltip()
@@ -70,21 +70,26 @@ this.perk_rf_strength_in_numbers <- ::inherit("scripts/skills/skill", {
 
 	function getSkillBonus()
 	{
+		if (!this.getContainer().getActor().isPlacedOnMap())
+		{
+			return 0;
+		}
+
 		return ::Tactical.Entities.getAlliedActors(this.getContainer().getActor().getFaction(), this.getContainer().getActor().getTile(), 1, true).len() * this.m.SkillBonus;
 	}
 
 	function getResolveBonus()
 	{
+		if (!this.getContainer().getActor().isPlacedOnMap())
+		{
+			return 0;
+		}
+
 		return ::Tactical.Entities.getAlliedActors(this.getContainer().getActor().getFaction(), this.getContainer().getActor().getTile(), 1, true).len() * this.m.ResolveBonus;
 	}
 
 	function onUpdate( _properties )
 	{
-		if (!this.getContainer().getActor().isPlacedOnMap())
-		{
-			return;
-		}
-
 		local bonus = this.getSkillBonus();
 		if (bonus > 0)
 		{


### PR DESCRIPTION
Move isPlacedOnMap checks into the getter functions, when the getTile() checks are actually required

Via hyperlinks you can view this tooltip for actors not placed on a map. This will then cause an error, which is catched by a try block and causes the following logs:

![image](https://github.com/user-attachments/assets/b2081e17-b224-4595-86b4-6d860ec66171)