### PR TITLE
balance: recover 3 AP from supporter and increase encourage AP cost to 4

### DIFF
--- a/scripts/skills/actives/rf_encourage_skill.nut
+++ b/scripts/skills/actives/rf_encourage_skill.nut
@@ -24,7 +24,7 @@ this.rf_encourage_skill <- ::inherit("scripts/skills/skill", {
 		this.m.IsActive = true;
 		this.m.IsTargeted = true;
 		this.m.IsIgnoredAsAOO = true;
-		this.m.ActionPointCost = 3;
+		this.m.ActionPointCost = 4;
 		this.m.FatigueCost = 15;
 		this.m.MinRange = 1;
 		this.m.MaxRange = 2;

--- a/scripts/skills/perks/perk_rf_supporter.nut
+++ b/scripts/skills/perks/perk_rf_supporter.nut
@@ -2,7 +2,7 @@ this.perk_rf_supporter <- ::inherit("scripts/skills/skill", {
 	m = {
 		// Config
 		MinDistanceAPRecovery = 1,
-		ActionPointsRecovered = 2,
+		ActionPointsRecovered = 3,
 
 		// Private
 		IsSpent = false,


### PR DESCRIPTION
- Supporter is buffed and now allows trying to free an ally from net 3 times instead of 2 per turn when standing next to him. Can now use a 4 AP skill targeting an ally and still have 8 AP left over to do two 4 AP actions.
- Encourage at 4 AP now disallows moving 3 tiles and using Encourage.