### PR TITLE
fix: throw net behavior with kingfisher

### DIFF
--- a/mod_reforged/hooks/ai/tactical/behaviors/ai_attack_throw_net.nut
+++ b/mod_reforged/hooks/ai/tactical/behaviors/ai_attack_throw_net.nut
@@ -3,7 +3,10 @@
 
 	q.onEvaluate = @(__original) function( _entity )
 	{
-		local ret = __original(_entity);
+		// Wrap generator properly
+		local ret, gen = __original(_entity);
+		while ((ret = resume gen) == null) yield null;
+
 		if (this.m.Skill != null && ret != ::Const.AI.Behavior.Score.Zero && ::Math.rand(1, 100) < 75 && _entity.getSkills().hasSkill("perk.rf_kingfisher"))
 			ret = ::Const.AI.Behavior.Score.Zero;
 


### PR DESCRIPTION
The function was returning integer sporadically, which caused "trying resume a 'integer'" crash.

Also, we won't get score until we cycle through the original generator.