### PR TITLE
refactor: improve dynamic duo shuffle and give aoe benefit

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1215,7 +1215,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			{
 				Type = ::UPD.EffectType.Active,
 				Description = [
-					"Gain the [Shuffle|Skill+rf_dynamic_duo_shuffle_skill] skill that allows you to swap places with your partner once per [turn|Concept.Turn] for free."
+					"Gain the [Shuffle|Skill+rf_dynamic_duo_shuffle_skill] skill that allows you to swap places with your partner once per [turn|Concept.Turn] for free, and puts them next in the [turn|Concept.Turn] order immediately after you."
 				]
 			}
 		]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1209,6 +1209,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 					"Allows you to choose another member of your company as your partner. You will remain partners until one of you dies or leaves the company. You and your partner gain the following bonuses when there is no ally next to you or your partner.",
 					"[Resolve|Concept.Bravery] and [Initiative|Concept.Initiative] are increased by " + ::MSU.Text.colorPositive("+20") + ".",
 					"Gain " + ::MSU.Text.colorPositive("+10") + " [Melee Skill|Concept.MeleeSkill] against enemies that attack your partner, and " + ::MSU.Text.colorPositive("+10") + " [Melee Defense|Concept.MeleeDefense] against enemies attacked by your partner, for one [turn.|Concept.Turn]",
+					"A partner\'s melee [AOE|Concept.AOE] attacks never have more than " + ::MSU.Text.colorPositive(::ModularVanilla.Const.HitChanceMin + "%") + " chance to hit their partner and inflict " + ::MSU.Text.colorPositive("50%") + " less damage.",
 					"The partner does not need to learn this [perk|Concept.Perk] in order to gain the benefits."
 				]
 			},

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1216,7 +1216,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			{
 				Type = ::UPD.EffectType.Active,
 				Description = [
-					"Gain the [Shuffle|Skill+rf_dynamic_duo_shuffle_skill] skill that allows you to swap places with your partner once per [turn|Concept.Turn] for free, and puts them next in the [turn|Concept.Turn] order immediately after you."
+					"Gain the [Shuffle|Skill+rf_dynamic_duo_shuffle_skill] skill that allows you to swap places with your partner once per [turn|Concept.Turn] for free and put them next in the [turn|Concept.Turn] order immediately after you."
 				]
 			}
 		]

--- a/scripts/skills/actives/rf_dynamic_duo_shuffle_skill.nut
+++ b/scripts/skills/actives/rf_dynamic_duo_shuffle_skill.nut
@@ -52,6 +52,13 @@ this.rf_dynamic_duo_shuffle_skill <- ::inherit("scripts/skills/skill", {
 				text = "Partner: " + partner.getName()
 			});
 
+			ret.push({
+				id = 11,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Swap places with your partner and put them next in the [turn|Concept.Turn] order")
+			});
+
 			if (actor.isPlacedOnMap())
 			{
 				if (!partner.isPlacedOnMap())
@@ -145,7 +152,9 @@ this.rf_dynamic_duo_shuffle_skill <- ::inherit("scripts/skills/skill", {
 
 	function onUse( _user, _targetTile )
 	{
-		::Tactical.getNavigator().switchEntities(_user, _targetTile.getEntity(), null, null, 1.0);
+		local target = _targetTile.getEntity();
+		::Tactical.getNavigator().switchEntities(_user, target, null, null, 1.0);
+		::Tactical.TurnSequenceBar.moveEntityToFront(target.getID());
 		this.m.IsSpent = true;
 		return true;
 	}

--- a/scripts/skills/perks/perk_rf_dynamic_duo_abstract.nut
+++ b/scripts/skills/perks/perk_rf_dynamic_duo_abstract.nut
@@ -162,9 +162,17 @@ this.perk_rf_dynamic_duo_abstract <- ::inherit("scripts/skills/skill", {
 
 	function onAnySkillUsed( _skill, _targetEntity, _properties )
 	{
-		if (_targetEntity != null && _skill.isAttack() && !_skill.isRanged() && this.hasEntityForAttackBonus(_targetEntity) && this.isEnabled())
+		if (_targetEntity == null || !_skill.isAttack() || _skill.isRanged() || !this.isEnabled())
+			return;
+
+		if (this.hasEntityForAttackBonus(_targetEntity))
 		{
 			_properties.MeleeSkill += this.m.MeleeSkillModifier;
+		}
+		else if (_skill.isAOE() && ::MSU.isEqual(_targetEntity, this.getPartner()))
+		{
+			_properties.MeleeSkillMult = 0;
+			_properties.DamageTotalMult *= 0.5;
 		}
 	}
 


### PR DESCRIPTION
- Shuffle now moves the target to the front in the turn order.
- AOE melee skills have 0 melee skill when attacking partner (which means they will have the minimum Hit Chance i.e. 5%) and will inflict 50% less damage.