### PR TITLE
feat: add custom framework for golem dual weapons and skills

### DIFF
--- a/mod_reforged/hooks/items/weapons/golems/golem_cleaver_hammer.nut
+++ b/mod_reforged/hooks/items/weapons/golems/golem_cleaver_hammer.nut
@@ -1,12 +1,29 @@
 ::Reforged.HooksMod.hook("scripts/items/weapons/golems/golem_cleaver_hammer", function(q) {
+	::Reforged.HooksHelper.dualWeapon(q);
+});
+
+::Reforged.HooksMod.hook("scripts/items/weapons/golems/golem_cleaver_hammer", function(q) {
+	q.m.Weapon1 = "scripts/items/weapons/butchers_cleaver";
+	q.m.Weapon2 = "scripts/items/weapons/pickaxe";
+
 	q.create = @(__original) function()
 	{
 		__original();
 		// VanillaFix: Vanilla did not assign icons for these, but we need to display something for the tooltips, so we add the icon of one of those weapons
 		this.m.IconLarge = "weapons/melee/miners_pick_01.png";
 		this.m.Icon = "weapons/melee/miners_pick_01_70x70.png";
+	}
 
-		this.m.Reach = 3;
-		this.addWeaponType(::Const.Items.WeaponType.Cleaver | ::Const.Items.WeaponType.Hammer, true);	// VanillaFix: this weapon has no weapon type assigned in vanilla
+	q.RF_getWeaponForSkill = @() function( _skill )
+	{
+		switch (_skill.ClassName)
+		{
+			case "golem_cleave_skill":
+			case "golem_decapitate_skill":
+				return this.m.Weapon1;
+
+			case "golem_batter_skill":
+				return this.m.Weapon2;
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/golems/golem_mace_flail.nut
+++ b/mod_reforged/hooks/items/weapons/golems/golem_mace_flail.nut
@@ -1,12 +1,29 @@
 ::Reforged.HooksMod.hook("scripts/items/weapons/golems/golem_mace_flail", function(q) {
+	::Reforged.HooksHelper.dualWeapon(q);
+});
+
+::Reforged.HooksMod.hook("scripts/items/weapons/golems/golem_mace_flail", function(q) {
+	q.m.Weapon1 = "scripts/items/weapons/bludgeon";
+	q.m.Weapon2 = "scripts/items/weapons/reinforced_wooden_flail";
+
 	q.create = @(__original) function()
 	{
 		__original();
 		// VanillaFix: Vanilla did not assign icons for these, but we need to display something for the tooltips, so we add the icon of one of those weapons
 		this.m.IconLarge = "weapons/melee/flail_03.png";
 		this.m.Icon = "weapons/melee/flail_03_70x70.png";
+	}
 
-		this.m.Reach = 3;
-		this.addWeaponType(::Const.Items.WeaponType.Mace | ::Const.Items.WeaponType.Flail, true);	// VanillaFix: this weapon has no weapon type assigned in vanilla
+	q.RF_getWeaponForSkill = @() function( _skill )
+	{
+		switch (_skill.ClassName)
+		{
+			case "golem_bash_skill":
+			case "golem_knock_out_skill":
+				return this.m.Weapon1;
+
+			case "golem_lash_skill":
+				return this.m.Weapon2;
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/golems/golem_mace_hammer.nut
+++ b/mod_reforged/hooks/items/weapons/golems/golem_mace_hammer.nut
@@ -1,12 +1,29 @@
 ::Reforged.HooksMod.hook("scripts/items/weapons/golems/golem_mace_hammer", function(q) {
+	::Reforged.HooksHelper.dualWeapon(q);
+});
+
+::Reforged.HooksMod.hook("scripts/items/weapons/golems/golem_mace_hammer", function(q) {
+	q.m.Weapon1 = "scripts/items/weapons/bludgeon";
+	q.m.Weapon2 = "scripts/items/weapons/pickaxe";
+
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Reach = 3;
 		// VanillaFix: Vanilla did not assign icons for these, but we need to display something for the tooltips, so we add the icon of one of those weapons
 		this.m.IconLarge = "weapons/melee/mace_02.png";
 		this.m.Icon = "weapons/melee/mace_02_70x70.png";
+	}
 
-		this.addWeaponType(::Const.Items.WeaponType.Mace | ::Const.Items.WeaponType.Hammer, true);	// VanillaFix: this weapon has no weapon type assigned in vanilla
+	q.RF_getWeaponForSkill = @() function( _skill )
+	{
+		switch (_skill.ClassName)
+		{
+			case "golem_bash_skill":
+			case "golem_knock_out_skill":
+				return this.m.Weapon1;
+
+			case "golem_batter_skill":
+				return this.m.Weapon2;
+		}
 	}
 });

--- a/mod_reforged/hooks/items/weapons/golems/golem_spear_sword.nut
+++ b/mod_reforged/hooks/items/weapons/golems/golem_spear_sword.nut
@@ -1,12 +1,28 @@
 ::Reforged.HooksMod.hook("scripts/items/weapons/golems/golem_spear_sword", function(q) {
+	::Reforged.HooksHelper.dualWeapon(q);
+});
+
+::Reforged.HooksMod.hook("scripts/items/weapons/golems/golem_spear_sword", function(q) {
+	q.m.Weapon1 = "scripts/items/weapons/militia_spear";
+	q.m.Weapon2 = "scripts/items/weapons/shortsword";
+
 	q.create = @(__original) function()
 	{
 		__original();
-		this.m.Reach = 5;
 		// VanillaFix: Vanilla did not assign icons for these, but we need to display something for the tooltips, so we add the icon of one of those weapons
 		this.m.IconLarge = "weapons/melee/spear_02.png";
 		this.m.Icon = "weapons/melee/spear_02_70x70.png";
+	}
 
-		this.addWeaponType(::Const.Items.WeaponType.Spear | ::Const.Items.WeaponType.Sword, true);	// VanillaFix: this weapon has no weapon type assigned in vanilla
+	q.RF_getWeaponForSkill = @() function( _skill )
+	{
+		switch (_skill.ClassName)
+		{
+			case "golem_thrust_skill":
+				return this.m.Weapon1;
+
+			case "golem_slash_skill":
+				return this.m.Weapon2;
+		}
 	}
 });

--- a/mod_reforged/hooks/skills/actives/golem_bash_skill.nut
+++ b/mod_reforged/hooks/skills/actives/golem_bash_skill.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/golem_bash_skill", function(q) {
+	::Reforged.HooksHelper.golemWeaponSkill(q);
+});

--- a/mod_reforged/hooks/skills/actives/golem_batter_skill.nut
+++ b/mod_reforged/hooks/skills/actives/golem_batter_skill.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/golem_batter_skill", function(q) {
+	::Reforged.HooksHelper.golemWeaponSkill(q);
+});

--- a/mod_reforged/hooks/skills/actives/golem_cleave_skill.nut
+++ b/mod_reforged/hooks/skills/actives/golem_cleave_skill.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/golem_cleave_skill", function(q) {
+	::Reforged.HooksHelper.golemWeaponSkill(q);
+});

--- a/mod_reforged/hooks/skills/actives/golem_decapitate_skill.nut
+++ b/mod_reforged/hooks/skills/actives/golem_decapitate_skill.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/golem_decapitate_skill", function(q) {
+	::Reforged.HooksHelper.golemWeaponSkill(q);
+});

--- a/mod_reforged/hooks/skills/actives/golem_knock_out_skill.nut
+++ b/mod_reforged/hooks/skills/actives/golem_knock_out_skill.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/golem_knock_out_skill", function(q) {
+	::Reforged.HooksHelper.golemWeaponSkill(q);
+});

--- a/mod_reforged/hooks/skills/actives/golem_lash_skill.nut
+++ b/mod_reforged/hooks/skills/actives/golem_lash_skill.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/golem_lash_skill", function(q) {
+	::Reforged.HooksHelper.golemWeaponSkill(q);
+});

--- a/mod_reforged/hooks/skills/actives/golem_slash_skill.nut
+++ b/mod_reforged/hooks/skills/actives/golem_slash_skill.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/golem_slash_skill", function(q) {
+	::Reforged.HooksHelper.golemWeaponSkill(q);
+});

--- a/mod_reforged/hooks/skills/actives/golem_thrust_skill.nut
+++ b/mod_reforged/hooks/skills/actives/golem_thrust_skill.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/golem_thrust_skill", function(q) {
+	::Reforged.HooksHelper.golemWeaponSkill(q);
+});

--- a/mod_reforged/hooks_helper.nut
+++ b/mod_reforged/hooks_helper.nut
@@ -1,6 +1,8 @@
 ::Reforged.HooksHelper <- {
 	function dualWeapon( q )
 	{
+		// These are strings which are the script paths to the weapons in this dual wield weapon
+		// e.g. "scripts/items/weapons/bludgeon" and "scripts/items/weapons/pickaxe".
 		q.m.Weapon1 <- null;
 		q.m.Weapon2 <- null;
 
@@ -52,6 +54,9 @@
 			__original(_skill);
 		}
 
+		// This function must be overwritten by the respective dual wield weapon using this hooks helper function.
+		// return either Weapon1 or Weapon2 based on which weapon _skill is meant to represent e.g. for bash skill
+		// return Weapon1 if Weapon1 is Bludgeon.
 		q.RF_getWeaponForSkill <- function( _skill )
 		{
 		}
@@ -73,6 +78,9 @@
 
 			this[superName].onAnySkillUsed(_skill, _targetEntity, _properties);
 
+			// We subtract the damage of the dual weapon this skill belongs to and then add the damage of
+			// the specific weapon within the dual weapon this skill is meant to represent.
+			// This is because with our implementation, the dual weapons no longer have 0 damage like in vanilla.
 			local weapon = this.getItem();
 			_properties.DamageRegularMin += this.m.RF_Weapon.m.RegularDamage - weapon.m.RegularDamage;
 			_properties.DamageRegularMax += this.m.RF_Weapon.m.RegularDamageMax - weapon.m.RegularDamageMax;

--- a/mod_reforged/hooks_helper.nut
+++ b/mod_reforged/hooks_helper.nut
@@ -1,0 +1,82 @@
+::Reforged.HooksHelper <- {
+	function dualWeapon( q )
+	{
+		q.m.Weapon1 <- null;
+		q.m.Weapon2 <- null;
+
+		q.create = @(__original) function()
+		{
+			if (typeof this.m.Weapon1 == "string")
+			{
+				this.m.Weapon1 = ::new(this.m.Weapon1);
+				this.m.Weapon2 = ::new(this.m.Weapon2);
+			}
+
+			__original();
+
+			this.m.Value = this.m.Weapon1.m.Value + this.m.Weapon2.m.Value;
+			this.m.ConditionMax = this.m.Weapon1.m.ConditionMax + this.m.Weapon2.m.ConditionMax;
+			this.m.Condition = this.m.ConditionMax;
+			this.m.StaminaModifier = this.m.Weapon1.m.StaminaModifier + this.m.Weapon2.m.StaminaModifier;
+
+			this.m.RegularDamage = (this.m.Weapon1.m.RegularDamage + this.m.Weapon2.m.RegularDamage) / 2;
+			this.m.RegularDamageMax = (this.m.Weapon1.m.RegularDamageMax + this.m.Weapon2.m.RegularDamageMax) / 2;
+			this.m.ArmorDamageMult = (this.m.Weapon1.m.ArmorDamageMult + this.m.Weapon2.m.ArmorDamageMult) / 2;
+			this.m.DirectDamageMult = (this.m.Weapon1.m.DirectDamageMult + this.m.Weapon2.m.DirectDamageMult) / 2;
+			this.m.Reach = (this.m.Weapon1.m.Reach + this.m.Weapon2.m.Reach) / 2;
+
+			// vanilla already drops loot for golem dual weapons manually from lesser flesh golem getLootForTile
+			// this.m.IsDroppedAsLoot = this.m.Weapon1.m.IsDroppedAsLoot || this.m.Weapon2.m.IsDroppedAsLoot;
+
+			this.setWeaponType(this.m.Weapon1.m.WeaponType);
+			this.addWeaponType(this.m.Weapon2.m.WeaponType);
+		}
+
+		// vanilla already drops loot for golem dual weapons manually from lesser flesh golem getLootForTile
+		// q.drop = @() function( _tile = null )
+		// {
+		// 	this.m.Weapon1.m.Condition *= this.m.Condition / this.m.ConditionMax;
+		// 	this.m.Weapon2.m.Condition *= this.m.Condition / this.m.ConditionMax;
+		// 	if (this.m.Weapon1.isDroppedAsLoot())
+		// 		this.m.Weapon1.drop(_tile);
+		// 	if (this.m.Weapon2.isDroppedAsLoot())
+		// 		this.m.Weapon2.drop(_tile);
+		// }
+
+		q.addSkill = @(__original) function( _skill )
+		{
+			if (::MSU.isIn("RF_Weapon", _skill.m, true))
+			{
+				_skill.m.RF_Weapon = ::MSU.asWeakTableRef(this.RF_getWeaponForSkill(_skill));
+			}
+			__original(_skill);
+		}
+
+		q.RF_getWeaponForSkill <- function( _skill )
+		{
+		}
+	}
+
+	function golemWeaponSkill( q )
+	{
+		q.m.RF_Weapon <- null;
+
+		local superName = q.SuperName;
+
+		q.onAnySkillUsed = @(__original) function( _skill, _targetEntity, _properties )
+		{
+			if (_skill != this || ::MSU.isNull(this.m.RF_Weapon) || ::MSU.isNull(this.getItem()))
+			{
+				__original(_skill, _targetEntity, _properties);
+				return;
+			}
+
+			this[superName].onAnySkillUsed(_skill, _targetEntity, _properties);
+
+			local weapon = this.getItem();
+			_properties.DamageRegularMin += this.m.RF_Weapon.m.RegularDamage - weapon.m.RegularDamage;
+			_properties.DamageRegularMax += this.m.RF_Weapon.m.RegularDamageMax - weapon.m.RegularDamageMax;
+			_properties.DamageArmorMult += this.m.RF_Weapon.m.ArmorDamageMult - weapon.m.ArmorDamageMult;
+		}
+	}
+}


### PR DESCRIPTION
- Dual weapons hold an instance of each weapon.
- Dual weapons now get assigned appropriate stats and weapon types based on the two weapons they are based off of.
- Golem skills use one of the instances of the weapons inside the dual weapon for its damage values.