### PR TITLE
Refactor remove named names

### DIFF
--- a/mod_reforged/hooks/config/item_names.nut
+++ b/mod_reforged/hooks/config/item_names.nut
@@ -1,4 +1,9 @@
 // Vanilla Adjustments
+::MSU.Array.removeValues(::Const.Strings.BillNames, [
+	"Bardiche",	// There is already a vanilla weapon with this name
+	"Voulge"	// There is already a reforged weapon with this name
+]);
+
 ::MSU.Array.removeValues(::Const.Strings.CrossbowNames, [
 	"Betrayer"		// moved over to dagger names
 ]);


### PR DESCRIPTION
I noticed that "Reach" is used in 4 different named weapons as a name, so I reduced it to only be used for Bows.
I also removed "Bardiche" and "Voulge" as possible names