### PR TITLE
feat: remove Shield from the name of Sipar and Adarga shields

### DIFF
--- a/mod_reforged/hooks/items/shields/oriental/metal_round_shield.nut
+++ b/mod_reforged/hooks/items/shields/oriental/metal_round_shield.nut
@@ -2,6 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
+		this.m.Name = "Sipar"; // Remove "Shield" from the name.
 		this.m.Condition = 300; // vanilla 60
 		this.m.ConditionMax = 300; // vanilla 60
 		this.m.MeleeDefense = 25; // vanilla 18

--- a/mod_reforged/hooks/items/shields/oriental/southern_light_shield.nut
+++ b/mod_reforged/hooks/items/shields/oriental/southern_light_shield.nut
@@ -2,6 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
+		this.m.Name = "Adarga"; // Remove "Shield" from the name.
 		this.m.StaminaModifier = -8; // Vanilla is -10.
 		this.m.Condition = 40; // vanilla 18
 		this.m.ConditionMax = 40; // vanilla 18


### PR DESCRIPTION
- Sipar is a Persian word that means shield.
- Adarga is of Berber origin and also seems to be used as a name for this kind of shield so doesn't need the "shield" suffix.

There was some discussion with players about this on Discord too: https://discord.com/channels/1006908336991645757/1006908337981509725/1360465548508532919