### PR TITLE
fix: gladiators from the gladiator origin getting double arena traits

### DIFF
--- a/mod_reforged/hooks/skills/backgrounds/gladiator_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/gladiator_background.nut
@@ -36,7 +36,9 @@
 
 	q.onAdded = @(__original) function()
 	{
-		if (this.m.IsNew)
+		// The PlayerRoster check is to prevent adding the traits to gladiators from the start of the gladiator origin
+		// because they get their own traits manually added during onSpawnAssets
+		if (this.m.IsNew && ::World.getPlayerRoster().getAll().find(this.getContainer().getActor().get()) == null)
 		{
 			local flags = this.getContainer().getActor().getFlags();
 			if (!flags.has("ArenaFights"))


### PR DESCRIPTION
There are two ways to go about this:
- We make the gladiators from the gladiator origin also follow this random trait assignment from the background script. I would prefer this, but I can't find a clean way to do this short of overwriting the entire `onSpawnAssets` function of  `gladiators_scenario`.
- Or we let the origin gladiators get their manual traits from `onSpawnAssets` and remove them from this random assignment. I have gone with this solution in this PR.

Unless someone can suggest a cleaner/better solution?