### PR TITLE
feat: always preserve dropped player weapons

### DIFF
--- a/mod_reforged/hooks/config/tip_of_the_day.nut
+++ b/mod_reforged/hooks/config/tip_of_the_day.nut
@@ -42,5 +42,6 @@ for (local index = (::Const.TipOfTheDay.len() - 1); index >= 0; index--)
 	"Reforged: Tavern rumors will never be about legendary locations you have already discovered.",
 	// "Reforged: Enemies will only drop loot if your faction has dealt at least 50% of the total damage received by that enemy." // This feature is removed due to mod compatibility issues, and should be re-included if we can find a good way.
 	"Reforged: Experience from slain enemies is awarded depending on how much damage was dealt to them by your brothers.",
-	"If you see colorful squares, do NOT save the game or you might end up with a corrupted save file."
+	"If you see colorful squares, do NOT save the game or you might end up with a corrupted save file.",
+	"Reforged: Weapons worn by your characters will always drop and be recovered after the battle, even if they break."
 ]);

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -71,6 +71,21 @@
 		}
 	}
 
+	q.isDroppedAsLoot = @(__original) function()
+	{
+		if (!this.item.isDroppedAsLoot())
+		{
+			return false;
+		}
+
+		if (this.m.LastEquippedByFaction == ::Const.Faction.Player || !::MSU.isNull(this.getContainer()) && ::MSU.isKindOf(this.getContainer().getActor(), "player"))
+		{
+			return true;	// Player Weapons now always drop guaranteed
+		}
+
+		return __original();
+	}
+
 	q.getReach <- function()
 	{
 		return this.m.Reach;

--- a/mod_reforged/hooks/retinue/followers/blacksmith_follower.nut
+++ b/mod_reforged/hooks/retinue/followers/blacksmith_follower.nut
@@ -1,0 +1,8 @@
+::Reforged.HooksMod.hook("scripts/retinue/followers/blacksmith_follower", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// In Reforged player weapons will always drop, so this part of the blacksmith is now redundant to mention
+		this.m.Effects[0] = ::MSU.String.replace(this.m.Effects[0] , ", weapons", "");
+	}
+});


### PR DESCRIPTION
In Vanilla: normal player weapons are never dropped if they have 11 or less condition unless you have the blacksmith retinue.
This PR will make it so weapons that were dropped from a player character always drop, even if they have 0 condition.

I have not yet tested this out ingame

We also need to verify what happens if you try to loot those 0 condition items again and equip them. Although this shouldnt be too buggy as that would also be possible with the blacksmith retinue in vanilla


### Blacksmith
![image](https://github.com/user-attachments/assets/4e8b1703-baa8-4646-8dc4-9ef76b516d24)

### Simple Test with Lute
![image](https://github.com/user-attachments/assets/95583208-94b9-4034-8656-29554117a57d)

