### PR TITLE
balance: buff southern faction

### DIFF
--- a/mod_reforged/hooks/config/faction_southern.nut
+++ b/mod_reforged/hooks/config/faction_southern.nut
@@ -26,7 +26,7 @@
 	MeleeSkill = 65,
 	RangedSkill = 75,
 	MeleeDefense = 5,
-	RangedDefense = 20, // vanilla 10
+	RangedDefense = 25, // vanilla 10
 	Initiative = 120,
 	FatigueEffectMult = 1.0,
 	MoraleEffectMult = 1.0,

--- a/mod_reforged/hooks/entity/tactical/humans/conscript.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/conscript.nut
@@ -25,6 +25,7 @@
 		// this.m.Skills.add(::new("scripts/skills/actives/recover_skill"));	// Now granted to all humans by default
 
 		// Reforged
+		this.m.Skills.add(::new("scripts/skills/perks/perk_dodge"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_poise"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rotation"));
 	}

--- a/mod_reforged/hooks/entity/tactical/humans/conscript_polearm.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/conscript_polearm.nut
@@ -2,25 +2,25 @@
 	q.onInit = @() function()
 	{
 		this.conscript.onInit();
-	}
 
-	q.assignRandomEquipment = @(__original) function()
-	{
-		__original();
-		local weapon = this.getMainhandItem();
-
-		if (weapon != null && weapon.isWeaponType(::Const.Items.WeaponType.Mace))
-		{
-			::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
-		}
-		else
-		{
-			this.m.Skills.add(::new("scripts/skills/perks/perk_crippling_strikes"));
-		}
+		// Reforged
+		this.m.Skills.removeByID("perk.dodge");
 	}
 
 	q.onSpawned = @() function()
 	{
 		this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_polearm"));
+
+		local weapon = this.getMainhandItem();
+		if (weapon != null && weapon.isWeaponType(::Const.Items.WeaponType.Mace))
+		{
+			::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
+			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_leverage"));
+		}
+		else
+		{
+			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_long_reach"));
+			this.m.Skills.add(::new("scripts/skills/perks/perk_crippling_strikes"));
+		}
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/humans/engineer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/engineer.nut
@@ -16,5 +16,6 @@
 
 		//Reforged
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rotation"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_dodge"));
 	}
 });


### PR DESCRIPTION
- increase gunner rdef from 20 to 25
- give frontline conscript dodge
- give backline conscript long reach with polearm and leverage with mace
- give engineer dodge