### PR TITLE
fix(vanilla): scenarios without intro event locking up the game

### DIFF
--- a/mod_reforged/hooks/states/world_state.nut
+++ b/mod_reforged/hooks/states/world_state.nut
@@ -1,4 +1,10 @@
 ::Reforged.HooksMod.hook("scripts/states/world_state", function(q) {
+	q.startNewCampaign = @(__original) function()
+	{
+		__original();
+		this.setAutoPause(false);	// VanillaFix: Fix scenarios without intro event locking up the game
+	}
+
 	// Add functionality to allow using more vars in troop names e.g. for champions
 	q.startScriptedCombat = @(__original) function( _properties = null, _isPlayerInitiated = true, _isCombatantsVisible = true, _allowFormationPicking = true )
 	{


### PR DESCRIPTION
Vanilla calls `setAutoPause(true)` at the start of `startNewCampaign` but never sets it to `false` again.
That does not cause problems in vanilla because every dialog or other window that might pop-up will always call a `this.setAutoPause(false);`, when they are closed and vanilla always spawns an intro event for every origin at the start of a new campaign.