### PR TITLE
fix: fallen heroes sometimes being forever stuck in place

### DIFF
--- a/scripts/skills/racial/rf_zombie_racial.nut
+++ b/scripts/skills/racial/rf_zombie_racial.nut
@@ -97,4 +97,9 @@ this.rf_zombie_racial <- ::inherit("scripts/skills/skill", {
 		baseProperties.FatigueEffectMult = this.m.FatigueEffectMult;
 		baseProperties.FatigueDealtPerHitMult += this.m.FatigueDealtPerHitMultModifier;	// In vanilla normal zombies don't have this bonus
 	}
+
+	function onUpdate( _properties )
+	{
+		_properties.Stamina += 50;	// Fix heavily armored zombies not moving at all because they reach super low stamina and level 4 encumbrance
+	}
 });


### PR DESCRIPTION
This is a quick way to fix situations like these, where Fallen Heroes are stuck in place.
This is very likely because their AI thinks they can't do any action because of their low available Stamina and the increased travel cost from level 4 encumbrance; Despite them having a 0% fatigue multiplier on all actions.

![Exhibit_A](https://github.com/user-attachments/assets/238b37f8-7688-401c-b88d-744fa3c73888)
![Exhibit_B](https://github.com/user-attachments/assets/f79f59b2-acc1-4483-b1a1-31770eaa5f8f)
![Exhibit_C](https://github.com/user-attachments/assets/2a2030bb-bfe9-4489-a32e-4d68802386bd)
![Exhibit_D](https://github.com/user-attachments/assets/64104f47-755c-4e1a-98d8-a8c0e27b3d96)
