### PR TITLE
fix(vanilla): goblin wolfriders getting damage modified by wolf bite

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
@@ -54,6 +54,9 @@
 
 		// Reforged
 		this.m.Skills.add(::new("scripts/skills/racial/rf_goblin_wolfrider_racial"));
+
+		// In vanilla goblin_wolfriders have a bug that they get the bonus damage from wolf_bite for ALL attacks
+		// until they use that skill. We have "fixed" that in Reforged. The fix is in the hook on wolf_bite.
 	}
 
 	q.assignRandomEquipment = @(__original) function()

--- a/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
@@ -54,6 +54,8 @@
 
 		// Reforged
 		this.m.Skills.add(::new("scripts/skills/racial/rf_goblin_wolfrider_racial"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_fast_adaption"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_double_strike"));
 
 		// In vanilla goblin_wolfriders have a bug that they get the bonus damage from wolf_bite for ALL attacks
 		// until they use that skill. We have "fixed" that in Reforged. The fix is in the hook on wolf_bite.

--- a/mod_reforged/hooks/skills/actives/wolf_bite.nut
+++ b/mod_reforged/hooks/skills/actives/wolf_bite.nut
@@ -11,4 +11,33 @@
 	{
 		return this.getDefaultTooltip();
 	}
+
+	// VanillaFix: Overwrite vanilla function to prevent passive damage modification
+	q.onUpdate = @() function( _properties )
+	{
+	}
+
+	// VanillaFix: Overwrite vanilla function to apply the damage modification to this skill
+	q.onAnySkillUsed = @() function( _skill, _targetEntity, _properties )
+	{
+		if (_skill == this)
+		{
+			// Remove the effect on damage from equipped weapon (relevant for goblin wolfriders)
+			// We basically revert the changes that the weapon applies inside weapon.onUpdateProperties.
+			local weapon = this.getContainer().getActor().getMainhandItem();
+			if (weapon != null)
+			{
+				_properties.DamageRegularMin -= weapon.m.RegularDamage;
+				_properties.DamageRegularMax -= weapon.m.RegularDamageMax;
+				_properties.DamageArmorMult /= weapon.m.ArmorDamageMult;
+				_properties.DamageDirectAdd -= weapon.m.DirectDamageAdd;
+				_properties.HitChance[::Const.BodyPart.Head] -= weapon.m.ChanceToHitHead;
+			}
+
+			// Then add the damage of this skill. This is copied from what vanilla does in onUpdate of this skill
+			_properties.DamageRegularMin += 20;
+			_properties.DamageRegularMax += 40;
+			_properties.DamageArmorMult *= 0.4;
+		}
+	}
 });


### PR DESCRIPTION
For "balancing" them we add Fast Adaptation and Double Strike perks to them.