### PR TITLE
fix: make whirling death with delayed attack non-lethal for NPC users

### DIFF
--- a/scripts/skills/perks/perk_rf_whirling_death.nut
+++ b/scripts/skills/perks/perk_rf_whirling_death.nut
@@ -153,7 +153,22 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 					}
 
 					this.m.IsPerformingExtraAttack = true;
-					_skill.useForFree(targetTile);
+					if (_user.isPlayerControlled())
+					{
+						_skill.useForFree(targetTile);
+					}
+					// Make it non-lethal for NPC users
+					// Hopefully this reduces/elminiates the cases where AI evaluation gets stuck due to killing someone with a delayed attack.
+					// Once a proper solution to that issue is found and implemented, this can be reverted.
+					else
+					{
+						// This implementation has a side-effect of preventing the target from receiving injuries.
+						local wasAbleToDie = target.m.IsAbleToDie;
+						target.m.IsAbleToDie = false;
+						_skill.useForFree(targetTile);
+						target.m.IsAbleToDie = wasAbleToDie;
+					}
+
 					this.m.IsPerformingExtraAttack = false;
 				}
 				this.getContainer().setBusy(false);


### PR DESCRIPTION
Related bug report on Discord: https://discord.com/channels/1006908336991645757/1295057578778427423