### PR TITLE
refactor: restrict recover to be unusable after movement or skill use

### DIFF
--- a/mod_reforged/hooks/skills/actives/recover_skill.nut
+++ b/mod_reforged/hooks/skills/actives/recover_skill.nut
@@ -7,9 +7,22 @@
 			id = 20,
 			type = "text",
 			icon = "ui/icons/warning.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Will end your [turn|Concept.Turn]")
+		});
+		ret.push({
+			id = 21,
+			type = "text",
+			icon = "ui/icons/warning.png",
 			text = "Cannot be used after movement or having used a skill"
 		});
 
+		return ret;
+	}
+
+	q.onUse = @(__original) function( _user, _targetTile )
+	{
+		local ret =__original(_user, _targetTile);
+		_user.m.IsTurnDone = true;
 		return ret;
 	}
 

--- a/mod_reforged/hooks/skills/actives/recover_skill.nut
+++ b/mod_reforged/hooks/skills/actives/recover_skill.nut
@@ -1,5 +1,5 @@
 ::Reforged.HooksMod.hook("scripts/skills/actives/recover_skill", function(q) {
-	q.m.HasMovedOrUsedSkill <- false
+	q.m.HasMovedOrUsedSkill <- false;
 
 	q.getTooltip = @(__original) function()
 	{
@@ -12,7 +12,7 @@
 			text = ::Reforged.Mod.Tooltips.parseString("Will end your [turn|Concept.Turn]")
 		});
 
-		local warning = "Cannot be used after movement or having used a skill"
+		local warning = "Cannot be used after movement or having used a skill";
 		local colorNegative = this.m.HasMovedOrUsedSkill || !::MSU.isNull(this.getContainer()) && !::MSU.isNull(this.getContainer().getActor()) && this.getContainer().getActor().isPreviewing();
 		ret.push({
 			id = 21,

--- a/mod_reforged/hooks/skills/actives/recover_skill.nut
+++ b/mod_reforged/hooks/skills/actives/recover_skill.nut
@@ -66,6 +66,6 @@
 	// to show that the skill won't be usable after the previewed action.
 	q.isAffordablePreview = @(__original) function()
 	{
-		return __original() && !this.getContainer().getActor().isPreviewing();
+		return !this.getContainer().getActor().isPreviewing() && __original();
 	}
 });

--- a/mod_reforged/hooks/skills/actives/recover_skill.nut
+++ b/mod_reforged/hooks/skills/actives/recover_skill.nut
@@ -7,7 +7,7 @@
 			id = 20,
 			type = "text",
 			icon = "ui/icons/warning.png",
-			text = ::Reforged.Mod.Tooltips.parseString("Cannot be used after movement or having used a skill")
+			text = "Cannot be used after movement or having used a skill"
 		});
 
 		return ret;

--- a/mod_reforged/hooks/skills/actives/recover_skill.nut
+++ b/mod_reforged/hooks/skills/actives/recover_skill.nut
@@ -15,11 +15,13 @@
 
 	q.onAnySkillExecuted = @(__original) function( _skill, _targetTile, _targetEntity, _forFree )
 	{
+		__original(_skill, _targetTile, _targetEntity, _forFree);
 		this.m.IsUsable = false;
 	}
 
 	q.onMovementStarted = @(__original) function( _tile, _numTiles )
 	{
+		__original(_tile, _numTiles);
 		this.m.IsUsable = false;
 	}
 

--- a/mod_reforged/hooks/skills/actives/recover_skill.nut
+++ b/mod_reforged/hooks/skills/actives/recover_skill.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/skills/actives/recover_skill", function(q) {
+	q.m.HasMovedOrUsedSkill <- false
+
 	q.getTooltip = @(__original) function()
 	{
 		local ret = __original();
@@ -9,11 +11,14 @@
 			icon = "ui/icons/warning.png",
 			text = ::Reforged.Mod.Tooltips.parseString("Will end your [turn|Concept.Turn]")
 		});
+
+		local warning = "Cannot be used after movement or having used a skill"
+		local colorNegative = this.m.HasMovedOrUsedSkill || !::MSU.isNull(this.getContainer()) && !::MSU.isNull(this.getContainer().getActor()) && this.getContainer().getActor().isPreviewing();
 		ret.push({
 			id = 21,
 			type = "text",
 			icon = "ui/icons/warning.png",
-			text = "Cannot be used after movement or having used a skill"
+			text = colorNegative ? ::MSU.Text.colorNegative(warning) : warning
 		});
 
 		return ret;
@@ -29,34 +34,38 @@
 	q.onAnySkillExecuted = @(__original) function( _skill, _targetTile, _targetEntity, _forFree )
 	{
 		__original(_skill, _targetTile, _targetEntity, _forFree);
-		this.m.IsUsable = false;
+		this.m.HasMovedOrUsedSkill = true;
 	}
 
 	q.onMovementStarted = @(__original) function( _tile, _numTiles )
 	{
 		__original(_tile, _numTiles);
-		this.m.IsUsable = false;
+		this.m.HasMovedOrUsedSkill = true;
 	}
 
 	q.onTurnStart = @(__original) function()
 	{
 		__original();
-		this.resetField("IsUsable");
+		this.m.HasMovedOrUsedSkill = false;
 	}
 
 	q.onCombatFinished = @(__original) function()
 	{
 		__original();
-		this.resetField("IsUsable");
+		this.m.HasMovedOrUsedSkill = false;
 	}
 
-	q.onAfterUpdate = @(__original) function( _properties )
+	// We have to return true during previewing otherwise the affordability preview system
+	// does not update the visuals during preview.
+	q.isUsable = @(__original) function()
 	{
-		__original(_properties);
-		// Ghetto way to show during skill/movement preview that Recover will become unusable
-		if (this.getContainer().getActor().isPreviewing())
-		{
-			this.m.ActionPointCost += 9999;
-		}
+		return this.getContainer().getActor().isPreviewing() || !this.m.HasMovedOrUsedSkill && __original();
+	}
+
+	// We have to show during preview that it won't be affordable so that the visuals update
+	// to show that the skill won't be usable after the previewed action.
+	q.isAffordablePreview = @(__original) function()
+	{
+		return __original() && !this.getContainer().getActor().isPreviewing();
 	}
 });

--- a/mod_reforged/hooks/skills/actives/recover_skill.nut
+++ b/mod_reforged/hooks/skills/actives/recover_skill.nut
@@ -1,0 +1,47 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/recover_skill", function(q) {
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+
+		ret.push({
+			id = 20,
+			type = "text",
+			icon = "ui/icons/warning.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Cannot be used after movement or having used a skill")
+		});
+
+		return ret;
+	}
+
+	q.onAnySkillExecuted = @(__original) function( _skill, _targetTile, _targetEntity, _forFree )
+	{
+		this.m.IsUsable = false;
+	}
+
+	q.onMovementStarted = @(__original) function( _tile, _numTiles )
+	{
+		this.m.IsUsable = false;
+	}
+
+	q.onTurnStart = @(__original) function()
+	{
+		__original();
+		this.resetField("IsUsable");
+	}
+
+	q.onCombatFinished = @(__original) function()
+	{
+		__original();
+		this.resetField("IsUsable");
+	}
+
+	q.onAfterUpdate = @(__original) function( _properties )
+	{
+		__original(_properties);
+		// Ghetto way to show during skill/movement preview that Recover will become unusable
+		if (this.getContainer().getActor().isPreviewing())
+		{
+			this.m.ActionPointCost += 9999;
+		}
+	}
+});


### PR DESCRIPTION
Features:
- Recover cannot be used after a movement or having used any skill.
- Your turn ends immediately after using Recover.