### PR TITLE
refactor: make flail spinner non-lethal for NPC users

### DIFF
--- a/scripts/skills/perks/perk_rf_flail_spinner.nut
+++ b/scripts/skills/perks/perk_rf_flail_spinner.nut
@@ -53,7 +53,21 @@ this.perk_rf_flail_spinner <- ::inherit("scripts/skills/skill", {
 						}
 
 						perk.m.IsSpinningFlail = true;
-						_skill.useForFree(_targetTile);
+						if (_user.isPlayerControlled())
+						{
+							_skill.useForFree(_targetTile);
+						}
+						// Make it non-lethal for NPC users
+						// Hopefully this reduces/elminiates the cases where AI evaluation gets stuck due to killing someone with a delayed attack.
+						// Once a proper solution to that issue is found and implemented, this can be reverted.
+						else
+						{
+							// This implementation has a side-effect of preventing the target from receiving injuries.
+							local wasAbleToDie = _targetEntity.m.IsAbleToDie;
+							_targetEntity.m.IsAbleToDie = false;
+							_skill.useForFree(_targetTile);
+							_targetEntity.m.IsAbleToDie = wasAbleToDie;
+						}
 						perk.m.IsSpinningFlail = false;
 					}
 


### PR DESCRIPTION
Hopefully this reduces/elminiates the cases where AI evaluation gets stuck due to killing someone with a delayed attack. Once a proper solution to that issue is found and implemented, this can be reverted.