### PR TITLE
Rework sword perks

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -670,7 +670,7 @@ local vanillaDescriptions = [
 					Description = [
 						"Unlocks the [Kata Step|Skill+rf_kata_step_skill] skill which, immediately after a successful attack, allows you to move one tile ignoring [Zone of Control|Concept.ZoneOfControl] with reduced [Action Point|Concept.ActionPoints] and [Fatigue|Concept.Fatigue] cost.",
 						"The target tile for the movement must be adjacent to an enemy.",
-						"Requires a two-handed sword or one-handed sword with the offhand free."
+						"Requires a cutting attack from a two-handed or double-gripped sword."
 					]
 				}
 			]
@@ -1288,6 +1288,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Type = ::UPD.EffectType.Passive,
 			Description = [
 				"Skills build up " + ::MSU.Text.colorPositive("20%") + " less [Fatigue|Concept.Fatigue] and gain " + ::MSU.Text.colorPositive("+10%") + " chance to hit.",
+				"The Damage Type requirement from [Kata Step|Skill+rf_kata_step_skill] is removed.",
 				"When using a one-handed fencing sword, the [Action Point|Concept.ActionPoints] costs of [Sword Thrust,|Skill+rf_sword_thrust_skill] [Riposte|Skill+riposte] and [Lunge|Skill+lunge_skill] are reduced by " + ::MSU.Text.colorPositive(1) + ".",
 				"When using a two-handed fencing sword, the range of [Lunge|Skill+lunge_skill] is increased by " + ::MSU.Text.colorPositive(1) + " tile."
 			]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1990,8 +1990,9 @@ foreach (vanillaDesc in vanillaDescriptions)
 			{
 				Type = ::UPD.EffectType.Passive,
 				Description = [
-					"Every hit or miss against any target increases your [Initiative|Concept.Initiative] by " + ::MSU.Text.colorPositive("+15") + ". This bonus is carried over into your next [turn|Concept.Turn] but only until the first skill used or upon [waiting|Concept.Wait] that [turn.|Concept.Turn]",
-					"The first two hits against opponents who act after you in the current [round|Concept.Round] recover " + ::MSU.Text.colorPositive("2") + " [Action Points|Concept.ActionPoints] each but cause the [Initiative|Concept.Initiative] bonus to expire."
+					"Gain " + ::MSU.Text.colorPositive(1) + " stack for every hit or miss against any target during your [turn|Concept.Turn]."
+					"Each stack increases your [Initiative|Concept.Initiative] by " + ::MSU.Text.colorPositive("+15") + ". This bonus is carried over into your next [turn|Concept.Turn] but only until the first skill used or upon [waiting|Concept.Wait] that [turn.|Concept.Turn]",
+					"During a [turn|Concept.Turn] gain " + ::MSU.Text.colorPositive("half") + " of the stacks gained during the previous [turn|Concept.Turn] as additional [Action Points|Concept.ActionPoints] and attacks build up " + ::MSU.Text.colorPositive("5%") + " less [Fatigue|Concept.Fatigue] per such stack."
 				]
 			}
 		]

--- a/mod_reforged/hooks/entity/tactical/enemies/goblin_fighter.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/goblin_fighter.nut
@@ -37,7 +37,9 @@
 		// Reforged
 		this.m.Skills.add(::new("scripts/skills/perks/perk_backstabber"));
 		this.m.Skills.add(::Reforged.new("scripts/skills/perks/perk_rf_kata", function(o) {
-			o.m.IsForceEnabled = true;
+			o.m.RequiredDamageType = null;
+			o.m.RequiredWeaponType = null;
+			o.m.RequireOffhandFree = false;
 		}));
 	}
 

--- a/mod_reforged/hooks/entity/tactical/humans/desert_devil.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/desert_devil.nut
@@ -34,7 +34,11 @@
 		//Reforged
 		this.m.Skills.add(::new("scripts/skills/perks/perk_dodge"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_footwork"));
-		this.m.Skills.add(::Reforged.new("scripts/skills/perks/perk_rf_kata", function(o) {o.m.IsForceEnabled = true;}));
+		this.m.Skills.add(::Reforged.new("scripts/skills/perks/perk_rf_kata", function(o) {
+			o.m.RequiredDamageType = null;
+			o.m.RequiredWeaponType = null;
+			o.m.RequireOffhandFree = false;
+		}));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_relentless"));
 	}
 

--- a/scripts/skills/actives/rf_kata_step_skill.nut
+++ b/scripts/skills/actives/rf_kata_step_skill.nut
@@ -3,7 +3,7 @@ this.rf_kata_step_skill <- ::inherit("scripts/skills/skill", {
 		IsSpent = true,
 		IsForceEnabled = false,
 		APCostModifier = -2,
-		FatigueCostModifier = 0
+		FatigueCostModifier = 2
 	},
 	function create()
 	{

--- a/scripts/skills/perks/perk_rf_fencer.nut
+++ b/scripts/skills/perks/perk_rf_fencer.nut
@@ -26,6 +26,15 @@ this.perk_rf_fencer <- ::inherit("scripts/skills/skill", {
 		return true;
 	}
 
+	function onUpdate( _properties )
+	{
+		local kataStep = this.getContainer().getSkillByID("actives.rf_kata_step");
+		if (kataStep != null)
+		{
+			kataStep.m.RequiredDamageType = null;
+		}
+	}
+
 	function onAfterUpdate( _properties )
 	{
 		if (!this.isEnabled()) return;

--- a/scripts/skills/perks/perk_rf_kata.nut
+++ b/scripts/skills/perks/perk_rf_kata.nut
@@ -1,6 +1,8 @@
 this.perk_rf_kata <- ::inherit("scripts/skills/skill", {
 	m = {
-		IsForceEnabled = false
+		RequiredWeaponType = ::Const.Items.WeaponType.Sword,
+		RequiredDamageType = ::Const.Damage.DamageType.Cutting,
+		RequireOffhandFree = true, // Require equipping two-handed weapon, or having off-hand free
 	},
 	function create()
 	{
@@ -15,7 +17,9 @@ this.perk_rf_kata <- ::inherit("scripts/skills/skill", {
 	function onAdded()
 	{
 		local kataStep = ::new("scripts/skills/actives/rf_kata_step_skill");
-		kataStep.m.IsForceEnabled = this.m.IsForceEnabled;
+		kataStep.m.RequiredDamageType = this.m.RequiredDamageType;
+		kataStep.m.RequiredWeaponType = this.m.RequiredWeaponType;
+		kataStep.m.RequireOffhandFree = this.m.RequireOffhandFree;
 		this.getContainer().add(kataStep);
 	}
 

--- a/scripts/skills/perks/perk_rf_swordmaster_blade_dancer.nut
+++ b/scripts/skills/perks/perk_rf_swordmaster_blade_dancer.nut
@@ -49,6 +49,7 @@ this.perk_rf_swordmaster_blade_dancer <- ::inherit("scripts/skills/perks/perk_rf
 		{
 			kataStep.m.ActionPointCost = ::Math.max(0, kataStep.m.ActionPointCost + this.m.KataStepAPCostModifier);
 			kataStep.m.FatigueCost = ::Math.max(0, kataStep.m.FatigueCost + this.m.KataStepFatigueCostModifier);
+			kataStep.m.RequireOffhandFree = false;
 		}
 	}
 });


### PR DESCRIPTION
- Kata Step
  - Now costs +2 fatigue based on movement cost of starting tile (up from +0).
  - Now requires Cutting damage type.
  - Code is improved to have the requirements be more granular as member variables. Entities code where it was using IsForceEnabled is updated to use these new member variables.
  - The effect of Blade Dancer perk on Kata Step has been fully encapsulated within that perk's file.
  - Fencer perk now removes the Damage Type requirement from Kata Step while a fencing sword is equipped.
- Rework tempo
  - Gain a stack for every hit/miss.
  - Each stack grants +15 Initiative. This lasts until your first attack next turn or waiting/ending next turn.
  - During your next turn gain half of the stacks of the previous turn as additional Action Points and attacks build 5% less fatigue per such stack.