### PR TITLE
refactor: remove changing killer during onDeath

### DIFF
--- a/mod_reforged/hooks/config/tip_of_the_day.nut
+++ b/mod_reforged/hooks/config/tip_of_the_day.nut
@@ -29,7 +29,7 @@ for (local index = (::Const.TipOfTheDay.len() - 1); index >= 0; index--)
 	"Click on an active contract to focus on its target on the world map, if it is known to you.",
 	"The more mods you add the harder it is to debug the game for the modder.",
 	"Reforged: Tavern rumors will never be about legendary locations you have already discovered.",
-	"Reforged: Enemies will only drop loot if your faction has dealt at least 50% of the total damage received by that enemy.",
+	// "Reforged: Enemies will only drop loot if your faction has dealt at least 50% of the total damage received by that enemy." // This feature is removed due to mod compatibility issues, and should be re-included if we can find a good way.
 	"Reforged: Experience from slain enemies is awarded depending on how much damage was dealt to them by your brothers.",
 	"If you see colorful squares, do NOT save the game or you might end up with a corrupted save file."
 ]);

--- a/scripts/!mods_preload/mod_reforged.nut
+++ b/scripts/!mods_preload/mod_reforged.nut
@@ -45,32 +45,6 @@ foreach (requirement in requiredMods)
 
 // TODO: Establish a cleaner way to organize "Early" bucket hooks on a per-file basis
 ::Reforged.HooksMod.queue(queueLoadOrder, function() {
-	::Reforged.HooksMod.hookTree("scripts/entity/tactical/actor", function(q) {
-		q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )
-		{
-			local playerRelevantDamage = 0.0;
-			if (::Const.Faction.Player in this.m.RF_DamageReceived)
-				playerRelevantDamage += this.m.RF_DamageReceived[::Const.Faction.Player].Total;
-			if (::Const.Faction.PlayerAnimals in this.m.RF_DamageReceived)
-				playerRelevantDamage +=  this.m.RF_DamageReceived[::Const.Faction.PlayerAnimals].Total;
-
-			// If player + player animals did at least 50% of total damage to this actor, we set the _killer to null to ensure that the loot properly drops from this actor.
-			// This is because vanilla drops loot if _killer is null or belongs to Player or PlayerAnimals faction.
-			// Warning: This will break any mod that hooks the original onDeath and expects _killer to represent the actual killer
-			if (playerRelevantDamage / this.m.RF_DamageReceived.Total >= 0.5)
-			{
-				_killer = null;
-			}
-			// Otherwise set the killer to the dying entity itself, so loot doesn't spawn for the player
-			else if (_killer == null || _killer.getFaction() == ::Const.Faction.Player || _killer.getFaction() == ::Const.Faction.PlayerAnimals)
-			{
-				_killer = this;
-			}
-
-			__original(_killer, _skill, _tile, _fatalityType);
-		}
-	});
-
 	::Reforged.HooksMod.hook("scripts/items/shields/shield", function(q) {
 		// Hook the vanilla function so that ShieldExpert does not reduce damage to shields.
 		// We do this in Early bucket so that subsequent hooks on this function are not affected


### PR DESCRIPTION
The purpose of this feature was to make loot drop only if the player and player animals did at least 50% damage to the dying entity, regardless of who the killer is. However, this was accomplished by changing the `_killer` which leads to conflicts with other mods which expect the `_killer` to be the real killer. So, in view of greater compatibility with mods, this feature should be removed until a more stable and more compatible method of accomplishing this can be achieved.

Associated bug report on Discord: https://discord.com/channels/1006908336991645757/1327651957657305099