### PR TITLE
refactor: improve hook shield

### DIFF
--- a/mod_reforged/hooks/skills/actives/shieldwall.nut
+++ b/mod_reforged/hooks/skills/actives/shieldwall.nut
@@ -7,13 +7,6 @@
 			id = 10,
 			type = "text",
 			icon = "ui/icons/special.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Grants immunity against [Hook Shield|Skill+rf_hook_shield_skill]")
-		});
-
-		ret.push({
-			id = 11,
-			type = "text",
-			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("Removes the penalty to shield defenses from built [Fatigue|Concept.Fatigue]")
 		});
 

--- a/mod_reforged/hooks/skills/effects/shieldwall_effect.nut
+++ b/mod_reforged/hooks/skills/effects/shieldwall_effect.nut
@@ -1,18 +1,4 @@
 ::Reforged.HooksMod.hook("scripts/skills/effects/shieldwall_effect", function(q) {
-	q.getTooltip = @(__original) function()
-	{
-		local ret = __original();
-
-		ret.push({
-			id = 6,
-			type = "text",
-			icon = "ui/icons/special.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Immune against [Hook Shield|Skill+rf_hook_shield_skill]")
-		});
-
-		return ret;
-	}
-
 	// Part of perk_rf_shield_sergeant functionality
 	q.onTurnStart = @(__original) function()
 	{

--- a/scripts/skills/actives/rf_hook_shield_skill.nut
+++ b/scripts/skills/actives/rf_hook_shield_skill.nut
@@ -138,7 +138,7 @@ this.rf_hook_shield_skill <- ::inherit("scripts/skills/skill", {
 				if (shieldWall != null)
 				{
 					::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " hooks " + ::Const.UI.getColorizedEntityName(targetEntity) + "\'s shield removing their " + shieldWall.m.Name);
-					targetEntity.getSkills().removeByID("effects.shieldWall");
+					targetEntity.getSkills().remove(shieldWall);
 				}
 				else
 				{

--- a/scripts/skills/actives/rf_hook_shield_skill.nut
+++ b/scripts/skills/actives/rf_hook_shield_skill.nut
@@ -39,6 +39,7 @@ this.rf_hook_shield_skill <- ::inherit("scripts/skills/skill", {
 		this.m.IsActive = true;
 		this.m.IsTargeted = true;
 		this.m.IsIgnoredAsAOO = true;
+		this.m.IsTooCloseShown = true;
 		this.m.IsWeaponSkill = true;
 		this.m.ActionPointCost = 3;
 		this.m.FatigueCost = 25;

--- a/scripts/skills/actives/rf_hook_shield_skill.nut
+++ b/scripts/skills/actives/rf_hook_shield_skill.nut
@@ -1,6 +1,8 @@
 this.rf_hook_shield_skill <- ::inherit("scripts/skills/skill", {
 	m = {
-		ApplyAxeMastery = true
+		ApplyAxeMastery = true,
+		LastTargetID = null,
+		IsSpent = false
 	},
 	function isAxeMasteryApplied()
 	{
@@ -39,7 +41,7 @@ this.rf_hook_shield_skill <- ::inherit("scripts/skills/skill", {
 		this.m.IsIgnoredAsAOO = true;
 		this.m.IsWeaponSkill = true;
 		this.m.ActionPointCost = 3;
-		this.m.FatigueCost = 15;
+		this.m.FatigueCost = 25;
 		this.m.MinRange = 1;
 		this.m.MaxRange = 1;
 		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.KnockOut;
@@ -53,11 +55,18 @@ this.rf_hook_shield_skill <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/special.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Applies the [Hooked Shield|Skill+rf_hooked_shield_effect] effect on the target")
+			text = ::Reforged.Mod.Tooltips.parseString("Removes [Shieldwall|Skill+shieldwall_effect] from the target. Otherwise applies the [Hooked Shield|Skill+rf_hooked_shield_effect] effect")
 		});
 
 		ret.push({
 			id = 11,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Once per [turn,|Concept.Turn] when used against the same target twice, the second use refunds all of its [Action Point|Concept.ActionPoints] cost")
+		});
+
+		ret.push({
+			id = 12,
 			type = "text",
 			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields")
@@ -83,13 +92,6 @@ this.rf_hook_shield_skill <- ::inherit("scripts/skills/skill", {
 			});
 		}
 
-		ret.push({
-			id = 12,
-			type = "text",
-			icon = "ui/icons/warning.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Cannot target someone who has the [Shieldwall|Skill+shieldwall_effect] effect")
-		});
-
 		return ret;
 	}
 
@@ -110,20 +112,38 @@ this.rf_hook_shield_skill <- ::inherit("scripts/skills/skill", {
 		if (targetEntity.isAlliedWith(this.getContainer().getActor()))
 			return false;
 
-		return targetEntity.isArmedWithShield() && this.skill.onVerifyTarget(_originTile, _targetTile) && !targetEntity.getSkills().hasSkill("effects.shieldwall") && !targetEntity.getSkills().hasSkill("effects.rf_hooked_shield");
+		return targetEntity.isArmedWithShield() && this.skill.onVerifyTarget(_originTile, _targetTile) && !targetEntity.getSkills().hasSkill("effects.rf_hooked_shield");
 	}
 
 	function onUse( _user, _targetTile )
 	{
 		local targetEntity = _targetTile.getEntity();
+
+		if (!this.m.IsSpent && targetEntity.getID() == this.m.LastTargetID)
+		{
+			_user.setActionPoints(::Math.min(_user.getActionPointsMax(), _user.getActionPoints() + this.getActionPointCost()));
+			this.m.IsSpent = true;
+		}
+
+		this.m.LastTargetID = targetEntity.getID();
+
 		local shield = targetEntity.getOffhandItem();
 		if (shield != null)
 		{
 			this.spawnAttackEffect(_targetTile, ::Const.Tactical.AttackEffectSplitShield);
 			if (this.attackEntity(_user, targetEntity))
 			{
-				::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " hooks " + ::Const.UI.getColorizedEntityName(targetEntity) + "\'s shield");
-				targetEntity.getSkills().add(::new("scripts/skills/effects/rf_hooked_shield_effect"));
+				local shieldWall = targetEntity.getSkills().getSkillByID("effects.shieldwall");
+				if (shieldWall != null)
+				{
+					::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " hooks " + ::Const.UI.getColorizedEntityName(targetEntity) + "\'s shield removing their " + shieldWall.m.Name);
+					targetEntity.getSkills().removeByID("effects.shieldWall");
+				}
+				else
+				{
+					::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " hooks " + ::Const.UI.getColorizedEntityName(targetEntity) + "\'s shield");
+					targetEntity.getSkills().add(::new("scripts/skills/effects/rf_hooked_shield_effect"));
+				}
 				if (!::Tactical.getNavigator().isTravelling(_targetTile.getEntity()))
 				{
 					::Tactical.getShaker().shake(targetEntity, _user.getTile(), 5, ::Const.Combat.ShakeEffectSplitShieldColor, ::Const.Combat.ShakeEffectSplitShieldHighlight, ::Const.Combat.ShakeEffectSplitShieldFactor, 1.0, [
@@ -156,5 +176,21 @@ this.rf_hook_shield_skill <- ::inherit("scripts/skills/skill", {
 				}
 			}
 		}
+	}
+
+	function onTurnStart()
+	{
+		this.m.IsSpent = false;
+	}
+
+	function onGetHitFactors( _skill, _targetTile, _tooltip )
+	{
+		if (_skill != this || this.m.IsSpent || !_targetTile.IsOccupiedByActor || _targetTile.getEntity().getID() != this.m.LastTargetID)
+			return;
+
+		_tooltip.push({
+			icon = "ui/icons/action_points.png",
+			text = "Refund Action Points on hit"
+		});
 	}
 });


### PR DESCRIPTION
- Allow using on targets using Shieldwall. Removes Shieldwall in this case.
- Second use on the same target refunds its AP cost.
- Increase Fatigue Cost from 15 to 25.