### PR TITLE
refactor: remove vanilla mention of bad terrain in hitfactors

### DIFF
--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -30,6 +30,8 @@
 				case "Resistance against ranged weapons":	// This was never followed through for anything other than skeletons
 				case "Resistance against piercing attacks":	// This was never followed through for anything other than skeletons
 				case "Nighttime":			// Already displayed on the stats of the character and in the effects section
+				case "On bad terrain":		// Terrain effects usually have their effects viewable in the actor tooltip
+				case "Target on bad terrain":	// Terrain effects usually have their effects viewable in the actor tooltip
 					ret.remove(index);
 					break;
 


### PR DESCRIPTION
Vanilla doesnt differentiate different types of bad terrain. It doesnt know whether this specific bad terrain actually influences your hitchance.
Also with our expanded tooltips, it is much easier to see the effects that the bad terrain has on you.
Currently the only bad terrain there is is swamp, which applies its effects continuously, being visible in the attributes.
*edit1:* Swamp also doesn't affect ranged skill, and yet it shows up as a "negative hitfactor", when you aim with a ranged skill onto an enemy while you stand in swamp

So I deem these entries as bloat/misleading