### PR TITLE
fix: sling skills overwriting any hookTree attempts on onUse

### DIFF
--- a/mod_reforged/config/sling_items.nut
+++ b/mod_reforged/config/sling_items.nut
@@ -79,8 +79,10 @@
 		return true;
 	}
 
+	local onUpdate = o.onUpdate;
 	o.onUpdate = function( _properties )
 	{
+		onUpdate(_properties);
 		local mainhandItem = this.getContainer().getActor().getMainhandItem();
 		if (mainhandItem == null) return;
 		if (mainhandItem.isItemType(::Const.Items.ItemType.Weapon) == false) return;

--- a/scripts/skills/actives/rf_sling_acid_flask_skill.nut
+++ b/scripts/skills/actives/rf_sling_acid_flask_skill.nut
@@ -7,4 +7,11 @@ this.rf_sling_acid_flask_skill <- ::inherit("scripts/skills/actives/throw_acid_f
 		this.m.Overlay = "rf_sling_acid_flask_skill";
 		::Reforged.Skills.adjustSlingItemSkill(this);
 	}
+
+	// We overwrite the onUse of acid_flask with the new one coming with adjustSlingItemSkill
+	// We have to do the overwrite here so that we don't invalidate hookTree hooks of onUse from skill.nut
+	function onUse( _user, _targetTile )
+	{
+		this.__onUse(_user, _targetTile);
+	}
 });

--- a/scripts/skills/actives/rf_sling_daze_bomb_skill.nut
+++ b/scripts/skills/actives/rf_sling_daze_bomb_skill.nut
@@ -7,4 +7,11 @@ this.rf_sling_daze_bomb_skill <- ::inherit("scripts/skills/actives/throw_daze_bo
 		this.m.Overlay = "rf_sling_daze_bomb_skill";
 		::Reforged.Skills.adjustSlingItemSkill(this);
 	}
+
+	// We overwrite the onUse of acid_flask with the new one coming with adjustSlingItemSkill
+	// We have to do the overwrite here so that we don't invalidate hookTree hooks of onUse from skill.nut
+	function onUse( _user, _targetTile )
+	{
+		this.__onUse(_user, _targetTile);
+	}
 });

--- a/scripts/skills/actives/rf_sling_fire_bomb_skill.nut
+++ b/scripts/skills/actives/rf_sling_fire_bomb_skill.nut
@@ -7,4 +7,11 @@ this.rf_sling_fire_bomb_skill <- ::inherit("scripts/skills/actives/throw_fire_bo
 		this.m.Overlay = "rf_sling_fire_bomb_skill";
 		::Reforged.Skills.adjustSlingItemSkill(this);
 	}
+
+	// We overwrite the onUse of acid_flask with the new one coming with adjustSlingItemSkill
+	// We have to do the overwrite here so that we don't invalidate hookTree hooks of onUse from skill.nut
+	function onUse( _user, _targetTile )
+	{
+		this.__onUse(_user, _targetTile);
+	}
 });

--- a/scripts/skills/actives/rf_sling_holy_water_skill.nut
+++ b/scripts/skills/actives/rf_sling_holy_water_skill.nut
@@ -7,4 +7,11 @@ this.rf_sling_holy_water_skill <- ::inherit("scripts/skills/actives/throw_holy_w
 		this.m.Overlay = "rf_sling_holy_water_skill";
 		::Reforged.Skills.adjustSlingItemSkill(this);
 	}
+
+	// We overwrite the onUse of acid_flask with the new one coming with adjustSlingItemSkill
+	// We have to do the overwrite here so that we don't invalidate hookTree hooks of onUse from skill.nut
+	function onUse( _user, _targetTile )
+	{
+		this.__onUse(_user, _targetTile);
+	}
 });

--- a/scripts/skills/actives/rf_sling_smoke_bomb_skill.nut
+++ b/scripts/skills/actives/rf_sling_smoke_bomb_skill.nut
@@ -7,4 +7,11 @@ this.rf_sling_smoke_bomb_skill <- ::inherit("scripts/skills/actives/throw_smoke_
 		this.m.Overlay = "rf_sling_smoke_bomb_skill";
 		::Reforged.Skills.adjustSlingItemSkill(this);
 	}
+
+	// We overwrite the onUse of acid_flask with the new one coming with adjustSlingItemSkill
+	// We have to do the overwrite here so that we don't invalidate hookTree hooks of onUse from skill.nut
+	function onUse( _user, _targetTile )
+	{
+		this.__onUse(_user, _targetTile);
+	}
 });

--- a/scripts/skills/effects/rf_faction_banner_effect.nut
+++ b/scripts/skills/effects/rf_faction_banner_effect.nut
@@ -33,9 +33,9 @@ this.rf_faction_banner_effect <- ::inherit("scripts/skills/skill", {
 			return;
 
 		local numEnemies = 0;
-		foreach (faction in ::Tactical.Entities.getAllInstances())
+		foreach (factionID, faction in ::Tactical.Entities.getAllInstances())
 		{
-			if (faction == actor.getFaction())
+			if (factionID == actor.getFaction())
 				continue;
 
 			foreach (entity in faction)


### PR DESCRIPTION
Previously onUse was overwritten during create, destroying any hookTree usage targeting that function in skill.nut for the sling skills