### PR TITLE
Apply Damage Resistances from Racial skills using DamageType probability of the skill

### DIFF
--- a/mod_reforged/hooks/skills/racial/alp_racial.nut
+++ b/mod_reforged/hooks/skills/racial/alp_racial.nut
@@ -87,6 +87,27 @@
 		baseProperties.IsImmuneToPoison = true;
 	}
 
+	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
+	{
+		local d = _skill.getDamageType();
+		if (d.contains(::Const.Damage.DamageType.Blunt))
+		{
+			if (_skill.isRanged())
+				_properties.DamageReceivedRegularMult *= 0.33;
+		}
+		else if (d.contains(::Const.Damage.DamageType.Piercing))
+		{
+			_properties.DamageReceivedRegularMult *= _skill.isRanged() ? 0.33 : 0.5;
+		}
+		else if (d.contains(::Const.Damage.DamageType.Cutting))
+		{
+			if (_skill.getID() == "actives.wardog_bite" || _skill.getID() == "actives.wolf_bite" || _skill.getID() == "actives.warhound_bite")
+			{
+				_properties.DamageReceivedRegularMult *= 0.33;
+			}
+		}
+	}
+
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
 		switch (_hitInfo.DamageType)

--- a/mod_reforged/hooks/skills/racial/alp_racial.nut
+++ b/mod_reforged/hooks/skills/racial/alp_racial.nut
@@ -90,22 +90,20 @@
 	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
 		local d = _skill.getDamageType();
+		local mult = 0.0;
 		if (d.contains(::Const.Damage.DamageType.Blunt))
 		{
-			if (_skill.isRanged())
-				_properties.DamageReceivedRegularMult *= 0.33;
+			mult += d.getProbability(::Const.Damage.DamageType.Blunt) * 0.66;
 		}
-		else if (d.contains(::Const.Damage.DamageType.Piercing))
+		if (d.contains(::Const.Damage.DamageType.Piercing))
 		{
-			_properties.DamageReceivedRegularMult *= _skill.isRanged() ? 0.33 : 0.5;
+			mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.66 : 0.5);
 		}
-		else if (d.contains(::Const.Damage.DamageType.Cutting))
+		if (d.contains(::Const.Damage.DamageType.Cutting) && (_skill.getID() == "actives.wardog_bite" || _skill.getID() == "actives.wolf_bite" || _skill.getID() == "actives.warhound_bite"))
 		{
-			if (_skill.getID() == "actives.wardog_bite" || _skill.getID() == "actives.wolf_bite" || _skill.getID() == "actives.warhound_bite")
-			{
-				_properties.DamageReceivedRegularMult *= 0.33;
-			}
+			mult += d.getProbability(::Const.Damage.DamageType.Cutting) * 0.66;
 		}
+		_properties.DamageReceivedRegularMult *= 1.0 - mult;
 	}
 
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )

--- a/mod_reforged/hooks/skills/racial/alp_racial.nut
+++ b/mod_reforged/hooks/skills/racial/alp_racial.nut
@@ -89,70 +89,52 @@
 
 	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
-		local d = _skill.getDamageType();
-		local mult = 0.0;
-		if (d.contains(::Const.Damage.DamageType.Blunt))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Blunt) * 0.66;
-		}
-		if (d.contains(::Const.Damage.DamageType.Piercing))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.66 : 0.5);
-		}
-		if (d.contains(::Const.Damage.DamageType.Cutting) && (_skill.getID() == "actives.wardog_bite" || _skill.getID() == "actives.wolf_bite" || _skill.getID() == "actives.warhound_bite"))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Cutting) * 0.66;
-		}
-		_properties.DamageReceivedRegularMult *= 1.0 - mult;
+		this.RF_applyDamageResistance(_attacker, _skill, null, _properties);
 	}
 
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
-		switch (_hitInfo.DamageType)
+		this.RF_applyDamageResistance(_attacker, _skill, _hitInfo, _properties);
+	}
+
+	// if _skill is null only then _hitInfo is checked
+	q.RF_applyDamageResistance <- function( _attacker, _skill, _hitInfo, _properties )
+	{
+		if (_skill != null)
 		{
-			case null:
-				break;
+			local d = _skill.getDamageType();
+			local mult = 0.0;
+			if (d.contains(::Const.Damage.DamageType.Blunt))
+			{
+				// In Vanilla this reduction only exists for slinging of stones. Here it expands to bolas and potential future blunt ranged attacks
+				mult += d.getProbability(::Const.Damage.DamageType.Blunt) * 0.66;
+			}
+			if (d.contains(::Const.Damage.DamageType.Piercing))
+			{
+				// This streamlines the following differences in vanilla:
+				// - javelins dealing 50% damage
+				// - handgonne and one-use throwing spear dealing 100% damage
+				mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.66 : 0.5);
+			}
+			// Maybe replace this with some sort of isAnimal or isBeast check on the attacker?
+			if (d.contains(::Const.Damage.DamageType.Cutting) && (_skill.getID() == "actives.wardog_bite" || _skill.getID() == "actives.wolf_bite" || _skill.getID() == "actives.warhound_bite"))
+			{
+				mult += d.getProbability(::Const.Damage.DamageType.Cutting) * 0.66;
+			}
 
-			case ::Const.Damage.DamageType.Blunt:
-				if (_skill != null)
-				{
-					if (_skill.isRanged())	// In Vanilla this reduction only exists for slinging of stones. Here it expands to bolas and potential future blunt ranged attacks
-					{
-						_properties.DamageReceivedRegularMult *= 0.33;
-					}
-				}
-				break;
+			_properties.DamageReceivedRegularMult *= 1.0 - mult;
+		}
+		else if (_hitInfo != null)
+		{
+			switch (_hitInfo.DamageType)
+			{
+				case null:
+					break;
 
-			case ::Const.Damage.DamageType.Piercing:
-				if (_skill == null)
-				{
+				case ::Const.Damage.DamageType.Piercing:
 					_properties.DamageReceivedRegularMult *= 0.5;
-				}
-				else
-				{
-					if (_skill.isRanged())
-					{
-						_properties.DamageReceivedRegularMult *= 0.33;
-						/* This streamlines the following differences in vanilla:
-							Arrows dealing only 10% damage
-							javelins dealing only 25% damage
-							handgonne & one-use throwing spear dealing 50% damage
-						*/
-					}
-					else
-					{
-						_properties.DamageReceivedRegularMult *= 0.5;
-					}
-				}
-				break;
-
-			case ::Const.Damage.DamageType.Cutting:
-				// Maybe replace this with some sort of isAnimal or isBeast check on the attacker?
-				if (_skill != null && (_skill.getID() == "actives.wardog_bite" || _skill.getID() == "actives.wolf_bite" || _skill.getID() == "actives.warhound_bite"))
-				{
-					_properties.DamageReceivedRegularMult *= 0.33;
-				}
-				break;
+					break;
+			}
 		}
 	}
 });

--- a/mod_reforged/hooks/skills/racial/golem_racial.nut
+++ b/mod_reforged/hooks/skills/racial/golem_racial.nut
@@ -99,38 +99,47 @@
 
 	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
-		if (_skill.getID() == "actives.throw_golem")
-		{
-			_properties.DamageReceivedTotalMult = 0.0;
-			return;
-		}
-
-		local d = _skill.getDamageType();
-		local mult = 0.0;
-		if (d.contains(::Const.Damage.DamageType.Burning))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Burning) * 0.9;
-		}
-		if (d.contains(::Const.Damage.DamageType.Piercing))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.66 : 0.5);
-		}
-		if (_skill.isRanged() && d.contains(::Const.Damage.DamageType.Blunt))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Blunt) * 0.66;
-		}
-		_properties.DamageReceivedRegularMult *= 1.0 - mult;
+		this.RF_applyDamageResistance(_attacker, _skill, null, _properties);
 	}
 
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
-		if (_skill != null && _skill.getID() == "actives.throw_golem")
-		{
-			_properties.DamageReceivedTotalMult = 0.0;
-			return;
-		}
+		this.RF_applyDamageResistance(_attacker, _skill, _hitInfo, _properties);
+	}
 
-		switch (_hitInfo.DamageType)
+	// if _skill is null only then _hitInfo is checked
+	q.RF_applyDamageResistance <- function( _attacker, _skill, _hitInfo, _properties )
+	{
+		if (_skill != null)
+		{
+			if (_skill.getID() == "actives.throw_golem")
+			{
+				_properties.DamageReceivedTotalMult = 0.0;
+				return;
+			}
+
+			local d = _skill.getDamageType();
+			local mult = 0.0;
+			if (d.contains(::Const.Damage.DamageType.Burning))
+			{
+				mult += d.getProbability(::Const.Damage.DamageType.Burning) * 0.9;
+			}
+			if (d.contains(::Const.Damage.DamageType.Piercing))
+			{
+				// This streamlines the following differences in vanilla:
+				// - javelins dealing 50% damage
+				// - handgonne and one-use throwing spear dealing 100% damage
+				mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.66 : 0.5);
+			}
+			if (_skill.isRanged() && d.contains(::Const.Damage.DamageType.Blunt))
+			{
+				// In Vanilla this reduction only exists for slinging of stones. Here it expands to bolas and potential future blunt ranged attacks
+				mult += d.getProbability(::Const.Damage.DamageType.Blunt) * 0.66;
+			}
+
+			_properties.DamageReceivedRegularMult *= 1.0 - mult;
+		}
+		else if (_hitInfo != null)
 		{
 			case null:
 				break;
@@ -139,37 +148,8 @@
 				_properties.DamageReceivedRegularMult *= 0.1;
 				break;
 
-			case ::Const.Damage.DamageType.Blunt:
-				if (_skill != null)
-				{
-					if (_skill.isRanged())	// In Vanilla this reduction only exists for slinging of stones. Here it expands to bolas and potential future blunt ranged attacks
-					{
-						_properties.DamageReceivedRegularMult *= 0.33;
-					}
-				}
-				break;
-
 			case ::Const.Damage.DamageType.Piercing:
-				if (_skill == null)
-				{
-					_properties.DamageReceivedRegularMult *= 0.5;
-				}
-				else
-				{
-					if (_skill.isRanged())
-					{
-						_properties.DamageReceivedRegularMult *= 0.33;
-						/* This streamlines the following differences in vanilla:
-							Arrows dealing only 10% damage
-							javelins and handgonne dealing only 25% damage
-							one-use throwing spear dealing 100% damage
-						*/
-					}
-					else
-					{
-						_properties.DamageReceivedRegularMult *= 0.5;
-					}
-				}
+				_properties.DamageReceivedRegularMult *= 0.5;
 				break;
 		}
 	}

--- a/mod_reforged/hooks/skills/racial/golem_racial.nut
+++ b/mod_reforged/hooks/skills/racial/golem_racial.nut
@@ -97,6 +97,30 @@
 		baseProperties.IsImmuneToStun = true;
 	}
 
+	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
+	{
+		if (_skill.getID() == "actives.throw_golem")
+		{
+			_properties.DamageReceivedTotalMult = 0.0;
+			return;
+		}
+
+		local d = _skill.getDamageType();
+		if (d.contains(::Const.Damage.DamageType.Burning))
+		{
+			_properties.DamageReceivedRegularMult *= 0.1;
+		}
+		else if (d.contains(::Const.Damage.DamageType.Blunt))
+		{
+			if (_skill.isRanged())
+				_properties.DamageReceivedRegularMult *= 0.33;
+		}
+		else if (d.contains(::Const.Damage.DamageType.Piercing))
+		{
+			_properties.DamageReceivedRegularMult *= _skill.isRanged() ? 0.33 : 0.5;
+		}
+	}
+
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
 		if (_skill != null && _skill.getID() == "actives.throw_golem")

--- a/mod_reforged/hooks/skills/racial/golem_racial.nut
+++ b/mod_reforged/hooks/skills/racial/golem_racial.nut
@@ -106,19 +106,20 @@
 		}
 
 		local d = _skill.getDamageType();
+		local mult = 0.0;
 		if (d.contains(::Const.Damage.DamageType.Burning))
 		{
-			_properties.DamageReceivedRegularMult *= 0.1;
+			mult += d.getProbability(::Const.Damage.DamageType.Burning) * 0.9;
 		}
-		else if (d.contains(::Const.Damage.DamageType.Blunt))
+		if (d.contains(::Const.Damage.DamageType.Piercing))
 		{
-			if (_skill.isRanged())
-				_properties.DamageReceivedRegularMult *= 0.33;
+			mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.66 : 0.5);
 		}
-		else if (d.contains(::Const.Damage.DamageType.Piercing))
+		if (_skill.isRanged() && d.contains(::Const.Damage.DamageType.Blunt))
 		{
-			_properties.DamageReceivedRegularMult *= _skill.isRanged() ? 0.33 : 0.5;
+			mult += d.getProbability(::Const.Damage.DamageType.Blunt) * 0.66;
 		}
+		_properties.DamageReceivedRegularMult *= 1.0 - mult;
 	}
 
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )

--- a/mod_reforged/hooks/skills/racial/schrat_racial.nut
+++ b/mod_reforged/hooks/skills/racial/schrat_racial.nut
@@ -121,13 +121,14 @@
 	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
 		local d = _skill.getDamageType();
+		local mult = 0.0;
 		if (d.contains(::Const.Damage.DamageType.Burning))
 		{
-			_properties.DamageReceivedRegularMult *= 2.0;
+			mult += d.getProbability(::Const.Damage.DamageType.Burning) * -1.0;
 		}
-		else if (d.contains(::Const.Damage.DamageType.Piercing))
+		if (d.contains(::Const.Damage.DamageType.Piercing))
 		{
-			_properties.DamageReceivedRegularMult *= _skill.isRanged() ? 0.25 : 0.5;
+			mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.75 : 0.5);
 		}
 	}
 

--- a/mod_reforged/hooks/skills/racial/schrat_racial.nut
+++ b/mod_reforged/hooks/skills/racial/schrat_racial.nut
@@ -118,6 +118,19 @@
 		baseProperties.IsIgnoringArmorOnAttack = true;
 	}
 
+	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
+	{
+		local d = _skill.getDamageType();
+		if (d.contains(::Const.Damage.DamageType.Burning))
+		{
+			_properties.DamageReceivedRegularMult *= 2.0;
+		}
+		else if (d.contains(::Const.Damage.DamageType.Piercing))
+		{
+			_properties.DamageReceivedRegularMult *= _skill.isRanged() ? 0.25 : 0.5;
+		}
+	}
+
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
 		switch (_hitInfo.DamageType)

--- a/mod_reforged/hooks/skills/racial/schrat_racial.nut
+++ b/mod_reforged/hooks/skills/racial/schrat_racial.nut
@@ -120,54 +120,54 @@
 
 	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
-		local d = _skill.getDamageType();
-		local mult = 0.0;
-		if (d.contains(::Const.Damage.DamageType.Burning))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Burning) * -1.0;
-		}
-		if (d.contains(::Const.Damage.DamageType.Piercing))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.75 : 0.5);
-		}
+		this.RF_applyDamageResistance(_attacker, _skill, null, _properties);
 	}
 
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
-		switch (_hitInfo.DamageType)
-		{
-			case null:
-				break;
-
-			case ::Const.Damage.DamageType.Burning:
-				_properties.DamageReceivedRegularMult *= 2.0;	// In Vanilla this is 1.33 for firelance and 3.0 for burning ground
-				break;
-
-			case ::Const.Damage.DamageType.Piercing:
-				if (_skill == null)
-				{
-					_properties.DamageReceivedRegularMult *= 0.50;
-				}
-				else
-				{
-					if (_skill.isRanged())
-					{
-						_properties.DamageReceivedRegularMult *= 0.25;
-						/* This streamlines the following differences in vanilla:
-							javelins dealing 50% damage
-							handgonne and one-use throwing spear dealing 100% damage
-						*/
-					}
-					else
-					{
-						_properties.DamageReceivedRegularMult *= 0.50;	// New: In Vanilla piercing melee attacks are not reduced
-					}
-				}
-				break;
-		}
+		this.RF_applyDamageResistance(_attacker, _skill, _hitInfo, _properties);
 	}
 
 	// We exported everything this function does into its own effect (rf_sapling_harvest).
 	// By overwriting this method we also nullify all other mods hooking into this before us but there is clean solution to this
 	q.onDamageReceived = @() function( _attacker, _damageHitpoints, _damageArmor ) {};
+
+	// if _skill is null only then _hitInfo is checked
+	q.RF_applyDamageResistance <- function( _attacker, _skill, _hitInfo, _properties )
+	{
+		if (_skill != null)
+		{
+			local d = _skill.getDamageType();
+			local mult = 0.0;
+			if (d.contains(::Const.Damage.DamageType.Burning))
+			{
+				mult += d.getProbability(::Const.Damage.DamageType.Burning) * -1.0; // In Vanilla this 1.33 for firelance and 3.0 for burning ground
+			}
+			if (d.contains(::Const.Damage.DamageType.Piercing))
+			{
+				// This streamlines the following differences in vanilla:
+				// - javelins dealing 50% damage
+				// - handgonne and one-use throwing spear dealing 100% damage
+				mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.75 : 0.5);
+			}
+
+			_properties.DamageReceivedRegularMult *= 1.0 - mult;
+		}
+		else if (_hitInfo != null)
+		{
+			switch (_hitInfo.DamageType)
+			{
+				case null:
+					break;
+
+				case ::Const.Damage.DamageType.Burning:
+					_properties.DamageReceivedRegularMult *= 2.0; // In Vanilla this is 1.33 for firelance and 3.0 for burning ground
+					break;
+
+				case ::Const.Damage.DamageType.Piercing:
+					_properties.DamageReceivedRegularMult *= 0.50; // New: In Vanilla piercing melee attacks are not reduced
+					break;
+			}
+		}
+	}
 });

--- a/mod_reforged/hooks/skills/racial/serpent_racial.nut
+++ b/mod_reforged/hooks/skills/racial/serpent_racial.nut
@@ -51,25 +51,36 @@
 
 	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
-		local d = _skill.getDamageType();
-		if (d.contains(::Const.Damage.DamageType.Burning))
-		{
-			_properties.DamageReceivedRegularMult *= 1.0 - d.getProbability(::Const.Damage.DamageType.Burning) * 0.33;
-		}
+		this.RF_applyDamageResistance(_attacker, _skill, null, _properties);
 	}
 
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
-		switch (_hitInfo.DamageType)
+		this.RF_applyDamageResistance(_attacker, _skill, _hitInfo, _properties);
+	}
+
+	// if _skill is null only then _hitInfo is checked
+	q.RF_applyDamageResistance <- function( _attacker, _skill, _hitInfo, _properties )
+	{
+		if (_skill != null)
 		{
-			case null:
-				break;
+			local d = _skill.getDamageType();
+			if (d.contains(::Const.Damage.DamageType.Burning))
+			{
+				_properties.DamageReceivedRegularMult *= 1.0 - d.getProbability(::Const.Damage.DamageType.Burning) * 0.33;
+			}
+		}
+		else if (_hitInfo != null)
+		{
+			switch (_hitInfo.DamageType)
+			{
+				case null:
+					break;
 
-			case ::Const.Damage.DamageType.Burning:
-				_properties.DamageReceivedRegularMult *= 0.66;
-				break;
-
-			// In Vanilla they also take reduced damage from firearms and mortars. But those are currently not covered here
+				case ::Const.Damage.DamageType.Burning:
+					_properties.DamageReceivedRegularMult *= 0.66;
+					break;
+			}
 		}
 	}
 });

--- a/mod_reforged/hooks/skills/racial/serpent_racial.nut
+++ b/mod_reforged/hooks/skills/racial/serpent_racial.nut
@@ -51,9 +51,10 @@
 
 	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
-		if (_skill.getDamageType().contains(::Const.Damage.DamageType.Burning))
+		local d = _skill.getDamageType();
+		if (d.contains(::Const.Damage.DamageType.Burning))
 		{
-			_properties.DamageReceivedRegularMult *= 0.66;
+			_properties.DamageReceivedRegularMult *= 1.0 - d.getProbability(::Const.Damage.DamageType.Burning) * 0.33;
 		}
 	}
 

--- a/mod_reforged/hooks/skills/racial/serpent_racial.nut
+++ b/mod_reforged/hooks/skills/racial/serpent_racial.nut
@@ -49,6 +49,14 @@
 		baseProperties.IsImmuneToDisarm = true;
 	}
 
+	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
+	{
+		if (_skill.getDamageType().contains(::Const.Damage.DamageType.Burning))
+		{
+			_properties.DamageReceivedRegularMult *= 0.66;
+		}
+	}
+
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
 		switch (_hitInfo.DamageType)

--- a/mod_reforged/hooks/skills/racial/skeleton_racial.nut
+++ b/mod_reforged/hooks/skills/racial/skeleton_racial.nut
@@ -81,14 +81,16 @@
 	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
 		local d = _skill.getDamageType();
+		local mult = 0.0;
 		if (d.contains(::Const.Damage.DamageType.Burning))
 		{
-			_properties.DamageReceivedRegularMult *= 0.25;
+			mult += d.getProbability(::Const.Damage.DamageType.Burning) * 0.75;
 		}
-		else if (d.contains(::Const.Damage.DamageType.Piercing))
+		if (d.contains(::Const.Damage.DamageType.Piercing))
 		{
-			_properties.DamageReceivedRegularMult *= _skill.isRanged() ? 0.33 : 0.5;
+			mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.66 : 0.5);
 		}
+		_properties.DamageReceivedRegularMult *= 1.0 - mult;
 	}
 
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )

--- a/mod_reforged/hooks/skills/racial/skeleton_racial.nut
+++ b/mod_reforged/hooks/skills/racial/skeleton_racial.nut
@@ -78,6 +78,19 @@
 		baseProperties.IsImmuneToPoison = true;
 	}
 
+	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
+	{
+		local d = _skill.getDamageType();
+		if (d.contains(::Const.Damage.DamageType.Burning))
+		{
+			_properties.DamageReceivedRegularMult *= 0.25;
+		}
+		else if (d.contains(::Const.Damage.DamageType.Piercing))
+		{
+			_properties.DamageReceivedRegularMult *= _skill.isRanged() ? 0.33 : 0.5;
+		}
+	}
+
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
 		switch (_hitInfo.DamageType)

--- a/mod_reforged/hooks/skills/racial/skeleton_racial.nut
+++ b/mod_reforged/hooks/skills/racial/skeleton_racial.nut
@@ -80,52 +80,49 @@
 
 	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
-		local d = _skill.getDamageType();
-		local mult = 0.0;
-		if (d.contains(::Const.Damage.DamageType.Burning))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Burning) * 0.75;
-		}
-		if (d.contains(::Const.Damage.DamageType.Piercing))
-		{
-			mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.66 : 0.5);
-		}
-		_properties.DamageReceivedRegularMult *= 1.0 - mult;
+		this.RF_applyDamageResistance(_attacker, _skill, null, _properties);
 	}
 
 	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitInfo, _properties )
 	{
-		switch (_hitInfo.DamageType)
+		this.RF_applyDamageResistance(_attacker, _skill, _hitInfo, _properties);
+	}
+
+	// if _skill is null only then _hitInfo is checked
+	q.RF_applyDamageResistance <- function( _attacker, _skill, _hitInfo, _properties )
+	{
+		if (_skill != null)
 		{
-			case null:
-				break;
+			local d = _skill.getDamageType();
+			local mult = 0.0;
+			if (d.contains(::Const.Damage.DamageType.Burning))
+			{
+				mult += d.getProbability(::Const.Damage.DamageType.Burning) * 0.75;
+			}
+			if (d.contains(::Const.Damage.DamageType.Piercing))
+			{
+				// This streamlines the following differences in vanilla:
+				// - javelins dealing 50% damage
+				// - handgonne and one-use throwing spear dealing 100% damage
+				mult += d.getProbability(::Const.Damage.DamageType.Piercing) * (_skill.isRanged() ? 0.66 : 0.5);
+			}
 
-			case ::Const.Damage.DamageType.Burning:
-				_properties.DamageReceivedRegularMult *= 0.25;
-				break;
+			_properties.DamageReceivedRegularMult *= 1.0 - mult;
+		}
+		else if (_hitInfo != null)
+		{
+			switch (_hitInfo.DamageType)
+			{
+				case null:
+					break;
 
-			case ::Const.Damage.DamageType.Piercing:
-				if (_skill == null)
-				{
+				case ::Const.Damage.DamageType.Burning:
+					_properties.DamageReceivedRegularMult *= 0.25;
+					break;
+
+				case ::Const.Damage.DamageType.Piercing:
 					_properties.DamageReceivedRegularMult *= 0.5;
-				}
-				else
-				{
-					if (_skill.isRanged())
-					{
-						_properties.DamageReceivedRegularMult *= 0.33;
-						/* This streamlines the following differences in vanilla:
-							Arrows dealing only 10% damage
-							javelins dealing only 25% damage
-							one-use throwing spear dealing 50% damage
-						*/
-					}
-					else
-					{
-						_properties.DamageReceivedRegularMult *= 0.5;
-					}
-				}
-				break;
+			}
 		}
 	}
 });


### PR DESCRIPTION
Additionally the resistances are now also taken into account in `onBeingAttacked` which ensures that AI properly takes into account the resistances when calculating expected damage (from `skill.getExpectedDamage`).