### PR TITLE
refactor: move all actual effects from PP to realized potential

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1706,7 +1706,8 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Type = ::UPD.EffectType.OneTimeEffect,
 			Description = [
 				"Upon reaching level 11, this perk has a " + ::MSU.Text.colorPositive("50%") + " chance of being replaced with [Realized Potential|Perk+perk_rf_realized_potential].",
-				"If unsuccessful, this perk is replaced by [Failed Potential|Perk+perk_rf_failed_potential] which does nothing."
+				"If unsuccessful, this perk is replaced by [Failed Potential|Perk+perk_rf_failed_potential] which does nothing.",
+				"A [Player Character|Skill+player_character_trait] has a " + ::MSU.Text.colorPositive("100%") + " chance to succeed."
 			]
 		}],
 		Footer = ::MSU.Text.colorNegative("This perk cannot be picked after you have spent a perk point elsewhere. This perk cannot be refunded.")

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1705,7 +1705,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.OneTimeEffect,
 			Description = [
-				"Upon reaching level 11, this perk has a " + ::MSU.Text.colorPositive("50%") + " chance of being replaced with [Realized Potential|Perk+perk_rf_realized_potential] which will double this character\'s salary, increase all attributes by " + ::MSU.Text.colorPositive("+15") + ", unlock new perk groups and refund all perk points, including the one spent on this perk.",
+				"Upon reaching level 11, this perk has a " + ::MSU.Text.colorPositive("50%") + " chance of being replaced with [Realized Potential|Perk+perk_rf_realized_potential].",
 				"If unsuccessful, this perk is replaced by [Failed Potential|Perk+perk_rf_failed_potential] which does nothing."
 			]
 		}],
@@ -1731,7 +1731,25 @@ foreach (vanillaDesc in vanillaDescriptions)
 		}]
 	}),
 	RF_RealizedPotential = ::UPD.getDescription({
-		Fluff = "From bones to brawn! This character has truly come a long way. Who was once a dreg of society is now a full-fledged mercenary. " + ::MSU.Text.colorPositive("\n\nAll perk points have been refunded and attributes increased."),
+		Fluff = "From bones to brawn! This character has truly come a long way. Who was once a dreg of society is now a full-fledged mercenary.",
+		Effects = [
+			{
+				Type = ::UPD.EffectType.Passive,
+				Description = [
+					"Require " + ::MSU.Text.colorNegative("100%") + " more daily wage.",
+				]
+			},
+			{
+				Type = ::UPD.EffectType.OneTimeEffect,
+				Description = [
+					"Refund all spent Perk Points.",
+					"Gain " + ::MSU.Text.colorPositive("+1") + " Perk Point.",
+					"Gain " + ::MSU.Text.colorPositive("1") + " random Shared Perk Group.",
+					"Gain " + ::MSU.Text.colorPositive("2") + " random Weapon Perk Groups.",
+					"All Attributes are increased by " + ::MSU.Text.colorPositive("+15") + "."
+				]
+			}
+		],
 		Footer = ::MSU.Text.colorNegative("This perk cannot be refunded.")
 	}),
 	RF_Rebuke = ::UPD.getDescription({

--- a/scripts/skills/perks/perk_rf_promised_potential.nut
+++ b/scripts/skills/perks/perk_rf_promised_potential.nut
@@ -1,6 +1,5 @@
 this.perk_rf_promised_potential <- ::inherit("scripts/skills/skill", {
 	m = {
-		StatBoost = 15,
 		WillSucceed = false
 	},
 	function create()
@@ -32,65 +31,17 @@ this.perk_rf_promised_potential <- ::inherit("scripts/skills/skill", {
 			local perkTree = actor.getPerkTree();
 			perkTree.removePerk(this.getID());
 
-			if (!this.m.WillSucceed)
+			if (this.m.WillSucceed)
 			{
-				perkTree.addPerk("perk.rf_failed_potential", 1);
-				this.getContainer().add(::new("scripts/skills/perks/perk_rf_failed_potential"));
+				perkTree.addPerk("perk.rf_realized_potential", 1);
+				this.getContainer().add(::new("scripts/skills/perks/perk_rf_realized_potential"));
+				actor.improveMood(1.0, "Realized potential");
+				actor.getBackground().m.Description += " Once a dreg of society, with your help, " + actor.getNameOnly() + " has grown into a full-fledged mercenary.";
 			}
 			else
 			{
-				actor.m.PerkPoints++;
-				actor.m.PerkPointsSpent--;
-				perkTree.addPerk("perk.rf_realized_potential", 1);
-				this.getContainer().add(::new("scripts/skills/perks/perk_rf_realized_potential"));
-
-				local b = actor.getBaseProperties();
-				b.DailyWageMult *= 2;
-				b.MeleeSkill += this.m.StatBoost;
-				b.MeleeDefense += this.m.StatBoost;
-				b.RangedSkill += this.m.StatBoost;
-				b.RangedDefense += this.m.StatBoost;
-				b.Hitpoints += this.m.StatBoost;
-				b.Stamina += this.m.StatBoost;
-				b.Initiative += this.m.StatBoost;
-				b.Bravery += this.m.StatBoost;
-
-				actor.getBackground().m.Description += " Once a dreg of society, with your help, " + actor.getNameOnly() + " has grown into a full-fledged mercenary.";
-
-				local categories = [
-					"pgc.rf_shared_1",
-					"pgc.rf_weapon",
-					"pgc.rf_weapon"
-				];
-
-				local exclude = ["pg.rf_tactician"];
-
-				foreach (categoryID in categories)
-				{
-					local category = ::DynamicPerks.PerkGroupCategories.findById(categoryID);
-					foreach (groupID in category.getGroups())
-					{
-						if (perkTree.hasPerkGroup(groupID)) exclude.push(groupID);
-					}
-					local newPerkGroup = category.getRandomGroup(exclude);
-					if (newPerkGroup != null) perkTree.addPerkGroup(newPerkGroup);
-				}
-
-				foreach (i, row in perkTree.getTree())
-				{
-					if (row.len() <= 13) continue;
-					for (local i = row.len() - 1; i > 12; i--)
-					{
-						local id = row[i].ID;
-						local tier = i + 1;
-						perkTree.removePerk(id);
-						if (tier != 7) perkTree.addPerk(id, tier + 1);
-					}
-				}
-
-				actor.resetPerks();
-
-				actor.improveMood(1.0, "Realized potential");
+				perkTree.addPerk("perk.rf_failed_potential", 1);
+				this.getContainer().add(::new("scripts/skills/perks/perk_rf_failed_potential"));
 			}
 		}
 	}

--- a/scripts/skills/perks/perk_rf_promised_potential.nut
+++ b/scripts/skills/perks/perk_rf_promised_potential.nut
@@ -31,6 +31,11 @@ this.perk_rf_promised_potential <- ::inherit("scripts/skills/skill", {
 			local perkTree = actor.getPerkTree();
 			perkTree.removePerk(this.getID());
 
+			if (this.getContainer().hasSkill("trait.player"))
+			{
+				this.m.WillSucceed = true;
+			}
+
 			if (this.m.WillSucceed)
 			{
 				perkTree.addPerk("perk.rf_realized_potential", 1);

--- a/scripts/skills/perks/perk_rf_realized_potential.nut
+++ b/scripts/skills/perks/perk_rf_realized_potential.nut
@@ -1,5 +1,15 @@
 this.perk_rf_realized_potential <- ::inherit("scripts/skills/skill", {
-	m = {},
+	m = {
+		AttributeModifier = 15,
+		DailyWageMult = 2.0,
+		NewPerkGroups = {
+			"pgc.rf_shared_1": 1, // categoryID : numGroups from this category
+			"pgc.rf_weapon": 2
+		},
+		ExcludedPerkGroups = [
+			"pg.rf_tactician"
+		]
+	},
 	function create()
 	{
 		this.m.ID = "perk.rf_realized_potential";
@@ -9,5 +19,67 @@ this.perk_rf_realized_potential <- ::inherit("scripts/skills/skill", {
 		this.m.Type = ::Const.SkillType.Perk;
 		this.m.Order = ::Const.SkillOrder.Perk;
 		this.m.IsRefundable = false;
+	}
+
+	function onAdded()
+	{
+		if (this.m.IsNew)
+		{
+			local actor = this.getContainer().getActor();
+
+			actor.resetPerks();
+			actor.m.PerkPoints++;
+
+			// Adjust Wage and Attributes
+			local b = actor.getBaseProperties();
+			b.DailyWageMult *= 2;
+			b.MeleeSkill += this.m.AttributeModifier;
+			b.MeleeDefense += this.m.AttributeModifier;
+			b.RangedSkill += this.m.AttributeModifier;
+			b.RangedDefense += this.m.AttributeModifier;
+			b.Hitpoints += this.m.AttributeModifier;
+			b.Stamina += this.m.AttributeModifier;
+			b.Initiative += this.m.AttributeModifier;
+			b.Bravery += this.m.AttributeModifier;
+
+			// Add new Perk Groups
+			local perkTree = actor.getPerkTree();
+			local exclude = clone this.m.ExcludedPerkGroups;
+
+			foreach (categoryID, numGroups in this.m.NewPerkGroups)
+			{
+				local category = ::DynamicPerks.PerkGroupCategories.findById(categoryID);
+				foreach (groupID in category.getGroups())
+				{
+					if (perkTree.hasPerkGroup(groupID))
+						exclude.push(groupID);
+				}
+
+				for (local i = 0; i < numGroups; i++)
+				{
+					local newPerkGroup = category.getRandomGroup(exclude);
+					if (newPerkGroup != null)
+					{
+						perkTree.addPerkGroup(newPerkGroup);
+						exclude.push(newPerkGroup);
+					}
+				}
+			}
+
+			// Adjust bro's perk tree so that no row is longer than 13 perks (so that it fits in the UI properly)
+			foreach (i, row in perkTree.getTree())
+			{
+				if (row.len() <= 13)
+					continue;
+
+				for (local i = row.len() - 1; i > 12; i--)
+				{
+					local id = row[i].ID;
+					local tier = i + 1;
+					perkTree.removePerk(id);
+					if (tier != 7) perkTree.addPerk(id, tier + 1);
+				}
+			}
+		}
 	}
 });


### PR DESCRIPTION
- Promised Potential now has a 100% chance to succeed at level 11 if the user has the **Player Character** perk
- Promised Potential perk description has been simplified a lot by moving all the effects into the **Realized Potential Description**

I verified that this change works by setting the WillSucceed chance to 0 and printing the WillSucceed chance right before it is swapped from the PlayerCharacter trait.
Then I loaded a Random Solo with a pauper starter and confirmed that he succeeded at level 11

![image](https://github.com/user-attachments/assets/29a65724-ce3b-485c-871f-1059fd889174)


![image](https://github.com/user-attachments/assets/b6288767-be07-4297-9ac0-67ee21b68d95)

**Player Character** is technically a trait but I decided to just call it like this

### Old Image from initial PR
![image](https://github.com/user-attachments/assets/a23152b0-1aa1-4295-9a4e-2311062f415d)