### PR TITLE
Fix command ai freeze

### DIFF
--- a/scripts/ai/tactical/behaviors/ai_rf_command.nut
+++ b/scripts/ai/tactical/behaviors/ai_rf_command.nut
@@ -78,7 +78,7 @@ this.ai_rf_command <- ::inherit("scripts/ai/tactical/behavior", {
 		foreach (a in allAllies)
 		{
 			// Skip allies who have already started their turn (and waited) or have ended their turn or are already in queue to act before all enemies or if the target is not valid for the skill
-			if (a.isTurnStarted() || a.isTurnDone() || ::Tactical.TurnSequenceBar.getTurnsUntilActive(a.getID()) < nextEnemyTurn || !this.m.Skill.onVerifyTarget(myTile, a.getTile()))
+			if (a.isTurnStarted() || a.isTurnDone() || ::Tactical.TurnSequenceBar.getTurnsUntilActive(a.getID()) < nextEnemyTurn || !this.m.Skill.isUsableOn(a.getTile()))
 			{
 				continue;
 			}
@@ -252,7 +252,7 @@ this.ai_rf_command <- ::inherit("scripts/ai/tactical/behavior", {
 			}
 			else
 			{
-				if (currentDanger >= ::Const.AI.Behavior.PossessUndeadMaxDanger || !this.m.Skill.onVerifyTarget(myTile, t.Tile))
+				if (currentDanger >= ::Const.AI.Behavior.PossessUndeadMaxDanger || !this.m.Skill.isUsableOn(t.Tile))
 				{
 					continue;
 				}


### PR DESCRIPTION
There are three `onVerifyTarget` in the old implementation. I couldnt replace the third one though as it simulates future tiles and isUsableOn always takes the skill owners current tile as the origin.


I tested this with a toggle of the before and after condition like this:
![image](https://github.com/user-attachments/assets/62550e23-f9f6-4fdd-affb-5542850925a9)

Then I pumpted the score for ai_command x100 and set its minimum range to 2 and maximum range to 1 = (impossible to use)

I did 3 (each) back&forth tests with both setups in a fight against 4 heralds
![image](https://github.com/user-attachments/assets/e1c1e426-972e-4a8d-acf4-f2c2f774b2f3)

The marked herald in exactly this setup consistently froze the game with the old check.
After the check swap (see first screenshot), I got no more freezes here. Instead that guy tried to move elsewhere


This is not a complete test by all means but good enough for me
