### PR TITLE
balance: add 2 beast reach tiers, adjust reach and stats of beasts

### DIFF
--- a/mod_reforged/config/reach.nut
+++ b/mod_reforged/config/reach.nut
@@ -9,6 +9,8 @@
 		BeastMedium = 5,
 		BeastLarge = 7,
 		BeastHuge = 9,
+		BeastEnormous = 11,
+		BeastGargantuan 13,
 
 		Dagger = 1,
 		Short_1H = 2,

--- a/mod_reforged/hooks/config/faction_beasts.nut
+++ b/mod_reforged/hooks/config/faction_beasts.nut
@@ -75,6 +75,25 @@
 		20
 	]
 });
+::MSU.Table.merge(::Const.Tactical.Actor.Lindwurm, {
+	XP = 800,
+	ActionPoints = 7,
+	Hitpoints = 1100,
+	Bravery = 180,
+	Stamina = 400,
+	MeleeSkill = 65, // vanilla 75
+	RangedSkill = 0,
+	MeleeDefense = 5, // vanilla 10 - lowered due to reach
+	RangedDefense = -10,
+	Initiative = 80,
+	FatigueEffectMult = 1.0,
+	MoraleEffectMult = 1.0,
+	FatigueRecoveryRate = 30,
+	Armor = [
+		400,
+		200
+	]
+});
 ::MSU.Table.merge(::Const.Tactical.Actor.Serpent, {
 	XP = 175,
 	ActionPoints = 9,
@@ -111,5 +130,62 @@
 	Armor = [
 		20,
 		20
+	]
+});
+::MSU.Table.merge(::Const.Tactical.Actor.Unhold, {
+	XP = 400,
+	ActionPoints = 9,
+	Hitpoints = 500,
+	Bravery = 130,
+	Stamina = 400,
+	MeleeSkill = 70,
+	RangedSkill = 0,
+	MeleeDefense = 5, // vanilla 10 - lowered due to reach
+	RangedDefense = 0,
+	Initiative = 75,
+	FatigueEffectMult = 1.0,
+	MoraleEffectMult = 1.0,
+	FatigueRecoveryRate = 30,
+	Armor = [
+		0,
+		0
+	]
+});
+::MSU.Table.merge(::Const.Tactical.Actor.UnholdBog, {
+	XP = 400,
+	ActionPoints = 9,
+	Hitpoints = 500,
+	Bravery = 130,
+	Stamina = 400,
+	MeleeSkill = 70,
+	RangedSkill = 0,
+	MeleeDefense = 5, // vanilla 10 - lowered due to reach
+	RangedDefense = 5,
+	Initiative = 75,
+	FatigueEffectMult = 1.0,
+	MoraleEffectMult = 1.0,
+	FatigueRecoveryRate = 30,
+	Armor = [
+		0,
+		0
+	]
+});
+::MSU.Table.merge(::Const.Tactical.Actor.UnholdFrost, {
+	XP = 450,
+	ActionPoints = 9,
+	Hitpoints = 600,
+	Bravery = 150,
+	Stamina = 400,
+	MeleeSkill = 70, // vanilla 75
+	RangedSkill = 0,
+	MeleeDefense = 5, // vanilla 10
+	RangedDefense = 0,
+	Initiative = 85,
+	FatigueEffectMult = 1.0,
+	MoraleEffectMult = 1.0,
+	FatigueRecoveryRate = 30,
+	Armor = [
+		90,
+		90
 	]
 });

--- a/mod_reforged/hooks/config/faction_beasts.nut
+++ b/mod_reforged/hooks/config/faction_beasts.nut
@@ -81,7 +81,7 @@
 	Hitpoints = 1100,
 	Bravery = 180,
 	Stamina = 400,
-	MeleeSkill = 65, // vanilla 75
+	MeleeSkill = 65, // vanilla 75 - lowered due to reach
 	RangedSkill = 0,
 	MeleeDefense = 5, // vanilla 10 - lowered due to reach
 	RangedDefense = -10,
@@ -160,7 +160,7 @@
 	MeleeSkill = 70,
 	RangedSkill = 0,
 	MeleeDefense = 5, // vanilla 10 - lowered due to reach
-	RangedDefense = 5,
+	RangedDefense = 15, // vanilla 5 - increased to offer variance compared to standard unhold
 	Initiative = 75,
 	FatigueEffectMult = 1.0,
 	MoraleEffectMult = 1.0,
@@ -176,9 +176,9 @@
 	Hitpoints = 600,
 	Bravery = 150,
 	Stamina = 400,
-	MeleeSkill = 70, // vanilla 75
+	MeleeSkill = 70, // vanilla 75 - lowered due to reach
 	RangedSkill = 0,
-	MeleeDefense = 5, // vanilla 10
+	MeleeDefense = 5, // vanilla 10 - lowered due to reach
 	RangedDefense = 0,
 	Initiative = 85,
 	FatigueEffectMult = 1.0,

--- a/mod_reforged/hooks/entity/tactical/enemies/lindwurm.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/lindwurm.nut
@@ -96,8 +96,8 @@
 		}
 
 		// Reforged
-		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastHuge + 2;
-		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_survival_instinct"));
+		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastGargantuan;
+		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_formidable_approach"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_menacing"));
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/sand_golem_high.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/sand_golem_high.nut
@@ -6,7 +6,7 @@
 		this.grow(true);
 
 		// Reforged
-		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastLarge + 1;
+		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastHuge + 1;
 		this.getSkills().update()
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/sand_golem_medium.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/sand_golem_medium.nut
@@ -5,7 +5,7 @@
 		this.grow(true);
 
 		// Reforged
-		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastMedium + 1;
+		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastLarge;
 		this.getSkills().update()
 	}
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/trickster_god.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/trickster_god.nut
@@ -37,7 +37,7 @@
 		this.m.Skills.add(::new("scripts/skills/actives/gore_skill"));
 
 		// Reforged
-		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastHuge;
+		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastEnormous;
 		this.m.Skills.add(::Reforged.new("scripts/skills/perks/perk_rf_dent_armor", function(o) {
 			o.m.RequiredDamageType = null;
 		}));

--- a/mod_reforged/hooks/entity/tactical/enemies/unhold.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/unhold.nut
@@ -59,7 +59,7 @@
 		this.m.Skills.add(::new("scripts/skills/actives/unstoppable_charge_skill"));
 
 		// Reforged
-		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastLarge;
+		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastHuge;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_rattle"));
 		this.m.Skills.add(::Reforged.new("scripts/skills/perks/perk_rf_dismantle", function(o) {
 			o.m.RequiredDamageType = null;

--- a/mod_reforged/hooks/entity/tactical/enemies/unhold_bog.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/unhold_bog.nut
@@ -48,7 +48,7 @@
 		this.m.Skills.add(::new("scripts/skills/actives/unstoppable_charge_skill"));
 
 		// Reforged
-		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastLarge;
+		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastHuge;
 		b.RangedDefense += 10;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_rattle"));
 		this.m.Skills.add(::Reforged.new("scripts/skills/perks/perk_rf_dismantle", function(o) {

--- a/mod_reforged/hooks/entity/tactical/enemies/unhold_bog.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/unhold_bog.nut
@@ -49,7 +49,6 @@
 
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastHuge;
-		b.RangedDefense += 10;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_rattle"));
 		this.m.Skills.add(::Reforged.new("scripts/skills/perks/perk_rf_dismantle", function(o) {
 			o.m.RequiredDamageType = null;

--- a/mod_reforged/hooks/entity/tactical/enemies/unhold_frost.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/unhold_frost.nut
@@ -50,7 +50,7 @@
 		this.m.Skills.add(::new("scripts/skills/actives/unstoppable_charge_skill"));
 
 		// Reforged
-		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastLarge + 1;
+		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.BeastHuge + 1;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_fearsome"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_rattle"));
 		this.m.Skills.add(::Reforged.new("scripts/skills/perks/perk_rf_dismantle", function(o) {


### PR DESCRIPTION
BeastEnormous = 11
BeastGargantuan = 13

Lindwurm
- Huge +2 to Gargantuan
- Matk from 75 to 65
- Mdef from 10 to 0
- Gain Formidable Approach, lose Survival Instinct

Unhold/Bog Unhold
- Large to Huge
- Mdef from 10 to 5

Unhold Frost
- Large +1 to Huge +1
- Matk from 75 to 70
- Mdef from 10 to 5

Ifrit High
- Large +1 to Huge +1

Ifrit Medium
- Medium +1 to Large