### PR TITLE
refactor: hide decisive outside of combat

### DIFF
--- a/scripts/skills/perks/perk_rf_decisive.nut
+++ b/scripts/skills/perks/perk_rf_decisive.nut
@@ -28,6 +28,12 @@ this.perk_rf_decisive <- ::inherit("scripts/skills/skill", {
 		return this.m.Stacks == 0 ? this.m.Name : this.m.Name + " (x" + this.m.Stacks + ")";
 	}
 
+	// During combat we always display this effect on player characters even with 0 stacks as a helpful reminder
+	function isHidden()
+	{
+		return !::Tactical.isActive() || this.m.Stacks == 0 && !this.getContainer().getActor().isPlayerControlled();
+	}
+
 	function getTooltip()
 	{
 		local ret = this.skill.getTooltip();


### PR DESCRIPTION
With the last release, we made it so decisive shows, no matter how many stacks you have, meant to help the player during combat to remember this perks restriction.
As a result it also shows outside of battle.

This PR adjusts the perk to always show during combat but never outside of it