### PR TITLE
Refactor decisive display

### DIFF
--- a/scripts/skills/perks/perk_rf_decisive.nut
+++ b/scripts/skills/perks/perk_rf_decisive.nut
@@ -93,20 +93,20 @@ this.perk_rf_decisive <- ::inherit("scripts/skills/skill", {
 	function onCombatFinished()
 	{
 		this.skill.onCombatFinished();
-		this.m.Stacks = 0;
+		this.setStacks(0);
 	}
 
 	function onTurnEnd()
 	{
 		if (this.getContainer().getActor().isWaitActionSpent() == false)
 		{
-			this.m.Stacks = ::Math.min(this.m.Stacks + 1, this.m.MaxStacks);
+			this.setStacks(::Math.min(this.m.Stacks + 1, this.m.MaxStacks))
 		}
 	}
 
 	function onWaitTurn()
 	{
-		this.m.Stacks = 0;
+		this.setStacks(0);
 	}
 
 	function onUpdate( _properties )
@@ -130,6 +130,11 @@ this.perk_rf_decisive <- ::inherit("scripts/skills/skill", {
 	}
 
 // New Functions
+	function setStacks( _stacks )
+	{
+		this.m.Stacks = _stacks;
+	}
+
 	function getResolveModifier()
 	{
 		return this.m.Stacks >= 1 ? this.m.ResolveModifier : 0;

--- a/scripts/skills/perks/perk_rf_decisive.nut
+++ b/scripts/skills/perks/perk_rf_decisive.nut
@@ -9,7 +9,8 @@ this.perk_rf_decisive <- ::inherit("scripts/skills/skill", {
 		MaxStacks = 3,
 
 		// Private
-		Stacks = 0
+		Stacks = 0,
+		OriginalIconMini = "perk_rf_decisive_mini"
 	},
 	function create()
 	{
@@ -17,7 +18,7 @@ this.perk_rf_decisive <- ::inherit("scripts/skills/skill", {
 		this.m.Name = ::Const.Strings.PerkName.RF_Decisive;
 		this.m.Description = "This character is capable of making quick and confident decisions without any hesitation.";
 		this.m.Icon = "ui/perks/perk_rf_decisive.png";
-		this.m.IconMini = "perk_rf_decisive_mini";
+		this.m.IconMini = "";
 		this.m.Type = ::Const.SkillType.Perk | ::Const.SkillType.StatusEffect;
 		this.m.Order = ::Const.SkillOrder.Perk;
 	}
@@ -25,11 +26,6 @@ this.perk_rf_decisive <- ::inherit("scripts/skills/skill", {
 	function getName()
 	{
 		return this.m.Stacks == 0 ? this.m.Name : this.m.Name + " (x" + this.m.Stacks + ")";
-	}
-
-	function isHidden()
-	{
-		return this.m.Stacks == 0;
 	}
 
 	function getTooltip()
@@ -133,6 +129,14 @@ this.perk_rf_decisive <- ::inherit("scripts/skills/skill", {
 	function setStacks( _stacks )
 	{
 		this.m.Stacks = _stacks;
+		if (this.m.Stacks == 0)
+		{
+			this.m.IconMini = "";
+		}
+		else
+		{
+			this.m.IconMini = this.m.OriginalIconMini;
+		}
 	}
 
 	function getResolveModifier()


### PR DESCRIPTION
- Decisive now always displays the effect icon, even with 0 Stacks
- Decisive now only shows its mini icon while you have at least 1 stack

These changes should make it easier for the player to quickly see, whether they are allowed to use Wait or must end the turn immediately during turn 1 of a combat.