### PR TITLE
refactor: improve rush of battle stacks management

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -2011,7 +2011,8 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Whenever you attack or are attacked, hit or miss, gain a stacking " + ::MSU.Text.colorPositive("+5") + " [Initiative|Concept.Initiative] and " + ::MSU.Text.colorPositive("+5%") + " reduction to the [Fatigue|Concept.Fatigue] cost of skills until the end of your [turn,|Concept.Turn] up to a maximum of " + ::MSU.Text.colorPositive("+25") + " and " + ::MSU.Text.colorPositive("+25%") + " respectively."
+				"Whenever you attack or are attacked, hit or miss, gain a stacking " + ::MSU.Text.colorPositive("+5") + " [Initiative|Concept.Initiative] and " + ::MSU.Text.colorPositive("+5%") + " reduction to the [Fatigue|Concept.Fatigue] cost of skills until the end of your next [turn,|Concept.Turn] up to a maximum of " + ::MSU.Text.colorPositive("+25") + " and " + ::MSU.Text.colorPositive("+25%") + " respectively.",
+				"Stacks gained during each [turn|Concept.Turn] are tracked separately."
 			]
 		}]
 	}),


### PR DESCRIPTION
Stacks gained during each turn are tracked separately and expire at the end of their next turn.