### PR TITLE
feat: allow armor attachments to spawn on northern human enemies

### DIFF
--- a/mod_reforged/config/config.nut
+++ b/mod_reforged/config/config.nut
@@ -4,5 +4,14 @@
 
 	UI = {
 		WorldBannerYOffset = 50
+	},
+
+	// Chance that units of a certain tier can spawn with armor attachments.
+	// Is used directly within entity files to roll for the chance
+	ArmorAttachmentChance = {
+		Tier4 = 40,
+		Tier3 = 30,
+		Tier2 = 20,
+		Tier1 = 10
 	}
 }

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_leader.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_leader.nut
@@ -132,6 +132,22 @@
 				if (helmet != null) this.m.Items.equip(::new(helmet));
 			}
 		}
+
+		local bodyItem = this.getBodyItem();
+		if (bodyItem != null && !bodyItem.isItemType(::Const.Items.ItemType.Named) && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+		{
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier > 40) return 0.0;
+					return _weight;
+				}
+			});
+
+			if (armorAttachment != null)
+				bodyItem.setUpgrade(::new(armorAttachment));
+		}
 	}
 
 	q.makeMiniboss = @() function()

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_leader.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_leader.nut
@@ -82,30 +82,55 @@
 			}
 		}
 
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+		if (this.m.IsMiniboss)
 		{
-			local armor = ::Reforged.ItemTable.BanditArmorLeader.roll({
-				Apply = function ( _script, _weight )
-				{
-					local conditionMax = ::ItemTables.ItemInfoByScript[_script].ConditionMax;
-					if (conditionMax < 210 || conditionMax > 240) return 0.0;
-					return _weight;
-				}
-			})
-			if (armor != null) this.m.Items.equip(::new(armor));
-		}
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+			{
+				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+					[1, "scripts/items/armor/rf_breastplate"],
+					[1, "scripts/items/armor/rf_brigandine_armor"],
+					[1, "scripts/items/armor/sellsword_armor"]
+				]).roll()));
+			}
 
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+			{
+				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+					[1, "scripts/items/helmets/barbute_helmet"],
+					[1, "scripts/items/helmets/rf_half_closed_sallet"],
+					[1, "scripts/items/helmets/rf_conical_billed_helmet"],
+					[1, "scripts/items/helmets/rf_sallet_helmet_with_mail"],
+					[1, "scripts/items/helmets/rf_padded_conical_billed_helmet"]
+				]).roll()));
+			}
+		}
+		else
 		{
-			local helmet = ::Reforged.ItemTable.BanditHelmetLeader.roll({
-				Apply = function ( _script, _weight )
-				{
-					local conditionMax = ::ItemTables.ItemInfoByScript[_script].ConditionMax;
-					if (conditionMax < 180 || conditionMax > 230) return 0.0;
-					return _weight;
-				}
-			})
-			if (helmet != null) this.m.Items.equip(::new(helmet));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+			{
+				local armor = ::Reforged.ItemTable.BanditArmorLeader.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionMax = ::ItemTables.ItemInfoByScript[_script].ConditionMax;
+						if (conditionMax < 210 || conditionMax > 240) return 0.0;
+						return _weight;
+					}
+				})
+				if (armor != null) this.m.Items.equip(::new(armor))
+			}
+
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+			{
+				local helmet = ::Reforged.ItemTable.BanditHelmetLeader.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionMax = ::ItemTables.ItemInfoByScript[_script].ConditionMax;
+						if (conditionMax < 180 || conditionMax > 230) return 0.0;
+						return _weight;
+					}
+				})
+				if (helmet != null) this.m.Items.equip(::new(helmet));
+			}
 		}
 	}
 

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_marksman.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_marksman.nut
@@ -68,7 +68,26 @@
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 20) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
@@ -73,7 +73,26 @@
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 30) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/mod_reforged/hooks/entity/tactical/humans/bounty_hunter.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/bounty_hunter.nut
@@ -39,5 +39,25 @@
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
+
+		if (this.getBodyItem() != null && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+		{
+			local armor = this.getBodyItem();
+			local conditionModifierCutoff = armor.getConditionMax() < 115 ? 20 : 30;
+
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier > conditionModifierCutoff) return 0.0;
+					return _weight;
+				}
+			});
+
+			if (armorAttachment != null)
+			{
+				this.getBodyItem().setUpgrade(::new(armorAttachment));
+			}
+		}
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/humans/bounty_hunter_ranged.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/bounty_hunter_ranged.nut
@@ -29,5 +29,23 @@
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
+
+		if (this.getBodyItem() != null)
+		{
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier2)
+			{
+				local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+						if (conditionModifier > 20) return 0.0;
+						return _weight;
+					}
+				})
+
+				if (armorAttachment != null)
+					this.getBodyItem().setUpgrade(::new(armorAttachment));
+			}
+		}
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/humans/caravan_guard.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/caravan_guard.nut
@@ -33,5 +33,23 @@
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
+
+		if (this.getBodyItem() != null)
+		{
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier2)
+			{
+				local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+						if (conditionModifier > 20) return 0.0;
+						return _weight;
+					}
+				})
+
+				if (armorAttachment != null)
+					this.getBodyItem().setUpgrade(::new(armorAttachment));
+			}
+		}
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
@@ -80,6 +80,22 @@
 				]).roll()));
 			}
 		}
+
+		local bodyItem = this.getBodyItem();
+		if (bodyItem != null && !bodyItem.isItemType(::Const.Items.ItemType.Named) && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+		{
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier < 30) return 0.0;
+					return _weight;
+				}
+			});
+
+			if (armorAttachment != null)
+				bodyItem.setUpgrade(::new(armorAttachment));
+		}
 	}
 
 	q.makeMiniboss = @() function()

--- a/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
@@ -41,26 +41,44 @@
 			this.m.Items.equip(::new(weapon));
 		}
 
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+		if (this.m.IsMiniboss)
 		{
-			local armor = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/armor/heavy_lamellar_armor"],
-				[1, "scripts/items/armor/coat_of_plates"],
-				[1, "scripts/items/armor/coat_of_scales"]
-			]).roll();
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+			{
+				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+					[1, "scripts/items/armor/rf_breastplate_armor"],
+					[1, "scripts/items/armor/rf_breastplate_harness"]
+				]).roll()));
+			}
 
-			this.m.Items.equip(::new(armor));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+			{
+				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+					[1, "scripts/items/helmets/rf_half_closed_sallet_with_mail"],
+					[1, "scripts/items/helmets/rf_visored_bascinet"],
+					[1, "scripts/items/helmets/rf_half_closed_sallet_with_bevor"]
+				]).roll()));
+			}
 		}
-
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+		else
 		{
-			local helmet = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/helmets/closed_flat_top_with_mail"],
-				[0.5, "scripts/items/helmets/conic_helmet_with_faceguard"],
-				[1, "scripts/items/helmets/full_helm"]
-			]).roll();
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+			{
+				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+					[1, "scripts/items/armor/heavy_lamellar_armor"],
+					[1, "scripts/items/armor/coat_of_plates"],
+					[1, "scripts/items/armor/coat_of_scales"]
+				]).roll()));
+			}
 
-			this.m.Items.equip(::new(helmet));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+			{
+				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+					[1, "scripts/items/helmets/closed_flat_top_with_mail"],
+					[0.5, "scripts/items/helmets/conic_helmet_with_faceguard"],
+					[1, "scripts/items/helmets/full_helm"]
+				]).roll()));
+			}
 		}
 	}
 

--- a/mod_reforged/hooks/entity/tactical/humans/knight.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/knight.nut
@@ -58,6 +58,22 @@
 			]).roll()));
 		}
 
+		local bodyItem = this.getBodyItem();
+		if (bodyItem != null && !bodyItem.isItemType(::Const.Items.ItemType.Named) && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier2)
+		{
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier < 30) return 0.0;
+					return _weight;
+				}
+			})
+
+			if (armorAttachment != null)
+				bodyItem.setUpgrade(::new(armorAttachment));
+		}
+
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
 		{
 			local script = ::MSU.Class.WeightedContainer([

--- a/mod_reforged/hooks/entity/tactical/humans/master_archer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/master_archer.nut
@@ -75,6 +75,22 @@
 				if (helmet != null) this.m.Items.equip(::new(helmet));
 			}
 		}
+
+		local bodyItem = this.getBodyItem();
+		if (bodyItem != null && !bodyItem.isItemType(::Const.Items.ItemType.Named) && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier2)
+		{
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier > 20) return 0.0;
+					return _weight;
+				}
+			});
+
+			if (armorAttachment != null)
+				bodyItem.setUpgrade(::new(armorAttachment));
+		}
 	}
 
 	q.makeMiniboss = @() function()

--- a/mod_reforged/hooks/entity/tactical/humans/master_archer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/master_archer.nut
@@ -52,23 +52,28 @@
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
 		{
-			local armor = ::MSU.Class.WeightedContainer([
+			this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
 				[1, "scripts/items/armor/thick_tunic"],
 				[1, "scripts/items/armor/padded_surcoat"],
 				[1, "scripts/items/armor/gambeson"]
-			]).roll();
-
-			this.m.Items.equip(::new(armor));
+			]).roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
 		{
-			local helmet = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/helmets/hood"],
-				[1, "scripts/items/helmets/hunters_hat"]
-			]).rollChance(33);
+			if (this.m.IsMiniboss)
+			{
+				this.m.Items.equip(::new("scripts/items/helmets/greatsword_hat"));
+			}
+			else
+			{
+				local helmet = ::MSU.Class.WeightedContainer([
+					[1, "scripts/items/helmets/hood"],
+					[1, "scripts/items/helmets/hunters_hat"]
+				]).rollChance(33);
 
-			if (helmet != null) this.m.Items.equip(::new(helmet));
+				if (helmet != null) this.m.Items.equip(::new(helmet));
+			}
 		}
 	}
 

--- a/mod_reforged/hooks/entity/tactical/humans/mercenary.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/mercenary.nut
@@ -219,6 +219,32 @@
 			}
 		}
 
+		if (this.getBodyItem() != null && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+		{
+			local armor = this.getBodyItem();
+			local conditionMax = armor.getConditionMax();
+
+			local conditionModifierCutoff = 40;
+			if (conditionMax < 90)
+				conditionModifierCutoff = 20;
+			else if (conditionMax < 150)
+				conditionModifierCutoff = 30;
+
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier > conditionModifierCutoff) return 0.0;
+					return _weight;
+				}
+			});
+
+			if (armorAttachment != null)
+			{
+				armor.setUpgrade(::new(armorAttachment));
+			}
+		}
+
 		if (::Math.rand(1, 100) <= 95)
 		{
 			local helmets = [

--- a/mod_reforged/hooks/entity/tactical/humans/mercenary_ranged.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/mercenary_ranged.nut
@@ -37,5 +37,24 @@
 		__original();
 
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
+
+		if (this.getBodyItem() != null && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+		{
+			local armor = this.getBodyItem();
+			local conditionModifierCutoff = armor.getConditionMax() < 115 ? 10 : 20;
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier > conditionModifierCutoff) return 0.0;
+					return _weight;
+				}
+			});
+
+			if (armorAttachment != null)
+			{
+				armor.setUpgrade(::new(armorAttachment));
+			}
+		}
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/humans/noble_arbalester.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_arbalester.nut
@@ -37,11 +37,28 @@
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
 		{
-			this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+			local armor = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/armor/gambeson"],
 				[1, "scripts/items/armor/padded_leather"],
 				[1, "scripts/items/armor/leather_lamellar"]
-			]).roll()));
+			]).roll();
+
+			this.m.Items.equip(::new(armor));
+
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+			{
+				local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+						if (conditionModifier > 20) return 0.0;
+						return _weight;
+					}
+				})
+
+				if (armorAttachment != null)
+					this.getBodyItem().setUpgrade(::new(armorAttachment));
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/mod_reforged/hooks/entity/tactical/humans/noble_billman.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_billman.nut
@@ -34,11 +34,28 @@
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
 		{
-			this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+			local armor = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/armor/gambeson"],
 				[1, "scripts/items/armor/basic_mail_shirt"],
 				[1, "scripts/items/armor/mail_shirt"]
-			]).roll()));
+			]).roll();
+
+			this.m.Items.equip(::new(armor));
+
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+			{
+				local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+						if (conditionModifier > 20) return 0.0;
+						return _weight;
+					}
+				})
+
+				if (armorAttachment != null)
+					this.getBodyItem().setUpgrade(::new(armorAttachment));
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/mod_reforged/hooks/entity/tactical/humans/noble_footman.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_footman.nut
@@ -59,6 +59,21 @@
 				armor.setVariant(28);
 
 			this.m.Items.equip(armor);
+
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+			{
+				local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+						if (conditionModifier > 30) return 0.0;
+						return _weight;
+					}
+				})
+
+				if (armorAttachment != null)
+					armor.setUpgrade(::new(armorAttachment));
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/mod_reforged/hooks/entity/tactical/humans/noble_greatsword.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_greatsword.nut
@@ -69,6 +69,22 @@
 				this.m.Items.equip(helmet);
 			}
 		}
+
+		local bodyItem = this.getBodyItem();
+		if (bodyItem != null && !bodyItem.isItemType(::Const.Items.ItemType.Named) && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+		{
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier > 40) return 0.0;
+					return _weight;
+				}
+			});
+
+			if (armorAttachment != null)
+				bodyItem.setUpgrade(::new(armorAttachment));
+		}
 	}
 
 	q.onSpawned = @() function()

--- a/mod_reforged/hooks/entity/tactical/humans/standard_bearer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/standard_bearer.nut
@@ -41,6 +41,21 @@
 				armor.setVariant(28);
 
 			this.m.Items.equip(armor);
+
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+			{
+				local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+						if (conditionModifier > 30) return 0.0;
+						return _weight;
+					}
+				})
+
+				if (armorAttachment != null)
+					armor.setUpgrade(::new(armorAttachment));
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/mod_reforged/hooks/entity/tactical/humans/swordmaster.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/swordmaster.nut
@@ -54,18 +54,31 @@
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
 		{
+			local armor;
 			if (this.m.MyArmorVariant == 0) // light armor
 			{
-				this.m.Items.equip(::new("scripts/items/armor/noble_mail_armor"));
+				armor = "scripts/items/armor/noble_mail_armor";
 			}
 			else // medium armor
 			{
-				local armor = ::MSU.Class.WeightedContainer([
+				armor = ::MSU.Class.WeightedContainer([
 					[1, "scripts/items/armor/rf_breastplate"],
 					[1, "scripts/items/armor/rf_brigandine_armor"]
 				]).roll();
+			}
 
-				this.m.Items.equip(::new(armor));
+			this.m.Items.equip(::new(armor));
+
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+			{
+				local armorAttachment = ::MSU.Class.WeightedContainer([
+					[1, "scripts/items/armor_upgrades/direwolf_pelt_upgrade"],
+					[1, "scripts/items/armor_upgrades/leather_shoulderguards_upgrade"],
+					[1, "scripts/items/armor_upgrades/double_mail_upgrade"]
+				]).roll();
+
+				if (armorAttachment != null)
+					this.getBodyItem().setUpgrade(::new(armorAttachment));
 			}
 		}
 

--- a/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_bandit.nut
@@ -115,7 +115,26 @@ this.rf_bandit_bandit <- ::inherit("scripts/entity/tactical/human", {
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 20) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/enemies/rf_bandit_baron.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_baron.nut
@@ -165,6 +165,22 @@ this.rf_bandit_baron <- ::inherit("scripts/entity/tactical/human", {
 				if (helmet != null) this.m.Items.equip(::new(helmet));
 			}
 		}
+
+		local bodyItem = this.getBodyItem();
+		if (bodyItem != null && !bodyItem.isItemType(::Const.Items.ItemType.Named) && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+		{
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier > 40) return 0.0;
+					return _weight;
+				}
+			});
+
+			if (armorAttachment != null)
+				bodyItem.setUpgrade(::new(armorAttachment));
+		}
 	}
 
 	function makeMiniboss()

--- a/scripts/entity/tactical/enemies/rf_bandit_baron.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_baron.nut
@@ -117,30 +117,53 @@ this.rf_bandit_baron <- ::inherit("scripts/entity/tactical/human", {
 			}
 		}
 
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+		if (this.m.IsMiniboss)
 		{
-			local armor = ::Reforged.ItemTable.BanditArmorLeader.roll({
-				Apply = function ( _script, _weight )
-				{
-					local conditionMax = ::ItemTables.ItemInfoByScript[_script].ConditionMax;
-					if (conditionMax < 260 || conditionMax > 300) return 0.0;
-					return _weight;
-				}
-			})
-			if (armor != null) this.m.Items.equip(::new(armor));
-		}
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+			{
+				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+					[1, "scripts/items/armor/rf_brigandine_harness"],
+					[1, "scripts/items/armor/rf_breastplate_armor"],
+					[1, "scripts/items/armor/coat_of_plates"]
+				]).roll()));
+			}
 
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+			{
+				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+					[1, "scripts/items/helmets/rf_sallet_helmet_with_bevor"],
+					[1, "scripts/items/helmets/rf_half_closed_sallet_with_mail"],
+					[1, "scripts/items/helmets/rf_visored_bascinet"]
+				]).roll()));
+			}
+		}
+		else
 		{
-			local helmet = ::Reforged.ItemTable.BanditHelmetLeader.roll({
-				Apply = function ( _script, _weight )
-				{
-					local conditionMax = ::ItemTables.ItemInfoByScript[_script].ConditionMax;
-					if (conditionMax < 260 || conditionMax > 290) return 0.0;
-					return _weight;
-				}
-			})
-			if (helmet != null) this.m.Items.equip(::new(helmet));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+			{
+				local armor = ::Reforged.ItemTable.BanditArmorLeader.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionMax = ::ItemTables.ItemInfoByScript[_script].ConditionMax;
+						if (conditionMax < 260 || conditionMax > 300) return 0.0;
+						return _weight;
+					}
+				})
+				if (armor != null) this.m.Items.equip(::new(armor))
+			}
+
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+			{
+				local helmet = ::Reforged.ItemTable.BanditHelmetLeader.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionMax = ::ItemTables.ItemInfoByScript[_script].ConditionMax;
+						if (conditionMax < 260 || conditionMax > 290) return 0.0;
+						return _weight;
+					}
+				})
+				if (helmet != null) this.m.Items.equip(::new(helmet));
+			}
 		}
 	}
 

--- a/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_highwayman.nut
@@ -93,7 +93,26 @@ this.rf_bandit_highwayman <- ::inherit("scripts/entity/tactical/human", {
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 40) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/enemies/rf_bandit_hunter.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_hunter.nut
@@ -96,7 +96,26 @@ this.rf_bandit_hunter <- ::inherit("scripts/entity/tactical/human", {
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier2)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 10) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head) && ::Math.rand(1, 100) > 25)

--- a/scripts/entity/tactical/enemies/rf_bandit_killer.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_killer.nut
@@ -117,7 +117,26 @@ this.rf_bandit_killer <- ::inherit("scripts/entity/tactical/human", {
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 20) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/enemies/rf_bandit_marauder.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_marauder.nut
@@ -69,7 +69,26 @@ this.rf_bandit_marauder <- ::inherit("scripts/entity/tactical/human", {
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 20) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/enemies/rf_bandit_outlaw.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_outlaw.nut
@@ -68,7 +68,26 @@ this.rf_bandit_outlaw <- ::inherit("scripts/entity/tactical/human", {
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 20) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/enemies/rf_bandit_pillager.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_pillager.nut
@@ -67,6 +67,38 @@ this.rf_bandit_pillager <- ::inherit("scripts/entity/tactical/human", {
 					if (conditionMax < 35 || conditionMax > 55) return 0.0;
 					return _weight;
 				}
+			});
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier2)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 10) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
+		}
+
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+		{
+			local armor = ::Reforged.ItemTable.BanditArmorTough.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionMax = ::ItemTables.ItemInfoByScript[_script].ConditionMax;
+					if (conditionMax < 35 || conditionMax > 55) return 0.0;
+					return _weight;
+				}
 			})
 			this.m.Items.equip(::new(armor));
 		}

--- a/scripts/entity/tactical/enemies/rf_bandit_robber.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_robber.nut
@@ -100,7 +100,26 @@ this.rf_bandit_robber <- ::inherit("scripts/entity/tactical/human", {
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier2)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 10) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/enemies/rf_bandit_sharpshooter.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_sharpshooter.nut
@@ -90,7 +90,26 @@ this.rf_bandit_sharpshooter <- ::inherit("scripts/entity/tactical/human", {
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 20) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
@@ -92,7 +92,26 @@ this.rf_bandit_vandal <- ::inherit("scripts/entity/tactical/human", {
 					return _weight;
 				}
 			})
-			if (armor != null) this.m.Items.equip(::new(armor));
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier2)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 20) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head) && ::Math.rand(1, 100) >= 20)

--- a/scripts/entity/tactical/humans/rf_arbalester_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_arbalester_heavy.nut
@@ -52,11 +52,31 @@ this.rf_arbalester_heavy <- ::inherit("scripts/entity/tactical/human" {
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
 		{
-			this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+			local armor = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/armor/leather_lamellar"],
 				[1, "scripts/items/armor/basic_mail_shirt"],
 				[1, "scripts/items/armor/mail_shirt"]
-			]).roll()));
+			]).roll();
+
+			if (armor != null)
+			{
+				this.m.Items.equip(::new(armor));
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 20) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						this.getBodyItem().setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/humans/rf_billman_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_billman_heavy.nut
@@ -57,11 +57,29 @@ this.rf_billman_heavy <- ::inherit("scripts/entity/tactical/human" {
 				[1, "scripts/items/armor/light_scale_armor"]
 			]).roll();
 
-			local armor = ::new(script);
-			if (script == "scripts/items/armor/mail_hauberk")
-				armor.setVariant(28);
+			if (script != null)
+			{
+				local armor = ::new(script);
+				if (script == "scripts/items/armor/mail_hauberk")
+					armor.setVariant(28);
 
-			this.m.Items.equip(armor);
+				this.m.Items.equip(armor);
+
+				if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+				{
+					local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+						Apply = function ( _script, _weight )
+						{
+							local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+							if (conditionModifier > 30) return 0.0;
+							return _weight;
+						}
+					})
+
+					if (armorAttachment != null)
+						armor.setUpgrade(::new(armorAttachment));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/humans/rf_fencer.nut
+++ b/scripts/entity/tactical/humans/rf_fencer.nut
@@ -85,6 +85,16 @@ this.rf_fencer <- ::inherit("scripts/entity/tactical/human" {
 				]).roll()));
 			}
 		}
+
+		local bodyItem = this.getBodyItem();
+		if (bodyItem != null && !bodyItem.isItemType(::Const.Items.ItemType.Named) && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+		{
+			bodyItem.setUpgrade(::new(::MSU.Class.WeightedContainer([
+				[1, "scripts/items/armor_upgrades/direwolf_pelt_upgrade"],
+				[1, "scripts/items/armor_upgrades/leather_shoulderguards_upgrade"],
+				[1, "scripts/items/armor_upgrades/double_mail_upgrade"]
+			]).roll()));
+		}
 	}
 
 	function onSpawned()

--- a/scripts/entity/tactical/humans/rf_footman_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_footman_heavy.nut
@@ -76,6 +76,21 @@ this.rf_footman_heavy <- ::inherit("scripts/entity/tactical/human" {
 				armor.setVariant(28);
 
 			this.m.Items.equip(armor);
+
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+			{
+				local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+						if (conditionModifier > 40) return 0.0;
+						return _weight;
+					}
+				})
+
+				if (armorAttachment != null)
+					armor.setUpgrade(::new(armorAttachment));
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/humans/rf_knight_anointed.nut
+++ b/scripts/entity/tactical/humans/rf_knight_anointed.nut
@@ -77,10 +77,27 @@ this.rf_knight_anointed <- ::inherit("scripts/entity/tactical/human" {
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
 		{
-			this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+			local armor = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/armor/rf_breastplate_harness"],
 				[1, "scripts/items/armor/rf_foreign_plate_harness"]
-			]).roll()));
+			]).roll();
+
+			this.m.Items.equip(::new(armor));
+
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier2)
+			{
+				local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+						if (conditionModifier < 30) return 0.0;
+						return _weight;
+					}
+				})
+
+				if (armorAttachment != null)
+					this.getBodyItem().setUpgrade(::new(armorAttachment));
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/entity/tactical/humans/rf_man_at_arms.nut
+++ b/scripts/entity/tactical/humans/rf_man_at_arms.nut
@@ -92,6 +92,22 @@ this.rf_man_at_arms <- ::inherit("scripts/entity/tactical/human" {
 				]).roll()));
 			}
 		}
+
+		local bodyItem = this.getBodyItem();
+		if (bodyItem != null && !bodyItem.isItemType(::Const.Items.ItemType.Named) && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
+		{
+			local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+				Apply = function ( _script, _weight )
+				{
+					local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+					if (conditionModifier > 40) return 0.0;
+					return _weight;
+				}
+			});
+
+			if (armorAttachment != null)
+				bodyItem.setUpgrade(::new(armorAttachment));
+		}
 	}
 
 	function onSpawned()

--- a/scripts/entity/tactical/humans/rf_squire.nut
+++ b/scripts/entity/tactical/humans/rf_squire.nut
@@ -69,6 +69,21 @@ this.rf_squire <- ::inherit("scripts/entity/tactical/human" {
 			local armor = ::new("scripts/items/armor/mail_hauberk");
 			armor.setVariant(28);
 			this.m.Items.equip(armor);
+
+			if (::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
+			{
+				local armorAttachment = ::Reforged.ItemTable.ArmorAttachmentNorthern.roll({
+					Apply = function ( _script, _weight )
+					{
+						local conditionModifier = ::ItemTables.ItemInfoByScript[_script].ConditionModifier;
+						if (conditionModifier > 30) return 0.0;
+						return _weight;
+					}
+				})
+
+				if (armorAttachment != null)
+					armor.setUpgrade(::new(armorAttachment));
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))

--- a/scripts/mods/mod_reforged/item_tables/armor_attachment_northern.nut
+++ b/scripts/mods/mod_reforged/item_tables/armor_attachment_northern.nut
@@ -1,0 +1,10 @@
+::Reforged.ItemTable.ArmorAttachmentNorthern <- ::ItemTables.Class.ItemTable([
+	[4, "scripts/items/armor_upgrades/leather_neckguard_upgrade"],
+	[4, "scripts/items/armor_upgrades/leather_shoulderguards_upgrade"],
+	[3, "scripts/items/armor_upgrades/double_mail_upgrade"],
+	[3, "scripts/items/armor_upgrades/mail_patch_upgrade"],
+	[2, "scripts/items/armor_upgrades/joint_cover_upgrade"],
+	[2, "scripts/items/armor_upgrades/metal_plating_upgrade"],
+	[1, "scripts/items/armor_upgrades/heraldic_plates_upgrade"],
+	[1, "scripts/items/armor_upgrades/metal_pauldrons_upgrade"]
+]);


### PR DESCRIPTION
Two errors, one when spawning master archers and the other when spawning swordmasters. Uploaded in armor attachments on human enemies thread in balance forum channel. Otherwise everything is tested and working.