### PR TITLE
balance: spear mastery free attack and spearwall AP reduction

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -658,7 +658,7 @@ local vanillaDescriptions = [
 					"Skills build up " + ::MSU.Text.colorPositive("25%") + " less [Fatigue.|Concept.Fatigue]",
 					"The [Action Point|Concept.ActionPoints] cost of [Spearwall|Skill+spearwall] is reduced by " + ::MSU.Text.colorPositive("1") + ".",
 					"[Spearwall|Skill+spearwall] is no longer disabled once an opponent manages to overcome it. Instead, [Spearwall|Skill+spearwall] can still be used and continues to give free attacks on any further opponent attempting to enter the [Zone of Control|Concept.ZoneOfControl]",
-					"When starting your [turn|Concept.Turn] with a spear equipped, the first piercing spear attack during your [turn|Concept.Turn] costs no [Action Points|Concept.ActionPoints] and builds " + ::MSU.Text.colorPositive("50%") + " less [Fatigue.|Concept.Fatigue] Expires upon switching your weapon.",
+					"When starting your [turn|Concept.Turn] with a spear equipped and not moving more than 1 tile from your position, the first piercing spear attack during your [turn|Concept.Turn] costs " + ::MSU.Text.colorPositive("no") + " [Action Points|Concept.ActionPoints] and builds " + ::MSU.Text.colorPositive("50%") + " less [Fatigue.|Concept.Fatigue]",
 					"The [Spetum|Item+spetum] and [Warfork|Item+warfork] no longer have a penalty for attacking targets directly adjacent."
 				]
 			}]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -656,7 +656,6 @@ local vanillaDescriptions = [
 				Type = ::UPD.EffectType.Passive,
 				Description = [
 					"Skills build up " + ::MSU.Text.colorPositive("25%") + " less [Fatigue.|Concept.Fatigue]",
-					"The [Action Point|Concept.ActionPoints] cost of [Spearwall|Skill+spearwall] is reduced by " + ::MSU.Text.colorPositive("1") + ".",
 					"[Spearwall|Skill+spearwall] is no longer disabled once an opponent manages to overcome it. Instead, [Spearwall|Skill+spearwall] can still be used and continues to give free attacks on any further opponent attempting to enter the [Zone of Control|Concept.ZoneOfControl]",
 					"When starting your [turn|Concept.Turn] with a spear equipped and not moving more than 1 tile from your position, the first piercing spear attack during your [turn|Concept.Turn] costs " + ::MSU.Text.colorPositive("no") + " [Action Points|Concept.ActionPoints] and builds " + ::MSU.Text.colorPositive("50%") + " less [Fatigue.|Concept.Fatigue]",
 					"The [Spetum|Item+spetum] and [Warfork|Item+warfork] no longer have a penalty for attacking targets directly adjacent."

--- a/mod_reforged/hooks/skills/perks/perk_mastery_spear.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_spear.nut
@@ -44,16 +44,21 @@
 			return;
 
 		local actor = this.getContainer().getActor();
-
-		if (!actor.isPreviewing() || actor.getPreviewMovement() != null || !this.isSkillValid(actor.getPreviewSkill()))
+		if (actor.isPreviewing())
 		{
-			foreach (skill in this.getContainer().m.Skills)
+			if (actor.getPreviewMovement() != null && actor.getPreviewMovement().Tiles + this.m.TilesMoved >= this.m.MaxTilesAllowed)
+				return;
+
+			if (actor.getPreviewSkill() != null && this.isSkillValid(actor.getPreviewSkill()))
+				return;
+		}
+
+		foreach (skill in this.getContainer().m.Skills)
+		{
+			if (this.isSkillValid(skill))
 			{
-				if (this.isSkillValid(skill))
-				{
-					skill.m.ActionPointCost = 0;
-					skill.m.FatigueCostMult *= this.m.FatigueCostMultMult;
-				}
+				skill.m.ActionPointCost = 0;
+				skill.m.FatigueCostMult *= this.m.FatigueCostMultMult;
 			}
 		}
 	}

--- a/mod_reforged/hooks/skills/perks/perk_mastery_spear.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_spear.nut
@@ -40,10 +40,6 @@
 	{
 		__original(_properties);
 
-		local spearwall = this.getContainer().getSkillByID("actives.spearwall");
-		if (spearwall != null && spearwall.m.ActionPointCost > 0)
-			spearwall.m.ActionPointCost -= 1;
-
 		if (this.m.IsSpent)
 			return;
 

--- a/mod_reforged/hooks/skills/perks/perk_mastery_spear.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_spear.nut
@@ -1,5 +1,7 @@
 ::Reforged.HooksMod.hook("scripts/skills/perks/perk_mastery_spear", function(q) {
 	q.m.IsSpent <- true;
+	q.m.TilesMoved <- 0;
+	q.m.MaxTilesAllowed <- 1;
 	q.m.FatigueCostMultMult <- 0.5;
 
 	q.create = @(__original) function()
@@ -28,7 +30,7 @@
 			id = 20,
 			type = "text",
 			icon = "ui/icons/warning.png",
-			text = "Will expire upon switching your weapon!"
+			text = "Will expire upon switching your weapon or moving" + (this.m.MaxTilesAllowed == 0 ? "" : "more than " + this.m.MaxTilesAllowed + " tile(s)")
 		});
 
 		return ret;
@@ -82,9 +84,19 @@
 		}
 	}
 
+	q.onMovementStarted = @(__original) function( _tile, _numTiles )
+	{
+		this.m.TilesMoved += _numTiles;
+		if (this.m.TilesMoved > this.m.MaxTilesAllowed)
+			this.m.IsSpent = true;
+		__original(_tile, _numTiles);
+	}
+
 	q.onTurnStart = @(__original) function()
 	{
 		__original();
+
+		this.m.TilesMoved = 0;
 
 		local actor = this.getContainer().getActor();
 		if (actor.isDisarmed())
@@ -99,6 +111,7 @@
 	{
 		__original();
 		this.m.IsSpent = true;
+		this.m.TilesMoved = 0;
 	}
 
 	q.isSkillValid <- function( _skill )


### PR DESCRIPTION
Keeps the identity of the free attack on spears while making it a little more gated to use for balance. Primarily it prevents 2-tile spears e.g. Warfork, Spetum, Swordstaff from walking 2 tiles and still attacking twice.

Also remove Spearwall AP cost reduction.