### PR TITLE
Update spawns definitions for Dynamic Spawns Framework

### DIFF
--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/bandit_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/bandit_parties.nut
@@ -6,13 +6,15 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
-			{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
-			{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
-			{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40 },
-			{ BaseID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20, ExclusionChance = 0.10 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
+				{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
+				{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
+				{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40 },
+				{ BaseID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20, ExclusionChance = 0.10 }
+			]
+		}
 
 		function generateIdealSize()
 		{
@@ -44,13 +46,15 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		IdealSizeLocationMult = 1.2,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
-			{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
-			{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
-			{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40, ExclusionChance = 0.10 },
-			{ BaseID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20, ExclusionChance = 0.10 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
+				{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
+				{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
+				{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40, ExclusionChance = 0.10 },
+				{ BaseID = "UnitBlock.RF.BanditDog", RatioMin = 0.00, RatioMax = 0.20, ExclusionChance = 0.10 }
+			]
+		}
 
 		function generateIdealSize()
 		{
@@ -82,14 +86,16 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		IdealSizeLocationMult = 1.2,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
-			{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.10 },
-			{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.10 },
-			{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40, ExclusionChance = 0.20 },
-			{ BaseID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.10, StartingResourceMin = 320 },
-			{ BaseID = "UnitBlock.RF.BanditBoss", RatioMin = 0.00, RatioMax = 0.11, ExclusionChance = 0.75, StartingResourceMin = 250, DeterminesFigure = true }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
+				{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.10 },
+				{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.10 },
+				{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40, ExclusionChance = 0.20 },
+				{ BaseID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.10, StartingResourceMin = 320 },
+				{ BaseID = "UnitBlock.RF.BanditBoss", RatioMin = 0.00, RatioMax = 0.11, ExclusionChance = 0.75, StartingResourceMin = 250, DeterminesFigure = true }
+			]
+		}
 
 		function generateIdealSize()
 		{
@@ -121,14 +127,16 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		IdealSizeLocationMult = 1.2,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
-			{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
-			{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
-			{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40 },
-			{ BaseID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.10 },
-			{ BaseID = "UnitBlock.RF.BanditBoss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 250 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
+				{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
+				{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
+				{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40 },
+				{ BaseID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.10 },
+				{ BaseID = "UnitBlock.RF.BanditBoss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 250 }
+			]
+		}
 
 		function generateIdealSize()
 		{
@@ -160,14 +168,16 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		IdealSizeLocationMult = 1.2,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
-			{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
-			{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
-			{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40 },
-			{ BaseID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35 },
-			{ BaseID = "UnitBlock.RF.BanditBoss", RatioMin = 0.01, RatioMax = 0.11 }  // One boss is always guaranteed
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BanditBalanced", RatioMin = 0.30, RatioMax = 1.0 },
+				{ BaseID = "UnitBlock.RF.BanditFast", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
+				{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.20 },
+				{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40 },
+				{ BaseID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.35 },
+				{ BaseID = "UnitBlock.RF.BanditBoss", RatioMin = 0.01, RatioMax = 0.11 }  // One boss is always guaranteed
+			]
+		}
 
 		function generateIdealSize()
 		{
@@ -198,9 +208,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BanditDisguisedDirewolf" }
-		],
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BanditDisguisedDirewolf" }
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/bandit_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/bandit_parties.nut
@@ -16,7 +16,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 			if (startingResources >= 216)
 			{
 				return 12;
@@ -54,7 +54,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 			if (startingResources >= 216)
 			{
 				return 12;
@@ -93,7 +93,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 			if (startingResources >= 216)
 			{
 				return 12;
@@ -132,7 +132,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 			if (startingResources >= 216)
 			{
 				return 12;
@@ -171,7 +171,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 			if (startingResources >= 216)
 			{
 				return 12;

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/bandit_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/bandit_parties.nut
@@ -93,7 +93,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.BanditTough", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.10 },
 				{ BaseID = "UnitBlock.RF.BanditRanged", RatioMin = 0.00, RatioMax = 0.40, ExclusionChance = 0.20 },
 				{ BaseID = "UnitBlock.RF.BanditElite", RatioMin = 0.00, RatioMax = 0.10, StartingResourceMin = 320 },
-				{ BaseID = "UnitBlock.RF.BanditBoss", RatioMin = 0.00, RatioMax = 0.11, ExclusionChance = 0.75, StartingResourceMin = 250, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.BanditBoss", RatioMin = 0.00, RatioMax = 0.11, ExclusionChance = 0.75, StartingResourceMin = 250 }
 			]
 		}
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
@@ -11,7 +11,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.BarbarianFrontline", RatioMin = 0.60, RatioMax = 1.00 },	// Vanilla: doesn't care about size
 				{ BaseID = "UnitBlock.RF.BarbarianSupport", RatioMin = 0.00, RatioMax = 0.07, PartySizeMin = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
 				{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5 },		// Vanilla: Start spawning in armies of 6+
-				{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, PartySizeMin = 5 }
+				{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, PartySizeMin = 5 }	// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
 			]
 		}
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
@@ -8,7 +8,7 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.BarbarianFrontline", RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
+				{ BaseID = "UnitBlock.RF.BarbarianFrontline", RatioMin = 0.60, RatioMax = 1.00 },	// Vanilla: doesn't care about size
 				{ BaseID = "UnitBlock.RF.BarbarianSupport", RatioMin = 0.00, RatioMax = 0.07, PartySizeMin = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
 				{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5 },		// Vanilla: Start spawning in armies of 6+
 				{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, PartySizeMin = 5 }
@@ -46,7 +46,7 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0 },
 				{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.20, RatioMax = 0.45 }
 			]
 		}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
@@ -6,12 +6,14 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BarbarianFrontline", RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.BarbarianSupport", RatioMin = 0.00, RatioMax = 0.07, PartySizeMin = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
-			{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5 },		// Vanilla: Start spawning in armies of 6+
-			{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, PartySizeMin = 5 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BarbarianFrontline", RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
+				{ BaseID = "UnitBlock.RF.BarbarianSupport", RatioMin = 0.00, RatioMax = 0.07, PartySizeMin = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
+				{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5 },		// Vanilla: Start spawning in armies of 6+
+				{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, PartySizeMin = 5 }
+			]
+		}
 
 		function generateIdealSize()
 		{
@@ -42,10 +44,12 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.20, RatioMax = 0.45 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BarbarianHunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.20, RatioMax = 0.45 }
+			]
+		}
 
 		function generateIdealSize()
 		{
@@ -67,10 +71,12 @@ local parties = [
 	{
 		ID = "BarbarianKing",
 		DefaultFigure = "figure_wildman_04",
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.BarbarianChosen" },
-			{ BaseID = "Unit.RF.BarbarianMarauder" }  // always spawn with one reaver to make early game contracts more balanced
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.BarbarianChosen" },
+				{ BaseID = "Unit.RF.BarbarianMarauder" }  // always spawn with one reaver to make early game contracts more balanced
+			]
+		}
 	},
 
 	// SubParties
@@ -78,33 +84,41 @@ local parties = [
 		ID = "OneUnhold",
 		HardMin = 1,
 		HardMax = 1,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BarbarianUnhold"}
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BarbarianUnhold" }
+			]
+		}
 	},
 	{
 		ID = "TwoUnhold",
 		HardMin = 2,
 		HardMax = 2,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BarbarianUnhold"}
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BarbarianUnhold" }
+			]
+		}
 	},
 	{
 		ID = "OneFrostUnhold",
 		HardMin = 1,
 		HardMax = 1,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BarbarianUnholdFrost"}
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BarbarianUnholdFrost" }
+			]
+		}
 	},
 	{
 		ID = "TwoFrostUnhold",
 		HardMin = 2,
 		HardMax = 2,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BarbarianUnholdFrost"}
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BarbarianUnholdFrost" }
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
@@ -8,9 +8,9 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.BarbarianFrontline", RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.BarbarianSupport", RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
-			{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
-			{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
+			{ BaseID = "UnitBlock.RF.BarbarianSupport", RatioMin = 0.00, RatioMax = 0.07, PartySizeMin = 10 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
+			{ BaseID = "UnitBlock.RF.BarbarianDog", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5 },		// Vanilla: Start spawning in armies of 6+
+			{ BaseID = "UnitBlock.RF.BarbarianBeastmaster", RatioMin = 0.00, RatioMax = 0.10, PartySizeMin = 5 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
 		]
 
 		function generateIdealSize()

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/barbarian_parties.nut
@@ -15,7 +15,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 
 			if (startingResources >= 550)
 			{
@@ -49,7 +49,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 			if (startingResources >= 216)
 			{
 				return 12;

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/beast_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/beast_parties.nut
@@ -6,9 +6,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Ghouls",
@@ -17,9 +19,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Lindwurm",
@@ -28,9 +32,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Lindwurm", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Lindwurm", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Unhold",
@@ -39,9 +45,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "UnholdFrost",
@@ -50,9 +58,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.UnholdFrost", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.UnholdFrost", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "UnholdBog",
@@ -61,9 +71,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Spiders",
@@ -72,9 +84,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Spider", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Spider", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Alps",
@@ -83,9 +97,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Alp", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Alp", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Schrats",
@@ -94,9 +110,11 @@ local parties = [
 		MovementSpeedMult = 0.5,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "HexenAndMore",
@@ -105,20 +123,24 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.Hexe" }	// This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
-		],
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.HexeWithBodyguard", RatioMin = 0.00, RatioMax = 0.13 },
-			{ BaseID = "UnitBlock.RF.Spider", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
-			{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
-			{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.HexeBanditRanged", RatioMin = 0.00, RatioMax = 0.13 }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.Hexe" }	// This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+			]
+		},
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.HexeWithBodyguard", RatioMin = 0.00, RatioMax = 0.13 },
+				{ BaseID = "UnitBlock.RF.Spider", RatioMin = 0.00, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+				{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+				{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+				{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.HexeBanditRanged", RatioMin = 0.00, RatioMax = 0.13 }
+			]
+		}
 	},
 	{
 		ID = "HexenAndNoSpiders",
@@ -127,18 +149,22 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.Hexe" }	// This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
-		],
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.HexeNoSpider", RatioMin = 0.00, RatioMax = 0.13 },
-			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
-			{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
-			{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
-			{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.Hexe" }	// This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+			]
+		},
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.HexeNoSpider", RatioMin = 0.00, RatioMax = 0.13 },
+				{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
+				{ BaseID = "UnitBlock.RF.Schrat", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+				{ BaseID = "UnitBlock.RF.Unhold", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+				{ BaseID = "UnitBlock.RF.UnholdBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+				{ BaseID = "UnitBlock.RF.Direwolf", RatioMin = 0.00, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.HexeBandit", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Hexen",
@@ -147,9 +173,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.HexeNoBodyguard", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.HexeNoBodyguard", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 
 	// Skipped Kraken
@@ -160,9 +188,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Hyena", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Hyena", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Serpents",
@@ -171,9 +201,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Serpent", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Serpent", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "SandGolems",
@@ -182,23 +214,29 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SandGolem", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.SandGolem", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	}
 
 	// SubParties
 	{
 		ID = "SpiderBodyguards",
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SpiderBodyguard" }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.SpiderBodyguard" }
+			]
+		}
 	},
 	{
 		ID = "DirewolfBodyguards",
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.DirewolfBodyguard" }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.DirewolfBodyguard" }
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/goblin_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/goblin_parties.nut
@@ -8,9 +8,9 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140 },
+				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140 },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120 }
 			]
 		}
 	},
@@ -23,9 +23,9 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00 }
 			]
 		}
 	},
@@ -38,10 +38,10 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
+			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
+			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250 }
 			]
 		}
 	},
@@ -54,10 +54,10 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
+				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250 }
 			]
 		}
 	},
@@ -73,7 +73,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
 				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
-				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11 }
 			]
 		}
 	}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/goblin_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/goblin_parties.nut
@@ -6,11 +6,13 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,		// Pure GoblinAmbusher groups have 0.75 here in vanilla
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true }		// Lategame GoblinRoamer only consist of Riders
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true }
+			]
+		}
 	},
 	{	// Similar to GoblinRoamer except Scout sizes are capped in vanilla and they more mixed than Roamers. We have no cap in this implementation
 		ID = "GoblinScouts",
@@ -19,11 +21,13 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,		// Parties that have no Rider have a value of 0.75 here in vanilla
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true }
+			]
+		}
 	},
 	{
 		ID = "GoblinRaiders",
@@ -32,12 +36,14 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
 			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true },
 			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true }	// One boss is guaranteed at 250+ resources
-		]
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true }
+			]
+		}
 	},
 	{
 		ID = "GoblinDefenders",
@@ -46,12 +52,14 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true }	// One boss is guaranteed at 250+ resources
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true }
+			]
+		}
 	},
 	{
 		ID = "GoblinBoss",
@@ -60,12 +68,14 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true }	// One boss is always guaranteed
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
+				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true }
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/goblin_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/goblin_parties.nut
@@ -39,9 +39,9 @@ local parties = [
 		DynamicDefs = {
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250 }	// One boss is guaranteed at 250+ resources
+				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
+				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250 }	// One boss is guaranteed at 250+ resources
 			]
 		}
 	},

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/goblin_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/goblin_parties.nut
@@ -10,7 +10,7 @@ local parties = [
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140 },
 				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140 },
-				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120 }
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120 }	// Lategame GoblinRoamer only consist of Riders
 			]
 		}
 	},
@@ -41,7 +41,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
 			{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
 			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250 }
+			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250 }	// One boss is guaranteed at 250+ resources
 			]
 		}
 	},
@@ -57,7 +57,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
 				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
-				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250 }
+				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250 }	// One boss is guaranteed at 250+ resources
 			]
 		}
 	},
@@ -73,7 +73,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.GoblinFrontline", RatioMin = 0.35, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.GoblinRanged", RatioMin = 0.15, RatioMax = 0.50 },
 				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.35 },
-				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11 }
+				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.01, RatioMax = 0.11 }	// One boss is always guaranteed
 			]
 		}
 	}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/greenskin_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/greenskin_parties.nut
@@ -8,14 +8,14 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.GoblinRegular", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinRegular", RatioMin = 0.00, RatioMax = 0.50 },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.50 },
+				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350 },
 
-				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 0.80 },
+				{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.50 },
+				{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.33 },
+				{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350 }
 			]
 		}
 	}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/greenskin_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/greenskin_parties.nut
@@ -6,16 +6,18 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.GoblinRegular", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true },
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.GoblinRegular", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinFlank", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GoblinBoss", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true },
 
-			{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true }
-		]
+				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true }
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/human_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/human_parties.nut
@@ -61,8 +61,8 @@ local parties = [
 		DynamicDefs = {
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.BountyHunter", RatioMin = 0.60, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30 },
-			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.05, RatioMax = 0.15 }
+				{ BaseID = "UnitBlock.RF.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30 },
+				{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.05, RatioMax = 0.15 }
 			]
 		}
 	},
@@ -76,9 +76,9 @@ local parties = [
 		DynamicDefs = {
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30 },
-			{ BaseID = "UnitBlock.RF.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, PartySizeMin = 10 },	// Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
-			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.00, RatioMax = 0.12 }
+				{ BaseID = "UnitBlock.RF.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30 },
+				{ BaseID = "UnitBlock.RF.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, PartySizeMin = 10 },	// Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
+				{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.00, RatioMax = 0.12 }
 			]
 		}
 	},

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/human_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/human_parties.nut
@@ -66,7 +66,7 @@ local parties = [
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00 },
 			{ BaseID = "UnitBlock.RF.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30 },
-			{ BaseID = "UnitBlock.RF.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, ReqPartySize = 10 },	// Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
+			{ BaseID = "UnitBlock.RF.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, PartySizeMin = 10 },	// Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
 			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.00, RatioMax = 0.12 }
 		]
 	},
@@ -80,7 +80,7 @@ local parties = [
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.MilitiaFrontline", RatioMin = 0.60, RatioMax = 1.00 },
 			{ BaseID = "UnitBlock.RF.MilitiaRanged", RatioMin = 0.12, RatioMax = 0.35 },
-			{ BaseID = "UnitBlock.RF.MilitiaCaptain", RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }	// Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
+			{ BaseID = "UnitBlock.RF.MilitiaCaptain", RatioMin = 0.09, RatioMax = 0.09, PartySizeMin = 12 }	// Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
 		]
 	},
 	{
@@ -94,7 +94,7 @@ local parties = [
 			{ BaseID = "Unit.RF.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },	// Vanilla: Second Donkey starts spawning at 7+
+			{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.17, RatioMax = 0.20, PartySizeMin = 6 },	// Vanilla: Second Donkey starts spawning at 7+
 			{ BaseID = "UnitBlock.RF.CaravanHand", RatioMin = 0.35, RatioMax = 0.80, DeterminesFigure = false },
 			{ BaseID = "UnitBlock.RF.CaravanGuard", RatioMin = 0.15, RatioMax = 0.55, DeterminesFigure = false }
 		]
@@ -111,7 +111,7 @@ local parties = [
 			{ BaseID = "Unit.RF.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },	// Vanilla: Third donkey spawns at 6+
+			{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.15, RatioMax = 0.35, PartySizeMin = 5 },	// Vanilla: Third donkey spawns at 6+
 			{ BaseID = "UnitBlock.RF.CaravanHand", RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = false }
 		]
 	}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/human_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/human_parties.nut
@@ -6,9 +6,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.CultistAmbush", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.CultistAmbush", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Peasants",
@@ -17,9 +19,11 @@ local parties = [
 		MovementSpeedMult = 0.75,
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Peasant", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Peasant", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "PeasantsArmed",
@@ -28,9 +32,11 @@ local parties = [
 		MovementSpeedMult = 0.75,
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.PeasantArmed", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.PeasantArmed", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "PeasantsSouthern",
@@ -39,9 +45,11 @@ local parties = [
 		MovementSpeedMult = 0.75,
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SouthernPeasant", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.SouthernPeasant", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "BountyHunters",
@@ -50,11 +58,13 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.BountyHunter", RatioMin = 0.60, RatioMax = 1.00 },
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.BountyHunter", RatioMin = 0.60, RatioMax = 1.00 },
 			{ BaseID = "UnitBlock.RF.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30 },
 			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.05, RatioMax = 0.15 }
-		]
+			]
+		}
 	},
 	{
 		ID = "Mercenaries",
@@ -63,12 +73,14 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00 },
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.MercenaryFrontline", RatioMin = 0.60, RatioMax = 1.00 },
 			{ BaseID = "UnitBlock.RF.MercenaryRanged", RatioMin = 0.12, RatioMax = 0.30 },
 			{ BaseID = "UnitBlock.RF.MercenaryElite", RatioMin = 0.10, RatioMax = 0.25, PartySizeMin = 10 },	// Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
 			{ BaseID = "UnitBlock.RF.Wardog", RatioMin = 0.00, RatioMax = 0.12 }
-		]
+			]
+		}
 	},
 	{
 		ID = "Militia",
@@ -77,11 +89,13 @@ local parties = [
 		MovementSpeedMult = 0.9,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.MilitiaFrontline", RatioMin = 0.60, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.MilitiaRanged", RatioMin = 0.12, RatioMax = 0.35 },
-			{ BaseID = "UnitBlock.RF.MilitiaCaptain", RatioMin = 0.09, RatioMax = 0.09, PartySizeMin = 12 }	// Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.MilitiaFrontline", RatioMin = 0.60, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.MilitiaRanged", RatioMin = 0.12, RatioMax = 0.35 },
+				{ BaseID = "UnitBlock.RF.MilitiaCaptain", RatioMin = 0.09, RatioMax = 0.09, PartySizeMin = 12 }
+			]
+		}
 	},
 	{
 		ID = "Caravan",
@@ -90,14 +104,18 @@ local parties = [
 		MovementSpeedMult = 0.5,
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.CaravanDonkey" }
-		],
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.17, RatioMax = 0.20, PartySizeMin = 6 },	// Vanilla: Second Donkey starts spawning at 7+
-			{ BaseID = "UnitBlock.RF.CaravanHand", RatioMin = 0.35, RatioMax = 0.80, DeterminesFigure = false },
-			{ BaseID = "UnitBlock.RF.CaravanGuard", RatioMin = 0.15, RatioMax = 0.55, DeterminesFigure = false }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.CaravanDonkey" }
+			]
+		},
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.17, RatioMax = 0.20, PartySizeMin = 6 },	// Vanilla: Second Donkey starts spawning at 7+
+				{ BaseID = "UnitBlock.RF.CaravanHand", RatioMin = 0.35, RatioMax = 0.80, DeterminesFigure = false },
+				{ BaseID = "UnitBlock.RF.CaravanGuard", RatioMin = 0.15, RatioMax = 0.55, DeterminesFigure = false }
+			]
+		}
 	},
 	{
 		ID = "CaravanEscort",	// Caravans spawned for player escort contract
@@ -106,14 +124,18 @@ local parties = [
 		MovementSpeedMult = 0.5,
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.CaravanDonkey" },	// In vanilla an escorted caravan can also have only a single Donkey. I chose to force 2 donkey every time instead
-			{ BaseID = "Unit.RF.CaravanDonkey" }
-		],
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.15, RatioMax = 0.35, PartySizeMin = 5 },	// Vanilla: Third donkey spawns at 6+
-			{ BaseID = "UnitBlock.RF.CaravanHand", RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = false }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.CaravanDonkey" },	// In vanilla an escorted caravan can also have only a single Donkey. I chose to force 2 donkey every time instead
+				{ BaseID = "Unit.RF.CaravanDonkey" }
+			]
+		},
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.CaravanDonkey", RatioMin = 0.15, RatioMax = 0.35, PartySizeMin = 5 },	// Vanilla: Third donkey spawns at 6+
+				{ BaseID = "UnitBlock.RF.CaravanHand", RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = false }
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/human_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/human_parties.nut
@@ -93,7 +93,7 @@ local parties = [
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.MilitiaFrontline", RatioMin = 0.60, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.MilitiaRanged", RatioMin = 0.12, RatioMax = 0.35 },
-				{ BaseID = "UnitBlock.RF.MilitiaCaptain", RatioMin = 0.09, RatioMax = 0.09, PartySizeMin = 12 }
+				{ BaseID = "UnitBlock.RF.MilitiaCaptain", RatioMin = 0.09, RatioMax = 0.09, PartySizeMin = 12 }	// Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
 			]
 		}
 	},

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
@@ -10,9 +10,7 @@ local parties = [
 		DynamicDefs = {
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.NobleFrontline", RatioMin = 0.30, RatioMax = 1.00, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NobleBackline", RatioMax = 0.40, DeterminesFigure = true,
-					function getSpawnWeight() { return base.getSpawnWeight() * 1.0; }
-				},
+				{ BaseID = "UnitBlock.RF.NobleBackline", RatioMax = 0.40, DeterminesFigure = true },
 				{ BaseID = "UnitBlock.RF.NobleRanged", RatioMax = 0.30, DeterminesFigure = true,
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.75; }
 				},

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
@@ -10,7 +10,8 @@ local parties = [
 		DynamicDefs = {
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.NobleFrontline", RatioMin = 0.30, RatioMax = 1.00 },
-				{ BaseID = "UnitBlock.RF.NobleBackline", RatioMax = 0.40,
+				{ BaseID = "UnitBlock.RF.NobleBackline", RatioMax = 0.40 },
+				{ BaseID = "UnitBlock.RF.NobleRanged", RatioMax = 0.30,
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.75; }
 				},
 				{ BaseID = "UnitBlock.RF.NobleElite",  RatioMax = 0.20 },

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
@@ -17,9 +17,9 @@ local parties = [
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.75; }
 				},
 				{ BaseID = "UnitBlock.RF.NobleElite",  RatioMax = 0.20, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NobleSupport", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, ReqPartySize = 9, ExclusionChance = 0.05 },
-				{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, ReqPartySize = 8, ExclusionChance = 0.3 },
-				{ BaseID = "UnitBlock.RF.NobleLeader", HardMax = 2, ReqPartySize = 10, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.NobleSupport", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, PartySizeMin = 9, ExclusionChance = 0.05 },
+				{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, PartySizeMin = 8, ExclusionChance = 0.3 },
+				{ BaseID = "UnitBlock.RF.NobleLeader", HardMax = 2, PartySizeMin = 10, DeterminesFigure = true },
 				{ BaseID = "UnitBlock.RF.NobleFlank", RatioMax = 0.25, HardMax = 3, ExclusionChance = 0.4 }
 			]
 		}
@@ -60,8 +60,8 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.NobleBackline", RatioMin = 0.00, RatioMax = 0.40, DeterminesFigure = false },
 				{ BaseID = "UnitBlock.RF.NobleRanged", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = false },
 				{ BaseID = "UnitBlock.RF.NobleElite", RatioMin = 0.00, RatioMax = 0.20, DeterminesFigure = false },
-				{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMin = 0.00, RatioMax = 0.05, ReqPartySize = 10, DeterminesFigure = false, function canUpgrade() { return false; } },  // Vanilla: spawns at 12, at 15 and at 18 once respectively
-				{ BaseID = "UnitBlock.RF.NobleDonkey", RatioMin = 0.01, RatioMax = 0.08, ReqPartySize = 13 }	// Vanilla: second donkey spawns at 14+
+				{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMin = 0.00, RatioMax = 0.05, PartySizeMin = 10, DeterminesFigure = false, function canUpgrade() { return false; } },  // Vanilla: spawns at 12, at 15 and at 18 once respectively
+				{ BaseID = "UnitBlock.RF.NobleDonkey", RatioMin = 0.01, RatioMax = 0.08, PartySizeMin = 13 }	// Vanilla: second donkey spawns at 14+
 			]
 		}
 	}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
@@ -17,17 +17,9 @@ local parties = [
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.75; }
 				},
 				{ BaseID = "UnitBlock.RF.NobleElite",  RatioMax = 0.20, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NobleSupport", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, ReqPartySize = 9, ExclusionChance = 0.05
-					function getSpawnWeight() {	return base.getSpawnWeight() * (this.getTopParty().getTotal() == this.getPartySizeMin() ? 10.0 : 1.0); }
-					function getUpgradeWeight() { return base.getUpgradeWeight() * 7.0; }
-				},
-				{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, ReqPartySize = 8, ExclusionChance = 0.3
-					function getSpawnWeight() {	return base.getSpawnWeight() * (this.getTopParty().getTotal() == this.getPartySizeMin() ? 10.0 : 1.0); }
-					function getUpgradeWeight() { return base.getUpgradeWeight() * 2.0; }
-				},
-				{ BaseID = "UnitBlock.RF.NobleLeader", HardMax = 2, ReqPartySize = 10, DeterminesFigure = true,
-					function getUpgradeWeight() { return base.getUpgradeWeight() * 5.0; }
-				},
+				{ BaseID = "UnitBlock.RF.NobleSupport", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, ReqPartySize = 9, ExclusionChance = 0.05 },
+				{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, ReqPartySize = 8, ExclusionChance = 0.3 },
+				{ BaseID = "UnitBlock.RF.NobleLeader", HardMax = 2, ReqPartySize = 10, DeterminesFigure = true },
 				{ BaseID = "UnitBlock.RF.NobleFlank", RatioMax = 0.25, HardMax = 3, ExclusionChance = 0.4 }
 			]
 		}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/noble_parties.nut
@@ -9,15 +9,14 @@ local parties = [
 		UpgradeChance = 0.50,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.NobleFrontline", RatioMin = 0.30, RatioMax = 1.00, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NobleBackline", RatioMax = 0.40, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NobleRanged", RatioMax = 0.30, DeterminesFigure = true,
+				{ BaseID = "UnitBlock.RF.NobleFrontline", RatioMin = 0.30, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.NobleBackline", RatioMax = 0.40,
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.75; }
 				},
-				{ BaseID = "UnitBlock.RF.NobleElite",  RatioMax = 0.20, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NobleSupport", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, PartySizeMin = 9, ExclusionChance = 0.05 },
-				{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMax = 0.2, HardMax = 2, DeterminesFigure = true, PartySizeMin = 8, ExclusionChance = 0.3 },
-				{ BaseID = "UnitBlock.RF.NobleLeader", HardMax = 2, PartySizeMin = 10, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.NobleElite",  RatioMax = 0.20 },
+				{ BaseID = "UnitBlock.RF.NobleSupport", RatioMax = 0.2, HardMax = 2,  PartySizeMin = 9, ExclusionChance = 0.05 },
+				{ BaseID = "UnitBlock.RF.NobleOfficer", RatioMax = 0.2, HardMax = 2,  PartySizeMin = 8, ExclusionChance = 0.3 },
+				{ BaseID = "UnitBlock.RF.NobleLeader", HardMax = 2, PartySizeMin = 10 },
 				{ BaseID = "UnitBlock.RF.NobleFlank", RatioMax = 0.25, HardMax = 3, ExclusionChance = 0.4 }
 			]
 		}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/nomad_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/nomad_parties.nut
@@ -8,8 +8,8 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.2, RatioMax = 0.50, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.50, RatioMax = 0.80 },
+				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.2, RatioMax = 0.50 }
 			]
 		}
 
@@ -40,10 +40,9 @@ local parties = [
 		IdealSizeLocationMult = 1.2,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
-				{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true,
+				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35 },
+				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10,  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.2; } }
 			]
 		}
@@ -75,10 +74,9 @@ local parties = [
 		IdealSizeLocationMult = 1.2,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },	// Vanilla: spawn at 7+
-				{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true,
+				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35 },
+				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10,	// Vanilla: spawn at 7+
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.2; } }
 			]
 		}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/nomad_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/nomad_parties.nut
@@ -6,10 +6,12 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.2, RatioMax = 0.50, DeterminesFigure = true }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.2, RatioMax = 0.50, DeterminesFigure = true }
+			]
+		}
 
 		function generateIdealSize()
 		{
@@ -36,13 +38,15 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		IdealSizeLocationMult = 1.2,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
-			{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true,
-			function getSpawnWeight() { return base.getSpawnWeight() * 0.2; } }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
+				{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true,
+					function getSpawnWeight() { return base.getSpawnWeight() * 0.2; } }
+			]
+		}
 
 		function generateIdealSize()
 		{
@@ -69,13 +73,15 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		IdealSizeLocationMult = 1.2,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },	// Vanilla: spawn at 7+
-			{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true,
-			function getSpawnWeight() { return base.getSpawnWeight() * 0.2; } }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },	// Vanilla: spawn at 7+
+				{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true,
+					function getSpawnWeight() { return base.getSpawnWeight() * 0.2; } }
+			]
+		}
 
 		function generateIdealSize()
 		{

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/nomad_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/nomad_parties.nut
@@ -13,7 +13,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 			if (startingResources >= 216)
 			{
 				return 12;
@@ -46,7 +46,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 			if (startingResources >= 216)
 			{
 				return 12;
@@ -79,7 +79,7 @@ local parties = [
 
 		function generateIdealSize()
 		{
-			local startingResources = this.getSpawnProcess().getStartingResources();
+			local startingResources = this.getTopParty().getStartingResources();
 			if (startingResources >= 216)
 			{
 				return 12;

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/nomad_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/nomad_parties.nut
@@ -42,7 +42,8 @@ local parties = [
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35 },
-				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10,  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
+				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10 },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
+				{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30,
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.2; } }
 			]
 		}
@@ -76,7 +77,8 @@ local parties = [
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.NomadFrontline", RatioMin = 0.25, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.NomadRanged", RatioMin = 0.00, RatioMax = 0.35 },
-				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10,	// Vanilla: spawn at 7+
+				{ BaseID = "UnitBlock.RF.NomadLeader", RatioMin = 0.00, RatioMax = 0.10 },	// Vanilla: spawn at 7+
+				{ BaseID = "UnitBlock.RF.NomadElite", RatioMin = 0.00, RatioMax = 0.30,
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.2; } }
 			]
 		}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/orc_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/orc_parties.nut
@@ -8,8 +8,8 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.55, RatioMax = 1.00, DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.OrcBerserker", DeterminesFigure = true, StartingResourceMin = 75, ExclusionChance = 0.45,
+				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.55, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.OrcBerserker",  StartingResourceMin = 75, ExclusionChance = 0.45,
 					function getSpawnWeight() {	return base.getSpawnWeight() * (this.getParty().getStartingResources() < 150 ? 0.75 : 15); }
 				}
 			]
@@ -24,7 +24,7 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.00, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150,
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.2; }
 				}
@@ -40,7 +40,7 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true,
+				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.15, RatioMax = 1.00,
 					function getSpawnWeight() {	// Lategame Parties will have fewer Young in them
 						local mult = 1.0;
 						local res = this.getParty().getStartingResources();
@@ -50,15 +50,15 @@ local parties = [
 						return base.getSpawnWeight() * mult;
 					}
 				},
-				{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45, DeterminesFigure = true, StartingResourceMin = 175,
+				{ BaseID = "UnitBlock.RF.OrcBerserker", RatioMin = 0.00, RatioMax = 0.45,  StartingResourceMin = 175,
 					function getExclusionChance() {return this.getParty().getStartingResources() < 300 ? 0.7 : 0.5; },
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.5 }
 				},
-				{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true, StartingResourceMin = 200,
+				{ BaseID = "UnitBlock.RF.OrcWarrior", RatioMin = 0.00, RatioMax = 0.80,  StartingResourceMin = 200,
 					function getExclusionChance() {return this.getParty().getStartingResources() < 300 ? 0.6 : 0.3; },
 					function getSpawnWeight() { return base.getSpawnWeight() *  2.0 }
 				},
-				{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.00, RatioMax = 0.08, HardMax = 1, DeterminesFigure = true, StartingResourceMin = 400,
+				{ BaseID = "UnitBlock.RF.OrcBoss", RatioMin = 0.00, RatioMax = 0.08, HardMax = 1,  StartingResourceMin = 400,
 					function getSpawnWeight() { return base.getSpawnWeight() * (this.getParty().getStartingResources() <= 450 ? 0.1 : 1.25); }	// Vanilla never spawns more than one Boss here
 				}
 			]
@@ -73,7 +73,7 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true,
+				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.15, RatioMax = 1.00,
 					function getSpawnWeight() { // Lategame Parties will have fewer Young in them
 						local mult = 1.0;
 						local res = this.getParty().getStartingResources();
@@ -105,7 +105,7 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true,
+				{ BaseID = "UnitBlock.RF.OrcYoung", RatioMin = 0.15, RatioMax = 1.00,
 					function getSpawnWeight() { // Lategame Parties will have fewer Young in them
 						local mult = 1.0;
 						local res = this.getParty().getStartingResources();
@@ -148,8 +148,8 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.OrcYoung", DeterminesFigure = true },
-				{ BaseID = "UnitBlock.RF.OrcBerserker", DeterminesFigure = true,
+				{ BaseID = "UnitBlock.RF.OrcYoung" },
+				{ BaseID = "UnitBlock.RF.OrcBerserker",
 					function getSpawnWeight() { return base.getSpawnWeight() * 0.5; }
 				}
 			]

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
@@ -8,16 +8,16 @@ local parties = [
 		VisionMult = 1.0,
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
-			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
+			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.12, PartySizeMin = 18},
+			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, PartySizeMin = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
 			{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.15, RatioMax = 1.00},
 			{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.09, RatioMax = 0.35},
-			{ BaseID = "UnitBlock.RF.SkeletonElite", 	RatioMin = 0.00, RatioMax = 0.11, ReqPartySize = 18},
-			{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17},
-			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, ReqPartySize = 18},
-			{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.0, ReqPartySize = 10 },
-			{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.0, ReqPartySize = 15 },
-			{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.0, ReqPartySize = 18 }
+			{ BaseID = "UnitBlock.RF.SkeletonElite", 	RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
+			{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, PartySizeMin = 17},
+			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
+			{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.0, PartySizeMin = 10 },
+			{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.0, PartySizeMin = 15 },
+			{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.0, PartySizeMin = 18 }
 		]
 	}
 ]

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
@@ -13,7 +13,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, PartySizeMin = 20 },	// Vanilla does not spawn T3 Ghouls. We allow it here
 				{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.15, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.09, RatioMax = 0.35 },
-				{ BaseID = "UnitBlock.RF.SkeletonElite", 	RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18 },
+				{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18 },
 				{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12,  PartySizeMin = 17 },
 				{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18 },
 				{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.0, PartySizeMin = 10 },

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
@@ -14,7 +14,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.15, RatioMax = 1.00},
 				{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.09, RatioMax = 0.35},
 				{ BaseID = "UnitBlock.RF.SkeletonElite", 	RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
-				{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, PartySizeMin = 17},
+				{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12,  PartySizeMin = 17},
 				{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
 				{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.0, PartySizeMin = 10 },
 				{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.0, PartySizeMin = 15 },

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
@@ -6,19 +6,21 @@ local parties = [
 		MovementSpeedMult = 0.9,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.12, PartySizeMin = 18},
-			{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, PartySizeMin = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
-			{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.15, RatioMax = 1.00},
-			{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.09, RatioMax = 0.35},
-			{ BaseID = "UnitBlock.RF.SkeletonElite", 	RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
-			{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, PartySizeMin = 17},
-			{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
-			{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.0, PartySizeMin = 10 },
-			{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.0, PartySizeMin = 15 },
-			{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.0, PartySizeMin = 18 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00},
+				{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.12, PartySizeMin = 18},
+				{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, PartySizeMin = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
+				{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.15, RatioMax = 1.00},
+				{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.09, RatioMax = 0.35},
+				{ BaseID = "UnitBlock.RF.SkeletonElite", 	RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
+				{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, PartySizeMin = 17},
+				{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
+				{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.0, PartySizeMin = 10 },
+				{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.0, PartySizeMin = 15 },
+				{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.0, PartySizeMin = 18 }
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/scourge_parties.nut
@@ -8,14 +8,14 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00},
-				{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.12, PartySizeMin = 18},
-				{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, PartySizeMin = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
-				{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.15, RatioMax = 1.00},
-				{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.09, RatioMax = 0.35},
-				{ BaseID = "UnitBlock.RF.SkeletonElite", 	RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
-				{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12,  PartySizeMin = 17},
-				{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18},
+				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.12, PartySizeMin = 18 },
+				{ BaseID = "UnitBlock.RF.Ghoul", RatioMin = 0.00, RatioMax = 0.20, PartySizeMin = 20 },	// Vanilla does not spawn T3 Ghouls. We allow it here
+				{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.15, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.09, RatioMax = 0.35 },
+				{ BaseID = "UnitBlock.RF.SkeletonElite", 	RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18 },
+				{ BaseID = "UnitBlock.RF.ScourgeSupport", RatioMin = 0.00, RatioMax = 0.12,  PartySizeMin = 17 },
+				{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.11, PartySizeMin = 18 },
 				{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.0, PartySizeMin = 10 },
 				{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.0, PartySizeMin = 15 },
 				{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.0, PartySizeMin = 18 }

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/southern_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/southern_parties.nut
@@ -9,11 +9,11 @@ local parties = [
 		VisionMult = 1.0,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.50, RatioMax = 0.70, DeterminesFigure = true },			// Vanilla: doesn't care about size
+				{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.50, RatioMax = 0.70 },			// Vanilla: doesn't care about size
 				{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
 				{ BaseID = "UnitBlock.RF.SouthernRanged", RatioMin = 0.00, RatioMax = 0.35 },		// Vanilla: doesn't care about size
 				{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 0.2, PartySizeMin = 7 },		// Vanilla: Start spawning at 8+
-				{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5, DeterminesFigure = true },		// Vanilla: Start spawning at 15+
+				{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5 },		// Vanilla: Start spawning at 15+
 				{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.13, PartySizeMin = 14 }
 			]
 		}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/southern_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/southern_parties.nut
@@ -7,14 +7,16 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.50, RatioMax = 0.70, DeterminesFigure = true },			// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.SouthernRanged", RatioMin = 0.00, RatioMax = 0.35 },		// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 0.2, PartySizeMin = 7 },		// Vanilla: Start spawning at 8+
-			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5, DeterminesFigure = true },		// Vanilla: Start spawning at 15+
-			{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.13, PartySizeMin = 14 }		// Vanilla: Start spawning at 19+
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.50, RatioMax = 0.70, DeterminesFigure = true },			// Vanilla: doesn't care about size
+				{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
+				{ BaseID = "UnitBlock.RF.SouthernRanged", RatioMin = 0.00, RatioMax = 0.35 },		// Vanilla: doesn't care about size
+				{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 0.2, PartySizeMin = 7 },		// Vanilla: Start spawning at 8+
+				{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5, DeterminesFigure = true },		// Vanilla: Start spawning at 15+
+				{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.13, PartySizeMin = 14 }
+			]
+		}
 	},
 	{
 		ID = "CaravanSouthern",
@@ -23,16 +25,20 @@ local parties = [
 		MovementSpeedMult = 0.5,
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.SouthernDonkey" }
-		],
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = false },
-			{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 0.25, DeterminesFigure = false },
-			{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40, DeterminesFigure = false },
-			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.08, PartySizeMin = 14, DeterminesFigure = false },
-			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.01, RatioMax = 0.12, PartySizeMin = 14 }	// Vanilla: Second starts spawning at 14, then 16+
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.SouthernDonkey" }
+			]
+		},
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = false },
+				{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 0.25, DeterminesFigure = false },
+				{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40, DeterminesFigure = false },
+				{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.08, PartySizeMin = 14, DeterminesFigure = false },
+				{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.01, RatioMax = 0.12, PartySizeMin = 14 }
+			]
+		}
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
 	{
@@ -42,14 +48,18 @@ local parties = [
 		MovementSpeedMult = 0.5,
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.SouthernDonkey" }
-		],
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = false },
-			// { BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 0.25 },	 // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
-			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.35, RatioMax = 0.50, PartySizeMin = 3 }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.SouthernDonkey" }
+			]
+		},
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = false },
+				// { BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 0.25 },	 // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
+				{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.35, RatioMax = 0.50, PartySizeMin = 3 }
+			]
+		}
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
 	{
@@ -59,9 +69,11 @@ local parties = [
 		MovementSpeedMult = 0.66,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "NorthernSlaves",
@@ -70,9 +82,11 @@ local parties = [
 		MovementSpeedMult = 0.66,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "Assassins",
@@ -81,9 +95,11 @@ local parties = [
 		MovementSpeedMult = 1.00,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 1.00 }
+			]
+		}
 	},
 
 	// SubParties
@@ -91,9 +107,11 @@ local parties = [
 		ID = "MortarEngineers"
 		HardMin = 2,
 		HardMax = 2,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Engineer"}
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Engineer"}
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/southern_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/southern_parties.nut
@@ -11,9 +11,9 @@ local parties = [
 			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.50, RatioMax = 0.70, DeterminesFigure = true },			// Vanilla: doesn't care about size
 			{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
 			{ BaseID = "UnitBlock.RF.SouthernRanged", RatioMin = 0.00, RatioMax = 0.35 },		// Vanilla: doesn't care about size
-			{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 0.2, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
-			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5, DeterminesFigure = true },		// Vanilla: Start spawning at 15+
-			{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 14 }		// Vanilla: Start spawning at 19+
+			{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 0.2, PartySizeMin = 7 },		// Vanilla: Start spawning at 8+
+			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5, DeterminesFigure = true },		// Vanilla: Start spawning at 15+
+			{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.13, PartySizeMin = 14 }		// Vanilla: Start spawning at 19+
 		]
 	},
 	{
@@ -30,8 +30,8 @@ local parties = [
 			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = false },
 			{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 0.25, DeterminesFigure = false },
 			{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40, DeterminesFigure = false },
-			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14, DeterminesFigure = false },
-			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }	// Vanilla: Second starts spawning at 14, then 16+
+			{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.08, PartySizeMin = 14, DeterminesFigure = false },
+			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.01, RatioMax = 0.12, PartySizeMin = 14 }	// Vanilla: Second starts spawning at 14, then 16+
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
@@ -48,7 +48,7 @@ local parties = [
 		UnitBlockDefs = [
 			{ BaseID = "UnitBlock.RF.SouthernFrontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = false },
 			// { BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 0.25 },	 // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
-			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
+			{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.35, RatioMax = 0.50, PartySizeMin = 3 }
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/southern_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/southern_parties.nut
@@ -14,7 +14,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.SouthernRanged", RatioMin = 0.00, RatioMax = 0.35 },		// Vanilla: doesn't care about size
 				{ BaseID = "UnitBlock.RF.Assassin", RatioMin = 0.00, RatioMax = 0.2, PartySizeMin = 7 },		// Vanilla: Start spawning at 8+
 				{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.15, PartySizeMin = 5 },		// Vanilla: Start spawning at 15+
-				{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.13, PartySizeMin = 14 }
+				{ BaseID = "UnitBlock.RF.Siege", RatioMin = 0.00, RatioMax = 0.13, PartySizeMin = 14 }	// Vanilla: Start spawning at 19+
 			]
 		}
 	},
@@ -36,7 +36,7 @@ local parties = [
 				{ BaseID = "UnitBlock.RF.Slave", RatioMin = 0.00, RatioMax = 0.25, DeterminesFigure = false },
 				{ BaseID = "UnitBlock.RF.SouthernBackline", RatioMin = 0.10, RatioMax = 0.40, DeterminesFigure = false },
 				{ BaseID = "UnitBlock.RF.Officer", RatioMin = 0.00, RatioMax = 0.08, PartySizeMin = 14, DeterminesFigure = false },
-				{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.01, RatioMax = 0.12, PartySizeMin = 14 }
+				{ BaseID = "UnitBlock.RF.SouthernCaravanDonkey", RatioMin = 0.01, RatioMax = 0.12, PartySizeMin = 14 }	// Vanilla: Second starts spawning at 14, then 16+
 			]
 		}
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
@@ -109,7 +109,7 @@ local parties = [
 		HardMax = 2,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.Engineer"}
+				{ BaseID = "UnitBlock.RF.Engineer" }
 			]
 		}
 	}

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/undead_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/undead_parties.nut
@@ -36,10 +36,10 @@ local parties = [
 					{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.00, RatioMax = 0.40 },
 					{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.00, RatioMax = 0.30, function getSpawnWeight(){ return base.getSpawnWeight() * 0.3 } },
 					{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.75, StartingResourceMin = 220, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMin = 0.00, RatioMax = 0.20, HardMax = 3, StartingResourceMin = 180, ReqPartySize = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMin = 0.00, RatioMax = 0.15, HardMax = 2, StartingResourceMin = 250, ReqPartySize = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 }  },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMin = 0.00, RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, ReqPartySize = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } },
-					{ BaseID = "UnitBlock.RF.SkeletonSupport", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
+					{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMin = 0.00, RatioMax = 0.20, HardMax = 3, StartingResourceMin = 180, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
+					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMin = 0.00, RatioMax = 0.15, HardMax = 2, StartingResourceMin = 250, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 }  },
+					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMin = 0.00, RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } },
+					{ BaseID = "UnitBlock.RF.SkeletonSupport", RatioMin = 0.00, RatioMax = 0.10, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
 				]
 			}],
 			[1, {
@@ -160,9 +160,9 @@ local parties = [
 				UnitBlockDefs = [
 					{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.01, RatioMax = 1.00 },
 					{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.40, HardMin = 3, function getSpawnWeight(){ return base.getSpawnWeight() * 0.5 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.1 } },
-					{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.20, StartingResourceMin = 180, HardMax = 3, ReqPartySize = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, StartingResourceMin = 250, HardMax = 2, ReqPartySize = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.15 } },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, StartingResourceMin = 300, HardMax = 1, ReqPartySize = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
+					{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.20, StartingResourceMin = 180, HardMax = 3, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
+					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, StartingResourceMin = 250, HardMax = 2, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.15 } },
+					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, StartingResourceMin = 300, HardMax = 1, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
 				]
 			}],
 			[1, {
@@ -183,8 +183,8 @@ local parties = [
 				UnitBlockDefs = [
 					{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 0.70 },
 					{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.50, HardMin = 3, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 250, ReqPartySize = 4, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, ReqPartySize = 5, function getSpawnWeight(){ return base.getSpawnWeight() * 0.15 } }
+					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 250, PartySizeMin = 4, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
+					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, PartySizeMin = 5, function getSpawnWeight(){ return base.getSpawnWeight() * 0.15 } }
 				]
 			}],
 			[1, {

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/undead_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/undead_parties.nut
@@ -31,16 +31,18 @@ local parties = [
 					}
 				}
 
-				UnitBlockDefs = [
-					{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.40, RatioMax = 1.0 },
-					{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.00, RatioMax = 0.40 },
-					{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.00, RatioMax = 0.30, function getSpawnWeight(){ return base.getSpawnWeight() * 0.3 } },
-					{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.75, StartingResourceMin = 220, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMin = 0.00, RatioMax = 0.20, HardMax = 3, StartingResourceMin = 180, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMin = 0.00, RatioMax = 0.15, HardMax = 2, StartingResourceMin = 250, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 }  },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMin = 0.00, RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } },
-					{ BaseID = "UnitBlock.RF.SkeletonSupport", RatioMin = 0.00, RatioMax = 0.10, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
-				]
+				DynamicDefs = {
+					UnitBlocks = [
+						{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.40, RatioMax = 1.0 },
+						{ BaseID = "UnitBlock.RF.SkeletonBackline", RatioMin = 0.00, RatioMax = 0.40 },
+						{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.00, RatioMax = 0.30, function getSpawnWeight(){ return base.getSpawnWeight() * 0.3 } },
+						{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.00, RatioMax = 0.30, ExclusionChance = 0.75, StartingResourceMin = 220, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.2 } },
+						{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMin = 0.00, RatioMax = 0.20, HardMax = 3, StartingResourceMin = 180, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
+						{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMin = 0.00, RatioMax = 0.15, HardMax = 2, StartingResourceMin = 250, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 }  },
+						{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMin = 0.00, RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } },
+						{ BaseID = "UnitBlock.RF.SkeletonSupport", RatioMin = 0.00, RatioMax = 0.10, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
+					]
+				}
 			}],
 			[1, {
 				ID = "UndeadArmy_1",
@@ -56,12 +58,14 @@ local parties = [
 					return 8;
 				}
 
-				UnitBlockDefs = [
-					{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 1.00 },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, StartingResourceMin = 250, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, StartingResourceMin = 300, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } },
-					{ BaseID = "UnitBlock.RF.SkeletonSupport", RatioMin = 0.00, RatioMax = 0.20, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
-				]
+				DynamicDefs = {
+					UnitBlocks = [
+						{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 1.00 },
+						{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, StartingResourceMin = 250, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
+						{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, StartingResourceMin = 300, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } },
+						{ BaseID = "UnitBlock.RF.SkeletonSupport", RatioMin = 0.00, RatioMax = 0.20, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
+					]
+				}
 			}],
 			[1, {
 				ID = "UndeadArmy_2",
@@ -77,13 +81,15 @@ local parties = [
 					return 8;
 				}
 
-				UnitBlockDefs = [
-					{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 0.80 },
-					{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.40, StartingResourceMin = 220 },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 250, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } },
-					{ BaseID = "UnitBlock.RF.SkeletonSupport", RatioMin = 0.00, RatioMax = 0.20, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
-				]
+				DynamicDefs = {
+					UnitBlocks = [
+						{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 0.80 },
+						{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.40, StartingResourceMin = 220 },
+						{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 250, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
+						{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } },
+						{ BaseID = "UnitBlock.RF.SkeletonSupport", RatioMin = 0.00, RatioMax = 0.20, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
+					]
+				}
 			}],
 			[1, {
 				ID = "UndeadArmy_3",
@@ -99,11 +105,13 @@ local parties = [
 					return 8;
 				}
 
-				UnitBlockDefs = [
-					{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 1.00 },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 180, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
-				]
+				DynamicDefs = {
+					UnitBlocks = [
+						{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 1.00 },
+						{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 180, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
+						{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
+					]
+				}
 			}]
 		])
 	},
@@ -121,9 +129,11 @@ local parties = [
 			return 4;
 		}
 
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.VampireOnly", RatioMin = 0.01, RatioMax = 1.00 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.VampireOnly", RatioMin = 0.01, RatioMax = 1.00 }
+			]
+		}
 	},
 	{
 		ID = "VampiresAndSkeletons",
@@ -157,13 +167,15 @@ local parties = [
 					}
 				}
 
-				UnitBlockDefs = [
-					{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.01, RatioMax = 1.00 },
-					{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.40, HardMin = 3, function getSpawnWeight(){ return base.getSpawnWeight() * 0.5 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.1 } },
-					{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.20, StartingResourceMin = 180, HardMax = 3, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, StartingResourceMin = 250, HardMax = 2, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.15 } },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, StartingResourceMin = 300, HardMax = 1, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
-				]
+				DynamicDefs = {
+					UnitBlocks = [
+						{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.01, RatioMax = 1.00 },
+						{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.40, HardMin = 3, function getSpawnWeight(){ return base.getSpawnWeight() * 0.5 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.1 } },
+						{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.20, StartingResourceMin = 180, HardMax = 3, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
+						{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, StartingResourceMin = 250, HardMax = 2, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.15 } },
+						{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, StartingResourceMin = 300, HardMax = 1, PartySizeMin = 6, function getSpawnWeight(){ return base.getSpawnWeight() * 0.1 } }
+					]
+				}
 			}],
 			[1, {
 				ID = "VampiresAndSkeletons_1",
@@ -180,12 +192,14 @@ local parties = [
 					return 9;
 				}
 
-				UnitBlockDefs = [
-					{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 0.70 },
-					{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.50, HardMin = 3, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 250, PartySizeMin = 4, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, PartySizeMin = 5, function getSpawnWeight(){ return base.getSpawnWeight() * 0.15 } }
-				]
+				DynamicDefs = {
+					UnitBlocks = [
+						{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 0.70 },
+						{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.50, HardMin = 3, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.2 } },
+						{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 250, PartySizeMin = 4, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } },
+						{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, PartySizeMin = 5, function getSpawnWeight(){ return base.getSpawnWeight() * 0.15 } }
+					]
+				}
 			}],
 			[1, {
 				ID = "VampiresAndSkeletons_2",
@@ -212,53 +226,65 @@ local parties = [
 					}
 				}
 
-				UnitBlockDefs = [
-					{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.01, RatioMax = 0.70, function getUpgradeWeight(){ return base.getUpgradeWeight() * 1.5 } },
-					{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 0.70, function getSpawnWeight(){ return base.getSpawnWeight() * 0.75 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.2 } },
-					{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.70, HardMin = 3, function getSpawnWeight(){ return base.getSpawnWeight() * 0.75 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.1 } },
-					{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.20, HardMax = 3, StartingResourceMin = 180, function getSpawnWeight(){ return base.getSpawnWeight() * 0.3 } },
-					{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 250, function getSpawnWeight(){ return base.getSpawnWeight() * 0.3 } },
-					{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } }
-				]
+				DynamicDefs = {
+					UnitBlocks = [
+						{ BaseID = "UnitBlock.RF.SkeletonFrontline", RatioMin = 0.01, RatioMax = 0.70, function getUpgradeWeight(){ return base.getUpgradeWeight() * 1.5 } },
+						{ BaseID = "UnitBlock.RF.SkeletonElite", RatioMin = 0.01, RatioMax = 0.70, function getSpawnWeight(){ return base.getSpawnWeight() * 0.75 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.2 } },
+						{ BaseID = "UnitBlock.RF.Vampire", RatioMin = 0.01, RatioMax = 0.70, HardMin = 3, function getSpawnWeight(){ return base.getSpawnWeight() * 0.75 }, function getUpgradeWeight(){ return base.getUpgradeWeight() * 0.1 } },
+						{ BaseID = "UnitBlock.RF.SkeletonDecanus", RatioMax = 0.20, HardMax = 3, StartingResourceMin = 180, function getSpawnWeight(){ return base.getSpawnWeight() * 0.3 } },
+						{ BaseID = "UnitBlock.RF.SkeletonCenturion", RatioMax = 0.10, HardMax = 2, StartingResourceMin = 250, function getSpawnWeight(){ return base.getSpawnWeight() * 0.3 } },
+						{ BaseID = "UnitBlock.RF.SkeletonLegatus", RatioMax = 0.10, HardMax = 1, StartingResourceMin = 300, function getSpawnWeight(){ return base.getSpawnWeight() * 0.2 } }
+					]
+				}
 			}]
 		])
 	},
 	{
 		ID = "SubPartyPrae",
 		HardMin = 1,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.RF_SkeletonHeavyLesserBodyguard" }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_SkeletonHeavyLesserBodyguard" }
+			]
+		}
 	},
 	{
 		ID = "SubPartyPrae2",
 		HardMin = 2,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.RF_SkeletonHeavyLesserBodyguard" },
-			{ BaseID = "Unit.RF.RF_SkeletonHeavyLesserBodyguard" }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_SkeletonHeavyLesserBodyguard" },
+				{ BaseID = "Unit.RF.RF_SkeletonHeavyLesserBodyguard" }
+			]
+		}
 	},
 	{
 		ID = "SubPartyPraeHonor",
 		HardMin = 1,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.RF_SkeletonHeavyLesserBodyguard" },
-			{ BaseID = "Unit.RF.SkeletonHeavyBodyguard" }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_SkeletonHeavyLesserBodyguard" },
+				{ BaseID = "Unit.RF.SkeletonHeavyBodyguard" }
+			]
+		}
 	},
 	{
 		ID = "SubPartyHonor2",
 		HardMin = 2,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.SkeletonHeavyBodyguard" },
-			{ BaseID = "Unit.RF.SkeletonHeavyBodyguard" }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.SkeletonHeavyBodyguard" },
+				{ BaseID = "Unit.RF.SkeletonHeavyBodyguard" }
+			]
+		}
 	},
 	// {
 	// 	ID = "SubPartySkeletonHeavy",
-	// 	UnitBlockDefs = [
-	// 		{ ID = "UnitBlock.RF_SkeletonHeavyBodyguard", RatioMin = 0.01, RatioMax = 1.00}
-	// 	]
+	// 	DynamicDefs = {
+	// 		UnitBlocks = [
+	// 			{ ID = "UnitBlock.RF_SkeletonHeavyBodyguard", RatioMin = 0.01, RatioMax = 1.00 }
+	// 		]
+	// 	}
 	// }
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/undead_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/undead_parties.nut
@@ -12,7 +12,7 @@ local parties = [
 
 				function generateIdealSize()
 				{
-					local startingResources = this.getSpawnProcess().getStartingResources();
+					local startingResources = this.getTopParty().getStartingResources();
 					if (startingResources >= 500)
 					{
 						return 12;
@@ -138,7 +138,7 @@ local parties = [
 
 				function generateIdealSize()
 				{
-					local startingResources = this.getSpawnProcess().getStartingResources();
+					local startingResources = this.getTopParty().getStartingResources();
 					if (startingResources >= 400)
 					{
 						return 11;
@@ -197,7 +197,7 @@ local parties = [
 
 				function generateIdealSize()
 				{
-					local startingResources = this.getSpawnProcess().getStartingResources();
+					local startingResources = this.getTopParty().getStartingResources();
 					if (startingResources >= 400)
 					{
 						return 10;

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/zombie_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/zombie_parties.nut
@@ -6,9 +6,11 @@ local parties = [
 		MovementSpeedMult = 0.8,
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true }
+			]
+		}
 	},
 	{
 		ID = "Ghosts",
@@ -17,9 +19,11 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 0.75,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.Ghost" }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.Ghost" }
+			]
+		}
 	},
 	{
 		ID = "ZombiesAndGhouls",
@@ -28,10 +32,12 @@ local parties = [
 		MovementSpeedMult = 0.8,
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.GhoulLowOnly", RatioMin = 0.10, RatioMax = 0.30 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.GhoulLowOnly", RatioMin = 0.10, RatioMax = 0.30 }
+			]
+		}
 	},
 	{
 		ID = "ZombiesAndGhosts",
@@ -40,10 +46,12 @@ local parties = [
 		MovementSpeedMult = 0.8,
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.12, RatioMax = 0.35 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.12, RatioMax = 0.35 }
+			]
+		}
 	},
 	{
 		ID = "Necromancer",
@@ -52,11 +60,13 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.50, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.20 },
-			{ BaseID = "UnitBlock.RF.NecromancerWithBodyguards", RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.50, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.20 },
+				{ BaseID = "UnitBlock.RF.NecromancerWithBodyguards", RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true }
+			]
+		}
 	},
 	{
 		ID = "NecromancerSouthern",
@@ -65,11 +75,13 @@ local parties = [
 		MovementSpeedMult = 1.0,
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieSouthern", RatioMin = 0.65, RatioMax = 1.00 },
-			{ BaseID = "UnitBlock.RF.NecromancerWithNomads", RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true },
-			{ BaseID = "UnitBlock.RF.ZombieElite", 	RatioMin = 0.00, RatioMax = 0.12 }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.ZombieSouthern", RatioMin = 0.65, RatioMax = 1.00 },
+				{ BaseID = "UnitBlock.RF.NecromancerWithNomads", RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.ZombieElite", 	RatioMin = 0.00, RatioMax = 0.12 }
+			]
+		}
 	},
 	{	// Only un-armored zombies
 		ID = "ZombiesLight",
@@ -78,47 +90,59 @@ local parties = [
 		MovementSpeedMult = 0.8,
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieLight" }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.ZombieLight" }
+			]
+		}
 	},
 
 	// SubParties
 	{
 		ID = "SubPartyYeoman",
 		HardMin = 1,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.ZombieYeomanBodyguard" }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.ZombieYeomanBodyguard" }
+			]
+		}
 	},
 	{
 		ID = "SubPartyKnight",
 		HardMin = 1,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.ZombieKnightBodyguard" }
-		]
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.ZombieKnightBodyguard" }
+			]
+		}
 	},
 	{
 		ID = "SubPartyYeomanKnight",
 		HardMin = 2,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.ZombieYeomanBodyguard" },
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.ZombieYeomanBodyguard" },
 			{ BaseID = "Unit.RF.ZombieKnightBodyguard" }
-		]
+			]
+		}
 	},
 	{
 		ID = "SubPartyKnightKnight",
 		HardMin = 2,
-		StaticUnitDefs = [
-			{ BaseID = "Unit.RF.ZombieKnightBodyguard" },
+		StaticDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.ZombieKnightBodyguard" },
 			{ BaseID = "Unit.RF.ZombieKnightBodyguard" }
-		]
+			]
+		}
 	},
 	{	// The amount is set from outside
 		ID = "SubPartyNomad",
-		UnitBlockDefs = [
-			{ BaseID = "UnitBlock.RF.ZombieNomadBodyguard" }
-		]
+		DynamicDefs = {
+			UnitBlocks = [
+				{ BaseID = "UnitBlock.RF.ZombieNomadBodyguard" }
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/zombie_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/zombie_parties.nut
@@ -122,7 +122,7 @@ local parties = [
 		StaticDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.ZombieYeomanBodyguard" },
-			{ BaseID = "Unit.RF.ZombieKnightBodyguard" }
+				{ BaseID = "Unit.RF.ZombieKnightBodyguard" }
 			]
 		}
 	},
@@ -132,7 +132,7 @@ local parties = [
 		StaticDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.ZombieKnightBodyguard" },
-			{ BaseID = "Unit.RF.ZombieKnightBodyguard" }
+				{ BaseID = "Unit.RF.ZombieKnightBodyguard" }
 			]
 		}
 	},

--- a/mod_reforged_AfterHooks/dynamic_spawns/parties/zombie_parties.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/parties/zombie_parties.nut
@@ -8,7 +8,7 @@ local parties = [
 		VisionMult = 0.8,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00 }
 			]
 		}
 	},
@@ -34,7 +34,7 @@ local parties = [
 		VisionMult = 0.8,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.GhoulLowOnly", RatioMin = 0.10, RatioMax = 0.30 }
 			]
 		}
@@ -48,7 +48,7 @@ local parties = [
 		VisionMult = 0.8,
 		DynamicDefs = {
 			UnitBlocks = [
-				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.00, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.12, RatioMax = 0.35 }
 			]
 		}
@@ -64,7 +64,7 @@ local parties = [
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.ZombieFrontline", RatioMin = 0.50, RatioMax = 1.00 },
 				{ BaseID = "UnitBlock.RF.Ghost", RatioMin = 0.00, RatioMax = 0.20 },
-				{ BaseID = "UnitBlock.RF.NecromancerWithBodyguards", RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true }
+				{ BaseID = "UnitBlock.RF.NecromancerWithBodyguards", RatioMin = 0.04, RatioMax = 0.09 }
 			]
 		}
 	},
@@ -78,7 +78,7 @@ local parties = [
 		DynamicDefs = {
 			UnitBlocks = [
 				{ BaseID = "UnitBlock.RF.ZombieSouthern", RatioMin = 0.65, RatioMax = 1.00 },
-				{ BaseID = "UnitBlock.RF.NecromancerWithNomads", RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true },
+				{ BaseID = "UnitBlock.RF.NecromancerWithNomads", RatioMin = 0.04, RatioMax = 0.09 },
 				{ BaseID = "UnitBlock.RF.ZombieElite", 	RatioMin = 0.00, RatioMax = 0.12 }
 			]
 		}

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/bandit_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/bandit_blocks.nut
@@ -1,7 +1,6 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.BanditBalanced",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.RF_BanditScoundrel" },
@@ -13,7 +12,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.BanditFast",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.RF_BanditRobber" }, // added for balanced spawns and upgrading compared to Balanced, Tough and Ranged
@@ -25,7 +23,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.BanditTough",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.BanditThug" },
@@ -37,7 +34,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.BanditRanged",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.BanditMarksmanLOW" },
@@ -49,7 +45,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.BanditDog",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.Wardog" },
@@ -59,7 +54,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.BanditElite",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = ::MSU.Class.WeightedContainer([
 				[1, { BaseID = "Unit.RF.MasterArcher" }],
@@ -70,7 +64,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.BanditBoss",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.BanditLeader" },

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/bandit_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/bandit_blocks.nut
@@ -2,71 +2,87 @@ local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.BanditBalanced",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.RF_BanditScoundrel" },
-			{ BaseID = "Unit.RF.RF_BanditVandal" },
-			{ BaseID = "Unit.RF.BanditRaider" },
-			{ BaseID = "Unit.RF.RF_BanditHighwayman" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_BanditScoundrel" },
+				{ BaseID = "Unit.RF.RF_BanditVandal" },
+				{ BaseID = "Unit.RF.BanditRaider" },
+				{ BaseID = "Unit.RF.RF_BanditHighwayman" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BanditFast",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.RF_BanditRobber" }, // added for balanced spawns and upgrading compared to Balanced, Tough and Ranged
-			{ BaseID = "Unit.RF.RF_BanditRobber" },
-			{ BaseID = "Unit.RF.RF_BanditBandit" },
-			{ BaseID = "Unit.RF.RF_BanditKiller" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_BanditRobber" }, // added for balanced spawns and upgrading compared to Balanced, Tough and Ranged
+				{ BaseID = "Unit.RF.RF_BanditRobber" },
+				{ BaseID = "Unit.RF.RF_BanditBandit" },
+				{ BaseID = "Unit.RF.RF_BanditKiller" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BanditTough",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.BanditThug" },
-			{ BaseID = "Unit.RF.RF_BanditPillager" },
-			{ BaseID = "Unit.RF.RF_BanditOutlaw" },
-			{ BaseID = "Unit.RF.RF_BanditMarauder" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.BanditThug" },
+				{ BaseID = "Unit.RF.RF_BanditPillager" },
+				{ BaseID = "Unit.RF.RF_BanditOutlaw" },
+				{ BaseID = "Unit.RF.RF_BanditMarauder" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BanditRanged",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.BanditMarksmanLOW" },
-			{ BaseID = "Unit.RF.RF_BanditHunter" },
-			{ BaseID = "Unit.RF.BanditMarksman" },
-			{ BaseID = "Unit.RF.RF_BanditSharpshooter" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.BanditMarksmanLOW" },
+				{ BaseID = "Unit.RF.RF_BanditHunter" },
+				{ BaseID = "Unit.RF.BanditMarksman" },
+				{ BaseID = "Unit.RF.RF_BanditSharpshooter" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BanditDog",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.Wardog" },
-			{ BaseID = "Unit.RF.ArmoredWardog", StartingResourceMin = 125 }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.Wardog" },
+				{ BaseID = "Unit.RF.ArmoredWardog", StartingResourceMin = 125 }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BanditElite",
 		DeterminesFigure = true,
-		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.RF.MasterArcher" }],
-			[1, { BaseID = "Unit.RF.HedgeKnight" }],
-			[1, { BaseID = "Unit.RF.Swordmaster" }]
-		])
+		DynamicDefs = {
+			Units = ::MSU.Class.WeightedContainer([
+				[1, { BaseID = "Unit.RF.MasterArcher" }],
+				[1, { BaseID = "Unit.RF.HedgeKnight" }],
+				[1, { BaseID = "Unit.RF.Swordmaster" }]
+			])
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BanditBoss",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.BanditLeader" },
-			{ BaseID = "Unit.RF.RF_BanditBaron", HardMax = 1 }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.BanditLeader" },
+				{ BaseID = "Unit.RF.RF_BanditBaron", HardMax = 1 }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BanditDisguisedDirewolf",
-		UnitDefs = [{ BaseID = "Unit.RF.BanditRaiderWolf" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BanditRaiderWolf" }]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/barbarian_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/barbarian_blocks.nut
@@ -1,33 +1,46 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.BarbarianFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianThrall" }, { BaseID = "Unit.RF.BarbarianMarauder" }, { BaseID = "Unit.RF.BarbarianChampion" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BarbarianThrall" }, { BaseID = "Unit.RF.BarbarianMarauder" }, { BaseID = "Unit.RF.BarbarianChampion" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianSupport",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianDrummer" }]
-
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BarbarianDrummer" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianDog",
-		UnitDefs = [{ BaseID = "Unit.RF.Warhound" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Warhound" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianBeastmaster",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianBeastmasterU" }, { BaseID = "Unit.RF.BarbarianBeastmasterF" }, { BaseID = "Unit.RF.BarbarianBeastmasterUU" }, { BaseID = "Unit.RF.BarbarianBeastmasterFF" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BarbarianBeastmasterU" }, { BaseID = "Unit.RF.BarbarianBeastmasterF" }, { BaseID = "Unit.RF.BarbarianBeastmasterUU" }, { BaseID = "Unit.RF.BarbarianBeastmasterFF" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianHunterFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianThrall" }, { BaseID = "Unit.RF.BarbarianMarauder" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BarbarianThrall" }, { BaseID = "Unit.RF.BarbarianMarauder" }]
+		}
 	},
 
 	{
 		ID = "UnitBlock.RF.BarbarianUnhold",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianUnhold" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BarbarianUnhold" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BarbarianUnholdFrost",
-		UnitDefs = [{ BaseID = "Unit.RF.BarbarianUnholdFrost" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BarbarianUnholdFrost" }]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/beast_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/beast_blocks.nut
@@ -12,14 +12,8 @@ local unitBlocks = [
 		ID = "UnitBlock.RF.Ghoul",
 		UnitDefs = [
 			{ BaseID = "Unit.RF.GhoulLOW" },
-			{ BaseID = "Unit.RF.Ghoul", function getHardMax() {
-					return ::Math.min(base.getHardMax(), this.getSpawnProcess().getTotal() * 0.7);
-				}
-			},
-			{ BaseID = "Unit.RF.GhoulHIGH", function getHardMax() {
-					return ::Math.min(base.getHardMax(), this.getSpawnProcess().getTotal() * 0.2);
-				}
-			}
+			{ BaseID = "Unit.RF.Ghoul", RatioMax = 0.7 },
+			{ BaseID = "Unit.RF.GhoulHIGH", RatioMax = 0.2 }
 		]
 	},
 	{

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/beast_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/beast_blocks.nut
@@ -2,96 +2,136 @@ local unitBlocks = [
 	// Purebred Beasts
 	{
 		ID = "UnitBlock.RF.Direwolf",
-		UnitDefs = [{ BaseID = "Unit.RF.Direwolf" }, { BaseID = "Unit.RF.DirewolfHIGH" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Direwolf" }, { BaseID = "Unit.RF.DirewolfHIGH" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.GhoulLowOnly",
-		UnitDefs = [{ BaseID = "Unit.RF.GhoulLOW" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.GhoulLOW" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Ghoul",
-		UnitDefs = [
-			{ BaseID = "Unit.RF.GhoulLOW" },
-			{ BaseID = "Unit.RF.Ghoul", RatioMax = 0.7 },
-			{ BaseID = "Unit.RF.GhoulHIGH", RatioMax = 0.2 }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.GhoulLOW" },
+				{ BaseID = "Unit.RF.Ghoul", RatioMax = 0.7 },
+				{ BaseID = "Unit.RF.GhoulHIGH", RatioMax = 0.2 }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Lindwurm",
-		UnitDefs = [{ BaseID = "Unit.RF.Lindwurm" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Lindwurm" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Unhold",
-		UnitDefs = [{ BaseID = "Unit.RF.Unhold" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Unhold" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.UnholdFrost",
-		UnitDefs = [{ BaseID = "Unit.RF.UnholdFrost" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.UnholdFrost" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.UnholdBog",
-		UnitDefs = [{ BaseID = "Unit.RF.UnholdBog" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.UnholdBog" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Spider",
-		UnitDefs = [{ BaseID = "Unit.RF.Spider" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Spider" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Alp",
-		UnitDefs = [{ BaseID = "Unit.RF.Alp" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Alp" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Schrat",
-		UnitDefs = [{ BaseID = "Unit.RF.Schrat" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Schrat" }]
+		}
 	},
 	// Vanilla Kraken skipped at this point
 	{
 		ID = "UnitBlock.RF.Hyena",
-		UnitDefs = [{ BaseID = "Unit.RF.Hyena" }, { BaseID = "Unit.RF.HyenaHIGH" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Hyena" }, { BaseID = "Unit.RF.HyenaHIGH" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Serpent",
-		UnitDefs = [{ BaseID = "Unit.RF.Serpent" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Serpent" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SandGolem",
-		UnitDefs = [{ BaseID = "Unit.RF.SandGolem" }, { BaseID = "Unit.RF.SandGolemMEDIUM" }, { BaseID = "Unit.RF.SandGolemHIGH" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.SandGolem" }, { BaseID = "Unit.RF.SandGolemMEDIUM" }, { BaseID = "Unit.RF.SandGolemHIGH" }]
+		}
 	},
 
 // Mixed Beasts
 	{
 		ID = "UnitBlock.RF.HexeNoBodyguard",
-		UnitDefs = [{ BaseID = "Unit.RF.Hexe" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Hexe" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.HexeWithBodyguard",
 		StartingResourceMin = 300,
-		UnitDefs = [{ BaseID = "Unit.RF.Hexe" }, { BaseID = "Unit.RF.HexeOneSpider" }, { BaseID = "Unit.RF.HexeTwoSpider" }, { BaseID = "Unit.RF.HexeOneDirewolf" }, { BaseID = "Unit.RF.HexeTwoDirewolf" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Hexe" }, { BaseID = "Unit.RF.HexeOneSpider" }, { BaseID = "Unit.RF.HexeTwoSpider" }, { BaseID = "Unit.RF.HexeOneDirewolf" }, { BaseID = "Unit.RF.HexeTwoDirewolf" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.HexeNoSpider",
 		StartingResourceMin = 300,
-		UnitDefs = [{ BaseID = "Unit.RF.Hexe" }, { BaseID = "Unit.RF.HexeOneDirewolf" }, { BaseID = "Unit.RF.HexeTwoDirewolf" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Hexe" }, { BaseID = "Unit.RF.HexeOneDirewolf" }, { BaseID = "Unit.RF.HexeTwoDirewolf" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.HexeBandit",	// Spawn in HexenFights
 		StartingResourceMin = 200,
-		UnitDefs = [{ BaseID = "Unit.RF.BanditRaider" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BanditRaider" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.HexeBanditRanged",	// Spawn in HexenFights. In Vanilla they only ever spawn a single marksman alongside several raiders. Never more
 		StartingResourceMin = 200,
-		UnitDefs = [{ BaseID = "Unit.RF.BanditMarksman" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BanditMarksman" }]
+		}
 	},
 
 // Bodyguards
 	{
 		ID = "UnitBlock.RF.SpiderBodyguard",
-		UnitDefs = [{ BaseID = "Unit.RF.SpiderBodyguard" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.SpiderBodyguard" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.DirewolfBodyguard",
-		UnitDefs = [{ BaseID = "Unit.RF.DirewolfBodyguard" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.DirewolfBodyguard" }]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/goblin_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/goblin_blocks.nut
@@ -1,27 +1,30 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.GoblinFrontline",
-		UnitDefs =
-		[
-			{ BaseID = "Unit.RF.GoblinSkirmisher" }
-		]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.GoblinSkirmisher" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.GoblinRanged",
-		UnitDefs = [
-			{ BaseID = "Unit.RF.GoblinAmbusher" }
-		]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.GoblinAmbusher" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.GoblinFlank",
-		UnitDefs = [{ BaseID = "Unit.RF.GoblinWolfrider" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.GoblinWolfrider" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.GoblinBoss",
-		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.RF.GoblinOverseer" }],
-			[1, { BaseID = "Unit.RF.GoblinShaman" }]
-		])
+		DynamicDefs = {
+			Units = ::MSU.Class.WeightedContainer([
+				[1, { BaseID = "Unit.RF.GoblinOverseer" }],
+				[1, { BaseID = "Unit.RF.GoblinShaman" }]
+			])
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/greenskin_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/greenskin_blocks.nut
@@ -1,10 +1,12 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.GoblinRegular",
-		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.RF.GoblinSkirmisher" }],
-			[1, { BaseID = "Unit.RF.GoblinAmbusher" }]
-		])
+		DynamicDefs = {
+			Units = ::MSU.Class.WeightedContainer([
+				[1, { BaseID = "Unit.RF.GoblinSkirmisher" }],
+				[1, { BaseID = "Unit.RF.GoblinAmbusher" }]
+			])
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/human_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/human_blocks.nut
@@ -1,81 +1,116 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.MercenaryFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.Mercenary" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Mercenary" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.MercenaryRanged",
-		UnitDefs = [{ BaseID = "Unit.RF.MercenaryRanged" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.MercenaryRanged" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.MercenaryElite",
-		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.RF.MasterArcher" }],
-			[1, { BaseID = "Unit.RF.HedgeKnight" }],
-			[1, { BaseID = "Unit.RF.Swordmaster" }]
-		])
+		DynamicDefs = {
+			Units = ::MSU.Class.WeightedContainer([
+				[1, { BaseID = "Unit.RF.MasterArcher" }],
+				[1, { BaseID = "Unit.RF.HedgeKnight" }],
+				[1, { BaseID = "Unit.RF.Swordmaster" }]
+			])
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BountyHunter",
-		UnitDefs = [{ BaseID = "Unit.RF.BountyHunter" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BountyHunter" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.BountyHunterRanged",
-		UnitDefs = [{ BaseID = "Unit.RF.BountyHunterRanged" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.BountyHunterRanged" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Wardog",
-		UnitDefs = [{ BaseID = "Unit.RF.Wardog" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Wardog" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Slave",
-		UnitDefs = [{ BaseID = "Unit.RF.Slave" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Slave" }]
+		}
 	},
 
 // Civilians
 	{
 		ID = "UnitBlock.RF.CultistAmbush",
-		UnitDefs = [{ BaseID = "Unit.RF.CultistAmbush" }]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.CultistAmbush" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Peasant",
-		UnitDefs = [{ BaseID = "Unit.RF.Peasant" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Peasant" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SouthernPeasant",
-		UnitDefs = [{ BaseID = "Unit.RF.SouthernPeasant" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.SouthernPeasant" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.PeasantArmed",
-		UnitDefs = [{ BaseID = "Unit.RF.PeasantArmed" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.PeasantArmed" }]
+		}
 	},
 
 // Caravans
 	{
 		ID = "UnitBlock.RF.CaravanDonkey",
-		UnitDefs = [{ BaseID = "Unit.RF.CaravanDonkey" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.CaravanDonkey" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.CaravanHand",
-		UnitDefs = [{ BaseID = "Unit.RF.CaravanHand" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.CaravanHand" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.CaravanGuard",
-		UnitDefs = [{ BaseID = "Unit.RF.CaravanGuard" }, { BaseID = "Unit.RF.Mercenary" }]		// In Vanilla they also allow ranged mercenaries here
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.CaravanGuard" }, { BaseID = "Unit.RF.Mercenary" }]
+		}		// In Vanilla they also allow ranged mercenaries here
 	},
 
 // Militia
 	{
 		ID = "UnitBlock.RF.MilitiaFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.Militia" }, { BaseID = "Unit.RF.MilitiaVeteran" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Militia" }, { BaseID = "Unit.RF.MilitiaVeteran" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.MilitiaRanged",
-		UnitDefs = [{ BaseID = "Unit.RF.MilitiaRanged" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.MilitiaRanged" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.MilitiaCaptain",
-		UnitDefs = [{ BaseID = "Unit.RF.MilitiaCaptain" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.MilitiaCaptain" }]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/noble_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/noble_blocks.nut
@@ -1,64 +1,82 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.NobleFrontline",
-		UnitDefs = [
-			"Unit.RF.Footman",
-			"Unit.RF.RF_FootmanHeavy"
-		]
+		DynamicDefs = {
+			Units = [
+				"Unit.RF.Footman",
+				"Unit.RF.RF_FootmanHeavy"
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NobleBackline",
-		UnitDefs = [
-			"Unit.RF.Billman",
-			"Unit.RF.RF_BillmanHeavy"
-		]
+		DynamicDefs = {
+			Units = [
+				"Unit.RF.Billman",
+				"Unit.RF.RF_BillmanHeavy"
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NobleRanged",
-		UnitDefs = [
-			"Unit.RF.Arbalester",
-			"Unit.RF.RF_ArbalesterHeavy"
-		]
+		DynamicDefs = {
+			Units = [
+				"Unit.RF.Arbalester",
+				"Unit.RF.RF_ArbalesterHeavy"
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NobleElite",
-		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1.0, "Unit.RF.RF_ManAtArms"],
-			[0.5, "Unit.RF.Greatsword"],
-			[0.5, "Unit.RF.RF_Fencer"]
-		])
+		DynamicDefs = {
+			Units = ::MSU.Class.WeightedContainer([
+				[1.0, "Unit.RF.RF_ManAtArms"],
+				[0.5, "Unit.RF.Greatsword"],
+				[0.5, "Unit.RF.RF_Fencer"]
+			])
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NobleSupport",
 		HardMax = 2,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.StandardBearer", HardMax = 2 },
-			{ BaseID = "Unit.RF.RF_Herald", HardMax = 1 }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.StandardBearer", HardMax = 2 },
+				{ BaseID = "Unit.RF.RF_Herald", HardMax = 1 }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NobleOfficer",
-		UnitDefs = [
-			{ BaseID = "Unit.RF.Sergeant", HardMax = 1 },
-			{ BaseID = "Unit.RF.RF_Marshal", HardMax = 1 }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.Sergeant", HardMax = 1 },
+				{ BaseID = "Unit.RF.RF_Marshal", HardMax = 1 }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NobleLeader",
-		UnitDefs = [
-			"Unit.RF.Knight",
-			{ BaseID = "Unit.RF.RF_KnightAnointed", HardMax = 1 }
-		]
+		DynamicDefs = {
+			Units = [
+				"Unit.RF.Knight",
+				{ BaseID = "Unit.RF.RF_KnightAnointed", HardMax = 1 }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NobleFlank",
-		UnitDefs = [{ BaseID = "Unit.RF.ArmoredWardog", HardMax = 3 }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.ArmoredWardog", HardMax = 3 }]
+		}
 	},
 
 // Caravan
 	{
 		ID = "UnitBlock.RF.NobleDonkey",
-		UnitDefs = ["Unit.RF.NobleCaravanDonkey"]
+		DynamicDefs = {
+			Units = ["Unit.RF.NobleCaravanDonkey"]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/nomad_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/nomad_blocks.nut
@@ -1,23 +1,31 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.NomadFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.NomadCutthroat" }, { BaseID = "Unit.RF.NomadOutlaw" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.NomadCutthroat" }, { BaseID = "Unit.RF.NomadOutlaw" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NomadRanged",
-		UnitDefs = [{ BaseID = "Unit.RF.NomadSlinger" }, { BaseID = "Unit.RF.NomadArcher" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.NomadSlinger" }, { BaseID = "Unit.RF.NomadArcher" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NomadLeader",
-		UnitDefs = [{ BaseID = "Unit.RF.NomadLeader" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.NomadLeader" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NomadElite",
-		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.RF.Executioner" }],
-			[1, { BaseID = "Unit.RF.DesertStalker" }],
-			[1, { BaseID = "Unit.RF.DesertDevil" }]
-		])
+		DynamicDefs = {
+			Units = ::MSU.Class.WeightedContainer([
+				[1, { BaseID = "Unit.RF.Executioner" }],
+				[1, { BaseID = "Unit.RF.DesertStalker" }],
+				[1, { BaseID = "Unit.RF.DesertDevil" }]
+			])
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/orc_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/orc_blocks.nut
@@ -1,19 +1,27 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.OrcYoung",
-		UnitDefs = [{ BaseID = "Unit.RF.OrcYoung" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.OrcYoung" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.OrcWarrior",
-		UnitDefs = [{ BaseID = "Unit.RF.OrcWarrior" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.OrcWarrior" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.OrcBerserker",
-		UnitDefs = [{ BaseID = "Unit.RF.OrcBerserker" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.OrcBerserker" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.OrcBoss",
-		UnitDefs = [{ BaseID = "Unit.RF.OrcWarlord" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.OrcWarlord" }]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/scourge_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/scourge_blocks.nut
@@ -1,12 +1,14 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.ScourgeSupport",
-		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { BaseID = "Unit.RF.SkeletonPriestPH" }],
-			[1, { BaseID = "Unit.RF.SkeletonPriestHH" }],
-			[1, { BaseID = "Unit.RF.NecromancerYK" }],
-			[1, { BaseID = "Unit.RF.NecromancerKK" }]
-		])
+		DynamicDefs = {
+			Units = ::MSU.Class.WeightedContainer([
+				[1, { BaseID = "Unit.RF.SkeletonPriestPH" }],
+				[1, { BaseID = "Unit.RF.SkeletonPriestHH" }],
+				[1, { BaseID = "Unit.RF.NecromancerYK" }],
+				[1, { BaseID = "Unit.RF.NecromancerKK" }]
+			])
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/southern_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/southern_blocks.nut
@@ -1,46 +1,59 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.SouthernFrontline",
-		//UnitDefs = [{ BaseID = "Conscript" }, { BaseID = "Conscript++" }]
-		UnitDefs = [{ BaseID = "Unit.RF.Conscript" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Conscript" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SouthernBackline",
-		//UnitDefs = [{ BaseID = "Conscript_Polearm" }, { BaseID = "Conscript_Polearm++" }]
-		UnitDefs = [{ BaseID = "Unit.RF.Conscript_Polearm" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Conscript_Polearm" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Assassin",
-		// UnitDefs = [{ BaseID = "Assassin" }, { BaseID = "Assassin++" }]
-		UnitDefs = [{ BaseID = "Unit.RF.Assassin" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Assassin" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Officer",
-		//UnitDefs = [{ BaseID = "Officer" }, { BaseID = "Officer++" }]
-		UnitDefs = [{ BaseID = "Unit.RF.Officer" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Officer" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SouthernRanged",
-		//UnitDefs = [{ BaseID = "Gunner" }, { BaseID = "Gunner++" }]
-		UnitDefs = [{ BaseID = "Unit.RF.Gunner" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Gunner" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Siege",
-		UnitDefs = [{ BaseID = "Unit.RF.Mortar" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Mortar" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Engineer",
-		UnitDefs = [{ BaseID = "Unit.RF.Engineer" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Engineer" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Slave",
-		UnitDefs = [{ BaseID = "Unit.RF.Slave" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Slave" }]
+		}
 	},
 
 // Caravan
 	{
 		ID = "UnitBlock.RF.SouthernCaravanDonkey",
-		UnitDefs = [{ BaseID = "Unit.RF.SouthernDonkey" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.SouthernDonkey" }]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/undead_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/undead_blocks.nut
@@ -2,77 +2,95 @@ local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.SkeletonFrontline",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.SkeletonLight" },
-			{ BaseID = "Unit.RF.RF_SkeletonLightElite" },
-			{ BaseID = "Unit.RF.SkeletonMedium" },
-			{ BaseID = "Unit.RF.RF_SkeletonMediumElite" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.SkeletonLight" },
+				{ BaseID = "Unit.RF.RF_SkeletonLightElite" },
+				{ BaseID = "Unit.RF.SkeletonMedium" },
+				{ BaseID = "Unit.RF.RF_SkeletonMediumElite" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonBackline",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.RF_SkeletonLightElitePolearm" },  // added for balanced spawns and upgrading compared to Frontline
-			{ BaseID = "Unit.RF.RF_SkeletonLightElitePolearm" },
-			{ BaseID = "Unit.RF.SkeletonMediumPolearm" },
-			{ BaseID = "Unit.RF.RF_SkeletonMediumElitePolearm" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_SkeletonLightElitePolearm" },  // added for balanced spawns and upgrading compared to Frontline
+				{ BaseID = "Unit.RF.RF_SkeletonLightElitePolearm" },
+				{ BaseID = "Unit.RF.SkeletonMediumPolearm" },
+				{ BaseID = "Unit.RF.RF_SkeletonMediumElitePolearm" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonElite",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.RF_SkeletonHeavyLesser" },
-			{ BaseID = "Unit.RF.SkeletonHeavy" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_SkeletonHeavyLesser" },
+				{ BaseID = "Unit.RF.SkeletonHeavy" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonSupport",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.SkeletonPriestP", StartingResourceMax = 400 },
-			{ BaseID = "Unit.RF.SkeletonPriestPP" },
-			{ BaseID = "Unit.RF.SkeletonPriestPH" },
-			{ BaseID = "Unit.RF.SkeletonPriestHH" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.SkeletonPriestP", StartingResourceMax = 400 },
+				{ BaseID = "Unit.RF.SkeletonPriestPP" },
+				{ BaseID = "Unit.RF.SkeletonPriestPH" },
+				{ BaseID = "Unit.RF.SkeletonPriestHH" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.VampireOnly",  // VampireOnly party created to solve Vampire Lords always spawning at certain resource intervals
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.Vampire" },
-			{ BaseID = "Unit.RF.RF_VampireLord", Cost = ::Const.World.Spawn.Troops.Vampire.Cost * 2, HardMax = 2 }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.Vampire" },
+				{ BaseID = "Unit.RF.RF_VampireLord", Cost = ::Const.World.Spawn.Troops.Vampire.Cost * 2, HardMax = 2 }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Vampire",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.Vampire" },
-			{ BaseID = "Unit.RF.RF_VampireLord", HardMax = 1 }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.Vampire" },
+				{ BaseID = "Unit.RF.RF_VampireLord", HardMax = 1 }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonDecanus",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.RF_SkeletonDecanus" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_SkeletonDecanus" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonCenturion",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.RF_SkeletonCenturion" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_SkeletonCenturion" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonLegatus",
 		DeterminesFigure = true,
-		UnitDefs = [
-			{ BaseID = "Unit.RF.RF_SkeletonLegatus" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.RF_SkeletonLegatus" }
+			]
+		}
 	}
 ];
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/undead_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/undead_blocks.nut
@@ -1,7 +1,6 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.SkeletonFrontline",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.SkeletonLight" },
@@ -13,7 +12,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonBackline",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.RF_SkeletonLightElitePolearm" },  // added for balanced spawns and upgrading compared to Frontline
@@ -25,7 +23,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonElite",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.RF_SkeletonHeavyLesser" },
@@ -35,7 +32,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonSupport",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.SkeletonPriestP", StartingResourceMax = 400 },
@@ -47,7 +43,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.VampireOnly",  // VampireOnly party created to solve Vampire Lords always spawning at certain resource intervals
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.Vampire" },
@@ -57,7 +52,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.Vampire",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.Vampire" },
@@ -67,7 +61,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonDecanus",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.RF_SkeletonDecanus" }
@@ -76,7 +69,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonCenturion",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.RF_SkeletonCenturion" }
@@ -85,7 +77,6 @@ local unitBlocks = [
 	},
 	{
 		ID = "UnitBlock.RF.SkeletonLegatus",
-		DeterminesFigure = true,
 		DynamicDefs = {
 			Units = [
 				{ BaseID = "Unit.RF.RF_SkeletonLegatus" }

--- a/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/zombie_blocks.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/unit_blocks/zombie_blocks.nut
@@ -1,50 +1,66 @@
 local unitBlocks = [
 	{
 		ID = "UnitBlock.RF.ZombieFrontline",
-		UnitDefs = [{ BaseID = "Unit.RF.Zombie" }, { BaseID = "Unit.RF.ZombieYeoman" }, { BaseID = "Unit.RF.ZombieKnight", RatioMax = 0.5 }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Zombie" }, { BaseID = "Unit.RF.ZombieYeoman" }, { BaseID = "Unit.RF.ZombieKnight", RatioMax = 0.5 }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.ZombieLight",
-		UnitDefs = [{ BaseID = "Unit.RF.Zombie" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Zombie" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.ZombieElite",
-		UnitDefs = [{ BaseID = "Unit.RF.ZombieKnight" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.ZombieKnight" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.ZombieSouthern",
-		UnitDefs = [{ BaseID = "Unit.RF.ZombieNomad" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.ZombieNomad" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Necromancer",
-		UnitDefs = [{ BaseID = "Unit.RF.Necromancer" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Necromancer" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NecromancerWithBodyguards",
-		UnitDefs = [
-			{ BaseID = "Unit.RF.NecromancerY" },
-			{ BaseID = "Unit.RF.NecromancerK" },
-			{ BaseID = "Unit.RF.NecromancerYK" },
-			{ BaseID = "Unit.RF.NecromancerKK" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.NecromancerY" },
+				{ BaseID = "Unit.RF.NecromancerK" },
+				{ BaseID = "Unit.RF.NecromancerYK" },
+				{ BaseID = "Unit.RF.NecromancerKK" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.NecromancerWithNomads",
-		UnitDefs = [
-			{ BaseID = "Unit.RF.NecromancerN" },
-			{ BaseID = "Unit.RF.NecromancerNN" },
-			{ BaseID = "Unit.RF.NecromancerNNN" }
-		]
+		DynamicDefs = {
+			Units = [
+				{ BaseID = "Unit.RF.NecromancerN" },
+				{ BaseID = "Unit.RF.NecromancerNN" },
+				{ BaseID = "Unit.RF.NecromancerNNN" }
+			]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.Ghost",
-		UnitDefs = [{ BaseID = "Unit.RF.Ghost" }]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.Ghost" }]
+		}
 	},
 	{
 		ID = "UnitBlock.RF.ZombieNomadBodyguard",
-		UnitDefs = [
-			{ BaseID = "Unit.RF.ZombieNomadBodyguard" }
-		]
+		DynamicDefs = {
+			Units = [{ BaseID = "Unit.RF.ZombieNomadBodyguard" }]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/barbarian_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/barbarian_units.nut
@@ -47,7 +47,7 @@ local units = [
 		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
 		StaticDefs = {
 			Parties = [
-				{BaseID = "OneUnhold", IsUsingTopPartyResources = false }
+				{ BaseID = "OneUnhold", IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -58,7 +58,7 @@ local units = [
 		StartingResourceMin = 400, // In Vanilla they appear in a group of 400 cost
 		StaticDefs = {
 			Parties = [
-				{BaseID = "TwoUnhold", IsUsingTopPartyResources = false}
+				{ BaseID = "TwoUnhold", IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -69,7 +69,7 @@ local units = [
 		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
 		StaticDefs = {
 			Parties = [
-				{BaseID = "OneFrostUnhold", IsUsingTopPartyResources = false}
+				{ BaseID = "OneFrostUnhold", IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -80,7 +80,7 @@ local units = [
 		StartingResourceMin = 430, // In Vanilla they appear in a group of 430 cost
 		StaticDefs = {
 			Parties = [
-				{BaseID = "TwoFrostUnhold", IsUsingTopPartyResources = false}
+				{ BaseID = "TwoFrostUnhold", IsUsingTopPartyResources = false }
 			]
 		}
 	}

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/barbarian_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/barbarian_units.nut
@@ -45,28 +45,44 @@ local units = [
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 15, // Diversified Beastmaster costs because all of them having the same cost was leading these spawns to have an undefined upgrade path. Result being an armored unhold always spawning on low (250) resources and a normal unhold on high (555+) resources.
 		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
-		SubPartyDef = {BaseID = "OneUnhold", IsUsingTopPartyResources = false }
+		StaticDefs = {
+			Parties = [
+				{BaseID = "OneUnhold", IsUsingTopPartyResources = false }
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterUU",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 17, // Diversified Beastmaster costs because all of them having the same cost was leading these spawns to have an undefined upgrade path. Result being an armored unhold always spawning on low (250) resources and a normal unhold on high (555+) resources.
 		StartingResourceMin = 400, // In Vanilla they appear in a group of 400 cost
-		SubPartyDef = {BaseID = "TwoUnhold", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "TwoUnhold", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 16, // Diversified Beastmaster costs because all of them having the same cost was leading these spawns to have an undefined upgrade path. Result being an armored unhold always spawning on low (250) resources and a normal unhold on high (555+) resources.
 		StartingResourceMin = 200, // In Vanilla they appear in a group of 195 cost
-		SubPartyDef = {BaseID = "OneFrostUnhold", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "OneFrostUnhold", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.BarbarianBeastmasterFF",
 		Troop = "BarbarianBeastmaster",	// Usually it's 1 Beastmaster for 1-2 Unholds. In one case vanilla spawns 3 Unholds for one Beastmaster. And in one case Vanilla spawns 3 Beastmaster for 4 Unholds. I would disregard these.
 		Cost = 18, // Diversified Beastmaster costs because all of them having the same cost was leading these spawns to have an undefined upgrade path. Result being an armored unhold always spawning on low (250) resources and a normal unhold on high (555+) resources.
 		StartingResourceMin = 430, // In Vanilla they appear in a group of 430 cost
-		SubPartyDef = {BaseID = "TwoFrostUnhold", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "TwoFrostUnhold", IsUsingTopPartyResources = false}
+			]
+		}
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/beast_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/beast_units.nut
@@ -111,28 +111,44 @@ local units = [
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50,
-		SubPartyDef = {BaseID = "SpiderBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SpiderBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.HexeTwoSpider",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50,
-		SubPartyDef = {BaseID = "SpiderBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SpiderBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.HexeOneDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50,
-		SubPartyDef = {BaseID = "DirewolfBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "DirewolfBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.HexeTwoDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
 		Cost = 50,
-		SubPartyDef = {BaseID = "DirewolfBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "DirewolfBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false}
+			]
+		}
 	},
 
 	// Bodyguards

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/beast_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/beast_units.nut
@@ -113,7 +113,7 @@ local units = [
 		Cost = 50,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SpiderBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false}
+				{ BaseID = "SpiderBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -124,7 +124,7 @@ local units = [
 		Cost = 50,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SpiderBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false}
+				{ BaseID = "SpiderBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -135,7 +135,7 @@ local units = [
 		Cost = 50,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "DirewolfBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false}
+				{ BaseID = "DirewolfBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -146,7 +146,7 @@ local units = [
 		Cost = 50,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "DirewolfBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false}
+				{ BaseID = "DirewolfBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false }
 			]
 		}
 	},

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/southern_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/southern_units.nut
@@ -26,7 +26,11 @@ local units = [
 		ID = "Unit.RF.Mortar",
 		Troop = "Mortar",
 		StartingResourceMin = 340, // In Vanilla they appear in a group of 340 cost
-		SubPartyDef = {BaseID = "MortarEngineers", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "MortarEngineers", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.Assassin",

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/southern_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/southern_units.nut
@@ -28,7 +28,7 @@ local units = [
 		StartingResourceMin = 340, // In Vanilla they appear in a group of 340 cost
 		StaticDefs = {
 			Parties = [
-				{BaseID = "MortarEngineers", IsUsingTopPartyResources = false}
+				{ BaseID = "MortarEngineers", IsUsingTopPartyResources = false }
 			]
 		}
 	},

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/undead_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/undead_units.nut
@@ -112,7 +112,7 @@ local units = [
 		Cost = 40,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SubPartyPrae", IsUsingTopPartyResources = false}
+				{ BaseID = "SubPartyPrae", IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -124,7 +124,7 @@ local units = [
 		Cost = 40,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SubPartyPrae2", IsUsingTopPartyResources = false}
+				{ BaseID = "SubPartyPrae2", IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -136,7 +136,7 @@ local units = [
 		Cost = 40,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SubPartyPraeHonor", IsUsingTopPartyResources = false}
+				{ BaseID = "SubPartyPraeHonor", IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -148,7 +148,7 @@ local units = [
 		Cost = 40,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SubPartyHonor2", IsUsingTopPartyResources = false}
+				{ BaseID = "SubPartyHonor2", IsUsingTopPartyResources = false }
 			]
 		}
 	}

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/undead_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/undead_units.nut
@@ -110,7 +110,11 @@ local units = [
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 300,
 		Cost = 40,
-		SubPartyDef = {BaseID = "SubPartyPrae", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SubPartyPrae", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.SkeletonPriestPP",
@@ -118,7 +122,11 @@ local units = [
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 325,
 		Cost = 40,
-		SubPartyDef = {BaseID = "SubPartyPrae2", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SubPartyPrae2", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.SkeletonPriestPH",
@@ -126,7 +134,11 @@ local units = [
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 350,
 		Cost = 40,
-		SubPartyDef = {BaseID = "SubPartyPraeHonor", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SubPartyPraeHonor", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.SkeletonPriestHH",
@@ -134,7 +146,11 @@ local units = [
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 375,
 		Cost = 40,
-		SubPartyDef = {BaseID = "SubPartyHonor2", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SubPartyHonor2", IsUsingTopPartyResources = false}
+			]
+		}
 	}
 ];
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/zombie_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/zombie_units.nut
@@ -37,7 +37,7 @@ local units = [
 		Cost = 30,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SubPartyYeoman", IsUsingTopPartyResources = false}
+				{ BaseID = "SubPartyYeoman", IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -49,7 +49,7 @@ local units = [
 		Cost = 30,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SubPartyKnight", IsUsingTopPartyResources = false}
+				{ BaseID = "SubPartyKnight", IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -61,7 +61,7 @@ local units = [
 		Cost = 30,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SubPartyYeomanKnight", IsUsingTopPartyResources = false}
+				{ BaseID = "SubPartyYeomanKnight", IsUsingTopPartyResources = false }
 			]
 		}
 	},
@@ -73,7 +73,7 @@ local units = [
 		Cost = 30,
 		StaticDefs = {
 			Parties = [
-				{BaseID = "SubPartyKnightKnight", IsUsingTopPartyResources = false}
+				{ BaseID = "SubPartyKnightKnight", IsUsingTopPartyResources = false }
 			]
 		}
 	},

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/zombie_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/zombie_units.nut
@@ -35,7 +35,11 @@ local units = [
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 100, // In Vanilla they appear in a group of 100 cost
 		Cost = 30,
-		SubPartyDef = {BaseID = "SubPartyYeoman", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SubPartyYeoman", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.NecromancerK",
@@ -43,7 +47,11 @@ local units = [
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 320, // In Vanilla they appear in a group of 320 cost
 		Cost = 30,
-		SubPartyDef = {BaseID = "SubPartyKnight", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SubPartyKnight", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.NecromancerYK",
@@ -51,7 +59,11 @@ local units = [
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 360, // In Vanilla they appear in a group of 415 cost
 		Cost = 30,
-		SubPartyDef = {BaseID = "SubPartyYeomanKnight", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SubPartyYeomanKnight", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.NecromancerKK",
@@ -59,7 +71,11 @@ local units = [
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 420, // In Vanilla they appear in a group of 415 cost
 		Cost = 30,
-		SubPartyDef = {BaseID = "SubPartyKnightKnight", IsUsingTopPartyResources = false}
+		StaticDefs = {
+			Parties = [
+				{BaseID = "SubPartyKnightKnight", IsUsingTopPartyResources = false}
+			]
+		}
 	},
 
 // Necromancer with Nomad Bodyguards
@@ -69,7 +85,11 @@ local units = [
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 110,
 		Cost = 30,
-		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false }
+		StaticDefs = {
+			Parties = [
+				{ BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false }
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.NecromancerNN",
@@ -77,7 +97,11 @@ local units = [
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 130,
 		Cost = 30,
-		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false }
+		StaticDefs = {
+			Parties = [
+				{ BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false }
+			]
+		}
 	},
 	{
 		ID = "Unit.RF.NecromancerNNN",
@@ -85,7 +109,11 @@ local units = [
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 170,
 		Cost = 30,
-		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3, IsUsingTopPartyResources = false }
+		StaticDefs = {
+			Parties = [
+				{ BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3, IsUsingTopPartyResources = false }
+			]
+		}
 	}
 
 // Bodyguards for Necromancer


### PR DESCRIPTION
This PR updates all spawns definitions to conform to the new setup in Dynamic Spawns Framework, along with some cleanup:
- `UnitBlockDefs` is replaced with `DynamicDefs` with `UnitBlocks` inside it.
- `UnitDefs` is replaced with `DynamicDefs` with `Units` inside it.
- `SubPartyDef` is replaced with `StaticDefs` with `Parties` inside it.
- `StaticUnitDefs` is replaced with `StaticDefs` with `Units` inside it.
- `DeterminesFigure = true` is removed as it is redundant.
- Replace `ReqPartySize` with `PartySizeMin`.
- Removed boosted SpawnWeight for units with defined `PartySizeMin`.
- Replace `getSpawnProcess()` with `getTopParty()`.
- Use `RatioMax` to restrict higher tier ghouls in their unit block instead of overwriting `getHardMax()`.