### PR TITLE
balance: make huge and above beasts immune to being netted

### DIFF
--- a/mod_reforged/hooks/skills/actives/throw_net.nut
+++ b/mod_reforged/hooks/skills/actives/throw_net.nut
@@ -21,6 +21,6 @@
 
 	q.onVerifyTarget = @(__original) function( _originTile, _targetTile )
 	{
-		return __original(_originTile, _targetTile) && !_targetTile.getEntity().getCurrentProperties().IsImmuneToRoot;
+		return __original(_originTile, _targetTile) && !_targetTile.getEntity().getCurrentProperties().IsImmuneToRoot && _targetTile.getEntity().getBaseProperties().Reach < ::Reforged.Reach.Default.BeastHuge;
 	}
 });


### PR DESCRIPTION
Examples of Huge and above beasts:
- Unhold
- Greater Flesh Golem
- Lindwurm
- Ijirok
- Ifrit High

Unholds and Ifrits are being increased in their size in another PR: #740 