### PR TITLE
fix: heavy crossbow reload ap cost change not being persistent

### DIFF
--- a/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
@@ -14,10 +14,19 @@
 		// Always add reload skill to DummyPlayer so that it appears in nested tooltips of weapons
 		if (!this.m.IsLoaded || ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
 		{
-			local reload = ::Reforged.new("scripts/skills/actives/reload_bolt", function(o) {
-				o.m.ActionPointCost += 1;
-			});
-			this.addSkill(reload);
+			this.addSkill(::new("scripts/skills/actives/reload_bolt"));
+		}
+	}
+
+	q.onAfterUpdateProperties = @(__original) function( _properties )
+	{
+		__original(_properties);
+		foreach (s in this.getSkills())
+		{
+			if (s.getID() == "actives.reload_bolt")
+			{
+				s.m.ActionPointCost += 1;
+			}
 		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
@@ -18,15 +18,13 @@
 		}
 	}
 
-	q.onAfterUpdateProperties = @(__original) function( _properties )
+	q.addSkill = @(__original) function( _skill )
 	{
-		__original(_properties);
-		foreach (s in this.getSkills())
+		if (_skill.getID() == "actives.reload_bolt")
 		{
-			if (s.getID() == "actives.reload_bolt")
-			{
-				s.m.ActionPointCost += 1;
-			}
+			_skill.m.ActionPointCost += 1;
 		}
+
+		__original(_properties);
 	}
 });

--- a/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
+++ b/mod_reforged/hooks/items/weapons/heavy_crossbow.nut
@@ -25,6 +25,6 @@
 			_skill.m.ActionPointCost += 1;
 		}
 
-		__original(_properties);
+		__original(_skill);
 	}
 });


### PR DESCRIPTION
Because the skill is removed and re-added upon every shoot bolt.