### PR TITLE
balance: improve southern, bandit and nomad spawns

### DIFF
--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/bandit_parties.nut
@@ -27,8 +27,18 @@ local parties = [
 			}
 			else
 			{
-				return 8;
+				return 9;
 			}
+		}
+
+		function getUpgradeChance()
+		{
+			local startingResources = this.getSpawnProcess().getStartingResources();
+			if (startingResources >= 200)
+			{
+				return 0.85;
+			}
+			return base.getUpgradeChance()
 		}
 	},
 	{
@@ -38,6 +48,7 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
+		IdealSizeLocationMult = 1.2,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
 			{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
@@ -59,8 +70,18 @@ local parties = [
 			}
 			else
 			{
-				return 8;
+				return 9;
 			}
+		}
+
+		function getUpgradeChance()
+		{
+			local startingResources = this.getSpawnProcess().getStartingResources();
+			if (startingResources >= 200)
+			{
+				return 0.85;
+			}
+			return base.getUpgradeChance()
 		}
 	},
 	{
@@ -70,6 +91,7 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
+		IdealSizeLocationMult = 1.2,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
 			{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.10 },
@@ -92,8 +114,18 @@ local parties = [
 			}
 			else
 			{
-				return 8;
+				return 9;
 			}
+		}
+
+		function getUpgradeChance()
+		{
+			local startingResources = this.getSpawnProcess().getStartingResources();
+			if (startingResources >= 200)
+			{
+				return 0.85;
+			}
+			return base.getUpgradeChance()
 		}
 	},
 	{
@@ -103,6 +135,7 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
+		IdealSizeLocationMult = 1.2,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
 			{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
@@ -125,8 +158,18 @@ local parties = [
 			}
 			else
 			{
-				return 8;
+				return 9;
 			}
+		}
+
+		function getUpgradeChance()
+		{
+			local startingResources = this.getSpawnProcess().getStartingResources();
+			if (startingResources >= 200)
+			{
+				return 0.85;
+			}
+			return base.getUpgradeChance()
 		}
 	},
 	{
@@ -136,6 +179,7 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
+		IdealSizeLocationMult = 1.2,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
 			{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
@@ -158,8 +202,18 @@ local parties = [
 			}
 			else
 			{
-				return 8;
+				return 9;
 			}
+		}
+
+		function getUpgradeChance()
+		{
+			local startingResources = this.getSpawnProcess().getStartingResources();
+			if (startingResources >= 200)
+			{
+				return 0.85;
+			}
+			return base.getUpgradeChance()
 		}
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/nomad_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/nomad_parties.nut
@@ -35,6 +35,7 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
+		IdealSizeLocationMult = 1.2,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
 			{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
@@ -67,6 +68,7 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
+		IdealSizeLocationMult = 1.2,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
 			{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },

--- a/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/parties/southern_parties.nut
@@ -8,12 +8,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.50, RatioMax = 0.90, DeterminesFigure = true },			// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.50, RatioMax = 0.70, DeterminesFigure = true },			// Vanilla: doesn't care about size
 			{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.SouthernRanged", RatioMin = 0.00, RatioMax = 0.30 },		// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
-			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true },		// Vanilla: Start spawning at 15+
-			{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
+			{ BaseID = "UnitBlock.RF.SouthernRanged", RatioMin = 0.00, RatioMax = 0.35 },		// Vanilla: doesn't care about size
+			{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 0.2, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
+			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5, DeterminesFigure = true },		// Vanilla: Start spawning at 15+
+			{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 14 }		// Vanilla: Start spawning at 19+
 		]
 	},
 	{

--- a/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
+++ b/scripts/mods/mod_reforged/dynamic_spawns/units/southern_units.nut
@@ -12,7 +12,7 @@ local units = [
 		ID = "Unit.RF.Officer",
 		Troop = "Officer",
 		Figure = "figure_southern_02",
-		StartingResourceMin = 250 // In Vanilla they appear in a group of 250 cost
+		StartingResourceMin = 280 // In Vanilla they appear in a group of 250 cost
 	},
 	{
 		ID = "Unit.RF.Gunner",
@@ -31,6 +31,7 @@ local units = [
 	{
 		ID = "Unit.RF.Assassin",
 		Troop = "Assassin"
+		StartingResourceMin = 250
 	},
 	{
 		ID = "Unit.RF.Slave",


### PR DESCRIPTION
- Add IdealSizeLocationMult
- Add getUpgradeChance based on startingResources
- lower RatioMax of SouthernFrontline block
- Raise RatioMax of SouthernRanged, Assassin, Officer, Siege blocks
- Lower ReqPartySize of Siege blocks
- Increase StartingResourceMin of Officer
- Add StartingResourceMin of 250 to Assassin