### PR TITLE
refactor: make human line breaker skill require an attack roll

### DIFF
--- a/scripts/skills/actives/rf_line_breaker_skill.nut
+++ b/scripts/skills/actives/rf_line_breaker_skill.nut
@@ -17,6 +17,8 @@ this.rf_line_breaker_skill <- ::inherit("scripts/skills/actives/line_breaker", {
 		];
 		this.m.IsSerialized = false;
 		this.m.FatigueCost = 25;
+		this.m.IsUsingHitchance = true;
+		this.m.HitChanceBonus = 15;
 		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.LineBreaker;
 	}
 
@@ -24,10 +26,17 @@ this.rf_line_breaker_skill <- ::inherit("scripts/skills/actives/line_breaker", {
 	{
 		local ret = this.skill.getDefaultUtilityTooltip();
 
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/hitchance.png",
+			text = ::Reforged.Mod.Tooltips.parseString(format("Has %s chance to hit", ::MSU.Text.colorizeValue(this.m.HitChanceBonus, {AddSign = true, AddPercent = true})))
+		});
+
 		if (!this.getContainer().getActor().getCurrentProperties().IsRooted || this.getContainer().getActor().getCurrentProperties().IsStunned)
 		{
 			ret.push({
-				id = 10,
+				id = 20,
 				type = "text",
 				icon = "ui/icons/warning.png",
 				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorNegative("Cannot be used while Rooted or [Stunned|Skill+stunned_effect]"))
@@ -41,5 +50,41 @@ this.rf_line_breaker_skill <- ::inherit("scripts/skills/actives/line_breaker", {
 	{
 		local actor = this.getContainer().getActor();
 		return this.skill.isUsable() && (this.m.IsForceEnabled || actor.isArmedWithShield()) && !actor.getCurrentProperties().IsRooted && !actor.getCurrentProperties().IsStunned;
+	}
+
+	function onUse( _user, _targetTile )
+	{
+		if (this.attackEntity(_user, _targetTile.getEntity()))
+		{
+			local tag = {
+				User = _user,
+				TargetTile = _targetTile
+			}
+			// Doing this.line_breaker.onUse here directly doesn't work properly.
+			// The target gets knocked back by Linebreaker, but the attacker does not move to the target tile.
+			// Using scheduleEvent even with a delay of 1 is enough to make it work properly. No idea why.
+			::Time.scheduleEvent(::TimeUnit.Virtual, 1, this.onPushThrough.bindenv(this), tag);
+
+			return true;
+		}
+
+		return false;
+	}
+
+	function onAnySkillUsed( _skill, _targetEntity, _properties )
+	{
+		this.line_breaker.onAnySkillUsed(_skill, _targetEntity, _properties);
+
+		if (_skill == this)
+		{
+			_properties.DamageTotalMult = 0.0;
+			_properties.MeleeSkill += this.m.HitChanceBonus;
+		}
+	}
+
+	function onPushThrough( _tag )
+	{
+		if (_tag.TargetTile.IsOccupiedByActor)
+			this.line_breaker.onUse(_tag.User, _tag.TargetTile);
 	}
 });


### PR DESCRIPTION
In my opinion the guaranteed Line Breaker is a thing that should be used only by large enemies e.g. Orcs against humans. Humans using this against other humans should depend on the melee skill and melee defense.

If we want to tweak it further at some point we can make the hit-chance scale with how fatigued/wounded the user/target is.