### PR TITLE
refactor: use projected attributes instead of talents for fencer special

### DIFF
--- a/scripts/mods/mod_reforged/perk_groups/special/pg_special_rf_fencer.nut
+++ b/scripts/mods/mod_reforged/perk_groups/special/pg_special_rf_fencer.nut
@@ -23,11 +23,12 @@ this.pg_special_rf_fencer <- ::inherit(::DynamicPerks.Class.SpecialPerkGroup, {
 		if (!_perkTree.hasPerkGroup("pg.rf_sword"))
 			return 0;
 
-		if (_perkTree.getActor().getBaseProperties().Initiative * _perkTree.getActor().getBaseProperties().InitiativeMult < 100)
+		local p = _perkTree.getProjectedAttributesAvg();
+		local initiative = p[::Const.Attributes.Initiative] - 150;
+		local meleeSkill = p[::Const.Attributes.MeleeSkill] - 85;
+		if (initiative < 0 || meleeSkill < 0)
 			return 0;
 
-		local talents = _perkTree.getActor().getTalents();
-
-		return talents.len() == 0 ? 0 : talents[::Const.Attributes.Initiative] * talents[::Const.Attributes.MeleeSkill];
+		return 1.0 + (initiative + meleeSkill) * 0.05;
 	}
 });


### PR DESCRIPTION
Complete setup is:
- No chance if no sword perk group.
- No chance if Projected Average Initiative is below 150 or Projected Average Melee Skill is below 85.
- For each point of projected average Initiative above 150 and Melee Skill above 85 the multiplier is increased by 0.05.
  - So a projected Initiative of 160 will have  1.5 multiplier. 170 will have 2 multiplier.
  - Similarly 90 projected melee skill will have 1.25 multiplier.
  - Someone with projected Initiative of 160 and Melee Skill of 90 will have 1.75 multiplier.

The multiplier is then multiplied by the base chance which is 25%.