### PR TITLE
refactor: guarantee a surcoat to spawn on all noble troops

### DIFF
--- a/mod_reforged/hooks/entity/tactical/humans/knight.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/knight.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/entity/tactical/humans/knight", function(q) {
+	q.m.SurcoatChance <- 100;	// Chance for this character to spawn with a cosmetic tabard of its faction
+
 	q.onInit = @() function()
 	{
 		this.human.onInit();
@@ -24,7 +26,7 @@
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 90)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/mod_reforged/hooks/entity/tactical/humans/noble_arbalester.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_arbalester.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/entity/tactical/humans/noble_arbalester", function(q) {
+	q.m.SurcoatChance <- 100;	// Chance for this character to spawn with a cosmetic tabard of its faction
+
 	q.onInit = @() function()
 	{
 		this.human.onInit();
@@ -22,7 +24,7 @@
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 80)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/mod_reforged/hooks/entity/tactical/humans/noble_billman.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_billman.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/entity/tactical/humans/noble_billman", function(q) {
+	q.m.SurcoatChance <- 100;	// Chance for this character to spawn with a cosmetic tabard of its faction
+
 	q.onInit = @() function()
 	{
 		this.human.onInit();
@@ -18,7 +20,7 @@
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 90)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/mod_reforged/hooks/entity/tactical/humans/noble_footman.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_footman.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/entity/tactical/humans/noble_footman", function(q) {
+	q.m.SurcoatChance <- 100;	// Chance for this character to spawn with a cosmetic tabard of its faction
+
 	q.onInit = @() function()
 	{
 		this.human.onInit();
@@ -20,7 +22,7 @@
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 90)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/mod_reforged/hooks/entity/tactical/humans/noble_greatsword.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_greatsword.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/entity/tactical/humans/noble_greatsword", function(q) {
+	q.m.SurcoatChance <- 100;	// Chance for this character to spawn with a cosmetic tabard of its faction
+
 	q.onInit = @() function()
 	{
 		this.human.onInit();
@@ -23,7 +25,7 @@
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 50)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/mod_reforged/hooks/entity/tactical/humans/noble_sergeant.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_sergeant.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/entity/tactical/humans/noble_sergeant", function(q) {
+	q.m.SurcoatChance <- 100;	// Chance for this character to spawn with a cosmetic tabard of its faction
+
 	q.create = @(__original) function()
 	{
 		__original();
@@ -39,7 +41,7 @@
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 80)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/mod_reforged/hooks/entity/tactical/humans/standard_bearer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/standard_bearer.nut
@@ -1,4 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/entity/tactical/humans/standard_bearer", function(q) {
+	q.m.SurcoatChance <- 100;	// Chance for this character to spawn with a cosmetic tabard of its faction
+
 	q.onInit = @() function()
 	{
 		this.human.onInit();
@@ -19,7 +21,10 @@
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
+		{
+			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
+		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{

--- a/scripts/entity/tactical/humans/rf_arbalester_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_arbalester_heavy.nut
@@ -1,5 +1,7 @@
 this.rf_arbalester_heavy <- ::inherit("scripts/entity/tactical/human" {
-	m = {},
+	m = {
+		SurcoatChance = 100		// Chance for this character to spawn with a cosmetic tabard of its faction
+	},
 	function create()
 	{
 		this.m.Type = ::Const.EntityType.RF_ArbalesterHeavy;
@@ -37,7 +39,7 @@ this.rf_arbalester_heavy <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 80)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/scripts/entity/tactical/humans/rf_billman_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_billman_heavy.nut
@@ -1,5 +1,7 @@
 this.rf_billman_heavy <- ::inherit("scripts/entity/tactical/human" {
-	m = {},
+	m = {
+		SurcoatChance = 100		// Chance for this character to spawn with a cosmetic tabard of its faction
+	},
 	function create()
 	{
 		this.m.Type = ::Const.EntityType.RF_BillmanHeavy;
@@ -35,7 +37,7 @@ this.rf_billman_heavy <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 90)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/scripts/entity/tactical/humans/rf_fencer.nut
+++ b/scripts/entity/tactical/humans/rf_fencer.nut
@@ -1,5 +1,7 @@
 this.rf_fencer <- ::inherit("scripts/entity/tactical/human" {
-	m = {},
+	m = {
+		SurcoatChance = 100		// Chance for this character to spawn with a cosmetic tabard of its faction
+	},
 	function create()
 	{
 		this.m.Type = ::Const.EntityType.RF_Fencer;
@@ -39,7 +41,7 @@ this.rf_fencer <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 75)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/scripts/entity/tactical/humans/rf_footman_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_footman_heavy.nut
@@ -1,5 +1,7 @@
 this.rf_footman_heavy <- ::inherit("scripts/entity/tactical/human" {
-	m = {},
+	m = {
+		SurcoatChance = 100		// Chance for this character to spawn with a cosmetic tabard of its faction
+	},
 	function create()
 	{
 		this.m.Type = ::Const.EntityType.RF_FootmanHeavy;
@@ -37,7 +39,7 @@ this.rf_footman_heavy <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 90)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/scripts/entity/tactical/humans/rf_herald.nut
+++ b/scripts/entity/tactical/humans/rf_herald.nut
@@ -1,5 +1,7 @@
 this.rf_herald <- ::inherit("scripts/entity/tactical/human" {
-	m = {},
+	m = {
+		SurcoatChance = 100		// Chance for this character to spawn with a cosmetic tabard of its faction
+	},
 	function create()
 	{
 		this.m.Type = ::Const.EntityType.RF_Herald;
@@ -66,7 +68,10 @@ this.rf_herald <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
+		{
+			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
+		}
 		this.getSprite("rf_surcoat_adornment").setBrush("bust_body_noble_0" + ::MSU.Array.rand([1, 3, 9]));
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))

--- a/scripts/entity/tactical/humans/rf_heralds_bodyguard.nut
+++ b/scripts/entity/tactical/humans/rf_heralds_bodyguard.nut
@@ -1,5 +1,6 @@
 this.rf_heralds_bodyguard <- ::inherit("scripts/entity/tactical/human" {
 	m = {
+		SurcoatChance = 100,		// Chance for this character to spawn with a cosmetic tabard of its faction
 		HelmetAdornment = {
 			Sprite = "",
 			SpriteDamaged = "",
@@ -109,7 +110,11 @@ this.rf_heralds_bodyguard <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
+		{
+			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
+		}
+
 		this.m.HelmetAdornment.Sprite = "faction_helmet_2_" + (banner < 10 ? "0" + banner : banner);
 		this.m.HelmetAdornment.SpriteDamaged = this.m.HelmetAdornment.Sprite + "_damaged";
 		this.m.HelmetAdornment.SpriteDead = this.m.HelmetAdornment.Sprite + "_dead";

--- a/scripts/entity/tactical/humans/rf_knight_anointed.nut
+++ b/scripts/entity/tactical/humans/rf_knight_anointed.nut
@@ -1,5 +1,7 @@
 this.rf_knight_anointed <- ::inherit("scripts/entity/tactical/human" {
-	m = {},
+	m = {
+		SurcoatChance = 100		// Chance for this character to spawn with a cosmetic tabard of its faction
+	},
 	function create()
 	{
 		this.m.Type = ::Const.EntityType.RF_KnightAnointed;
@@ -49,7 +51,7 @@ this.rf_knight_anointed <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 90)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/scripts/entity/tactical/humans/rf_man_at_arms.nut
+++ b/scripts/entity/tactical/humans/rf_man_at_arms.nut
@@ -1,5 +1,7 @@
 this.rf_man_at_arms <- ::inherit("scripts/entity/tactical/human" {
-	m = {},
+	m = {
+		SurcoatChance = 100		// Chance for this character to spawn with a cosmetic tabard of its faction
+	},
 	function create()
 	{
 		this.m.Type = ::Const.EntityType.RF_ManAtArms;
@@ -35,7 +37,7 @@ this.rf_man_at_arms <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 50)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/scripts/entity/tactical/humans/rf_marshal.nut
+++ b/scripts/entity/tactical/humans/rf_marshal.nut
@@ -1,5 +1,7 @@
 this.rf_marshal <- ::inherit("scripts/entity/tactical/human" {
-	m = {},
+	m = {
+		SurcoatChance = 100		// Chance for this character to spawn with a cosmetic tabard of its faction
+	},
 	function create()
 	{
 		this.m.Type = ::Const.EntityType.RF_Marshal;
@@ -43,7 +45,7 @@ this.rf_marshal <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 80)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}

--- a/scripts/entity/tactical/humans/rf_squire.nut
+++ b/scripts/entity/tactical/humans/rf_squire.nut
@@ -1,5 +1,7 @@
 this.rf_squire <- ::inherit("scripts/entity/tactical/human" {
-	m = {},
+	m = {
+		SurcoatChance = 100		// Chance for this character to spawn with a cosmetic tabard of its faction
+	},
 	function create()
 	{
 		this.m.Type = ::Const.EntityType.RF_Squire;
@@ -38,7 +40,7 @@ this.rf_squire <- ::inherit("scripts/entity/tactical/human" {
 	{
 		local banner = ::Tactical.State.isScenarioMode() ? this.getFaction() : ::World.FactionManager.getFaction(this.getFaction()).getBanner();
 		this.m.Surcoat = banner;
-		if (::Math.rand(1, 100) <= 90)
+		if (::Math.rand(1, 100) <= this.m.SurcoatChance)
 		{
 			this.getSprite("surcoat").setBrush("surcoat_" + (banner < 10 ? "0" + banner : banner));
 		}


### PR DESCRIPTION
This PR does two things:
- guarantees surcoats on all noble troops (instead of there being a 10%-50% chance for them to spawn without one
  - this increases visual clarity during bigger fights with multiple noble houses or when they have mercenaries in their partiy
- make surcoat spawnchance a member variable
  - some noble troops during special events might not (or with reduced chance) spawn with surcoats (e.g. deserted, hexed or otherwise betraying nobles)

## Before
![image](https://github.com/user-attachments/assets/352a2edd-051d-4c87-9d80-4ec639373b33)

## After
![image](https://github.com/user-attachments/assets/5c74a89f-87ef-43b6-8c5e-f2f25dc1cf33)
