### PR TITLE
Flail tooltips improvements

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -564,7 +564,7 @@ local vanillaDescriptions = [
 				Type = ::UPD.EffectType.Passive,
 				Description = [
 					"Skills build up " + ::MSU.Text.colorPositive("25%") + " less [Fatigue.|Concept.Fatigue]",
-					"[Lash|Skill+lash_skill] and [Hail|Skill+hail_skill] ignore the defense bonus of shields.",
+					"[Lash|Skill+lash_skill] and [Hail|Skill+hail_skill] ignore the defense bonus granted by shields but not by [Shieldwall.|Skill+shieldwall_effect]",
 					"Gain the [From all Sides|Perk+perk_rf_from_all_sides] perk.",
 					"[Pound|Skill+pound] ignores an additional " + ::MSU.Text.colorPositive("+10%") + " of armor on head hits.",
 					"[Thresh|Skill+thresh] gains " + ::MSU.Text.colorPositive("+5%") + " chance to hit.",

--- a/mod_reforged/hooks/skills/actives/cascade_skill.nut
+++ b/mod_reforged/hooks/skills/actives/cascade_skill.nut
@@ -2,6 +2,29 @@
 	q.m.RerollDamageMult <- 1.0;
 	q.m.IsAttacking <- false;
 
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+
+		foreach (entry in ret)
+		{
+			switch (entry.id)
+			{
+				// Modify the vanilla 3 separate strikes tooltip to mention our method of three attack rolls but single strike
+				case 7:
+					entry.text = "Will make three separate attack rolls for one third of the damage each, combined into one strike";
+					break;
+
+				// Improve the vanilla entry about ignoring Shields to also mention Shieldwall
+				case 8:
+					entry.text = ::Reforged.Mod.Tooltips.parseString(format("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields %s[Shieldwall|Skill+shieldwall_effect]", this.m.IsShieldwallRelevant ? "but not by " : "and "));
+					break;
+			}
+		}
+
+		return ret;
+	}
+
 	q.create = @(__original) function()
 	{
 		__original();

--- a/mod_reforged/hooks/skills/actives/flail_skill.nut
+++ b/mod_reforged/hooks/skills/actives/flail_skill.nut
@@ -1,0 +1,18 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/flail_skill", function(q) {
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+
+		foreach (entry in ret)
+		{
+			// Improve the vanilla entry about ignoring Shields to also mention Shieldwall
+			if (entry.id == 7)
+			{
+				entry.text = ::Reforged.Mod.Tooltips.parseString(format("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields %s[Shieldwall|Skill+shieldwall_effect]", this.m.IsShieldwallRelevant ? "but not by " : "and "));
+				break;
+			}
+		}
+
+		return ret;
+	}
+});

--- a/mod_reforged/hooks/skills/actives/hail_skill.nut
+++ b/mod_reforged/hooks/skills/actives/hail_skill.nut
@@ -2,6 +2,29 @@
 	q.m.RerollDamageMult <- 1.0;
 	q.m.IsAttacking <- false;
 
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+
+		foreach (entry in ret)
+		{
+			switch (entry.id)
+			{
+				// Modify the vanilla 3 separate strikes tooltip to mention our method of three attack rolls but single strike
+				case 7:
+					entry.text = "Will make three separate attack rolls for one third of the damage each, combined into one strike";
+					break;
+
+				// Improve the vanilla entry about ignoring Shields to also mention Shieldwall
+				case 8:
+					entry.text = ::Reforged.Mod.Tooltips.parseString(format("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields %s[Shieldwall|Skill+shieldwall_effect]", this.m.IsShieldwallRelevant ? "but not by " : "and "));
+					break;
+			}
+		}
+
+		return ret;
+	}
+
 	q.create = @(__original) function()
 	{
 		__original();

--- a/mod_reforged/hooks/skills/actives/lash_skill.nut
+++ b/mod_reforged/hooks/skills/actives/lash_skill.nut
@@ -1,0 +1,18 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/lash_skill", function(q) {
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+
+		foreach (entry in ret)
+		{
+			// Improve the vanilla entry about ignoring Shields to also mention Shieldwall
+			if (entry.id == 8)
+			{
+				entry.text = ::Reforged.Mod.Tooltips.parseString(format("Ignores the bonus to [Melee Defense|Concept.MeleeDefense] granted by shields %s[Shieldwall|Skill+shieldwall_effect]", this.m.IsShieldwallRelevant ? "but not by " : "and "));
+				break;
+			}
+		}
+
+		return ret;
+	}
+});

--- a/scripts/skills/actives/rf_flail_pole_skill.nut
+++ b/scripts/skills/actives/rf_flail_pole_skill.nut
@@ -9,6 +9,20 @@ this.rf_flail_pole_skill <- ::inherit("scripts/skills/actives/flail_skill", {
 		this.m.MaxRange = 2;
 	}
 
+	function getTooltip()
+	{
+		local ret = this.flail_skill.getTooltip();
+
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorPositive(this.getMaxRange()) + " tiles"
+		});
+
+		return ret;
+	}
+
 	function onAnySkillUsed( _skill, _targetEntity, _properties )
 	{
 		this.flail_skill.onAnySkillUsed(_skill, _targetEntity, _properties);

--- a/scripts/skills/actives/rf_flail_pole_skill.nut
+++ b/scripts/skills/actives/rf_flail_pole_skill.nut
@@ -7,6 +7,7 @@ this.rf_flail_pole_skill <- ::inherit("scripts/skills/actives/flail_skill", {
 		this.m.ActionPointCost = 5;
 		this.m.FatigueCost = 15;
 		this.m.MaxRange = 2;
+		this.m.IsTooCloseShown = true;
 	}
 
 	function getTooltip()

--- a/scripts/skills/actives/rf_lash_pole_skill.nut
+++ b/scripts/skills/actives/rf_lash_pole_skill.nut
@@ -7,6 +7,7 @@ this.rf_lash_pole_skill <- ::inherit("scripts/skills/actives/lash_skill", {
 		this.m.ActionPointCost = 5;
 		this.m.FatigueCost = 25;
 		this.m.MaxRange = 2;
+		this.m.IsTooCloseShown = true;
 	}
 
 	function getTooltip()

--- a/scripts/skills/actives/rf_lash_pole_skill.nut
+++ b/scripts/skills/actives/rf_lash_pole_skill.nut
@@ -9,6 +9,20 @@ this.rf_lash_pole_skill <- ::inherit("scripts/skills/actives/lash_skill", {
 		this.m.MaxRange = 2;
 	}
 
+	function getTooltip()
+	{
+		local ret = this.lash_skill.getTooltip();
+
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/vision.png",
+			text = "Has a range of " + ::MSU.Text.colorPositive(this.getMaxRange()) + " tiles"
+		});
+
+		return ret;
+	}
+
 	function onAnySkillUsed( _skill, _targetEntity, _properties )
 	{
 		this.lash_skill.onAnySkillUsed(_skill, _targetEntity, _properties);


### PR DESCRIPTION
- Improve vanilla flail skills tooltips.
  - Mention Shieldwall in addition to the defense bonus of Shields for clarity.
  - Adjust Cascade and Hail tooltips for the Reforged system of three attack rolls but one strike.
- Add missing range entry to pole flail and lash skills.
- Fix pole flail and lash skills not showing too close in hit factors.