### PR TITLE
balance: increase AP cost of skills on two-handed weapons

### DIFF
--- a/mod_reforged/hooks/items/weapons/goedendag.nut
+++ b/mod_reforged/hooks/items/weapons/goedendag.nut
@@ -25,7 +25,7 @@
 			o.m.Icon = "skills/active_127.png";
 			o.m.IconDisabled = "skills/active_127_sw.png";
 			o.m.Overlay = "active_127";
-			o.m.ActionPointCost += 1;
+			o.m.ActionPointCost += 2;
 		}));
 	}
 });

--- a/mod_reforged/hooks/items/weapons/named/named_spetum.nut
+++ b/mod_reforged/hooks/items/weapons/named/named_spetum.nut
@@ -1,18 +1,23 @@
 ::Reforged.HooksMod.hook("scripts/items/weapons/named/named_spetum", function(q) {
 	q.m.BaseItemScript = "scripts/items/weapons/spetum";
 
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla 2800. Increased due to attacking twice with perk in Reforged.
+		this.m.Value = 3500;
+	}
+
 	q.onEquip = @() function()
 	{
 		this.named_weapon.onEquip();
 
-		local prong = ::Reforged.new("scripts/skills/actives/prong_skill", function(o) {
-			o.m.ActionPointCost -= 1;
-		});
+		local prong = ::new("scripts/skills/actives/prong_skill");
 
 		this.addSkill(prong);
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/spearwall", function(o) {
-			o.m.ActionPointCost += 1;
+			o.m.ActionPointCost += 2;
 			o.m.FatigueCost += 5;
 			o.m.Icon = "skills/active_124.png";
 			o.m.IconDisabled = "skills/active_124_sw.png";

--- a/mod_reforged/hooks/items/weapons/spetum.nut
+++ b/mod_reforged/hooks/items/weapons/spetum.nut
@@ -3,20 +3,20 @@
 	{
 		__original();
 		this.m.Reach = 6;
+		 // Vanilla 750 where it is comparable to Hooked Blade in value and damage output. Increased due to attacking twice with perk in Reforged.
+		this.m.Value = 1050;
 	}
 
 	q.onEquip = @() function()
 	{
 		this.weapon.onEquip();
 
-		local prong = ::Reforged.new("scripts/skills/actives/prong_skill", function(o) {
-			o.m.ActionPointCost -= 1;
-		});
+		local prong = ::new("scripts/skills/actives/prong_skill");
 
 		this.addSkill(prong);
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/spearwall", function(o) {
-			o.m.ActionPointCost += 1;
+			o.m.ActionPointCost += 2;
 			o.m.FatigueCost += 5;
 			o.m.Icon = "skills/active_124.png";
 			o.m.IconDisabled = "skills/active_124_sw.png";

--- a/mod_reforged/hooks/items/weapons/two_handed_mace.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_mace.nut
@@ -10,7 +10,6 @@
 		this.weapon.onEquip();
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/cudgel_skill", function(o) {
-			o.m.ActionPointCost -= 1;
 			o.m.FatigueCost -= 1;
 			o.m.Icon = "skills/active_131.png";
 			o.m.IconDisabled = "skills/active_131_sw.png";
@@ -18,7 +17,6 @@
 		}));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/strike_down_skill", function(o) {
-			o.m.ActionPointCost -= 1;
 			o.m.FatigueCost -= 5;
 			o.m.Icon = "skills/active_132.png";
 			o.m.IconDisabled = "skills/active_132_sw.png";
@@ -26,7 +24,7 @@
 		}));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/split_shield", function(o) {
-			o.m.ActionPointCost += 1;
+			o.m.ActionPointCost += 2;
 			o.m.FatigueCost += 2;
 		}));
 	}

--- a/mod_reforged/hooks/items/weapons/two_handed_wooden_flail.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_wooden_flail.nut
@@ -18,7 +18,6 @@
 		}));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/thresh", function(o) {
-			o.m.ActionPointCost -= 1;
 			o.m.FatigueCost -= 5;
 			o.m.Icon = "skills/active_130.png";
 			o.m.IconDisabled = "skills/active_130_sw.png";

--- a/mod_reforged/hooks/items/weapons/two_handed_wooden_hammer.nut
+++ b/mod_reforged/hooks/items/weapons/two_handed_wooden_hammer.nut
@@ -10,17 +10,15 @@
 		this.weapon.onEquip();
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/smite_skill", function(o) {
-			o.m.ActionPointCost -= 1;
 			o.m.FatigueCost -= 2;
 		}));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/shatter_skill", function(o) {
-			o.m.ActionPointCost -= 1;
 			o.m.FatigueCost -= 5;
 		}));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/split_shield", function(o) {
-			o.m.ActionPointCost += 1;
+			o.m.ActionPointCost += 2;
 			o.m.FatigueCost += 2;
 		}));
 	}

--- a/mod_reforged/hooks/items/weapons/warfork.nut
+++ b/mod_reforged/hooks/items/weapons/warfork.nut
@@ -3,6 +3,8 @@
 	{
 		__original();
 		this.m.Reach = 6;
+		 // Vanilla 400. Increased due to attacking twice with perk in Reforged.
+		this.m.Value = 600;
 	}
 
 	q.onEquip = @() function()
@@ -10,7 +12,6 @@
 		this.weapon.onEquip();
 
 		local prong = ::Reforged.new("scripts/skills/actives/prong_skill", function(o) {
-			o.m.ActionPointCost -= 1;
 			o.m.FatigueCost -= 3;
 			o.m.Icon = "skills/active_174.png";
 			o.m.IconDisabled = "skills/active_174_sw.png";
@@ -20,7 +21,7 @@
 		this.addSkill(prong);
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/spearwall", function(o) {
-			o.m.ActionPointCost += 1;
+			o.m.ActionPointCost += 2;
 			o.m.Icon = "skills/active_173.png";
 			o.m.IconDisabled = "skills/active_173_sw.png";
 			o.m.Overlay = "active_173";

--- a/mod_reforged/hooks/items/weapons/woodcutters_axe.nut
+++ b/mod_reforged/hooks/items/weapons/woodcutters_axe.nut
@@ -15,7 +15,6 @@
 		}));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/round_swing", function(o) {
-			o.m.ActionPointCost -= 1;
 			o.m.FatigueCost -= 5;
 		}));
 

--- a/scripts/items/weapons/rf_greatsword.nut
+++ b/scripts/items/weapons/rf_greatsword.nut
@@ -41,12 +41,10 @@ this.rf_greatsword <- ::inherit("scripts/items/weapons/weapon", {
 		}.bindenv(this)));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/split", function(o) {
-			o.m.ActionPointCost -= 1;
 			o.m.FatigueCost -= 5;
 		}));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/swing", function(o) {
-			o.m.ActionPointCost -= 1;
 			o.m.FatigueCost -= 5;
 		}));
 


### PR DESCRIPTION
- Generally 2-tile weapons are changed to 6 AP except a few.
- Spetum and Warfork are increased in Value.
- Two-Handed 1-tile weapons are generally made to be 5 AP on their main attack and 6 AP on the secondary attacks, except the Two Handed Mace and Two Handed Wooden Hammer which are made to be 6 AP completely.