### PR TITLE
balance: reduce armor pen and hitchance on steady brace

### DIFF
--- a/scripts/skills/perks/perk_rf_steady_brace.nut
+++ b/scripts/skills/perks/perk_rf_steady_brace.nut
@@ -1,8 +1,8 @@
 this.perk_rf_steady_brace <- ::inherit("scripts/skills/skill", {
 	m = {
 		IsInEffect = false,
-		DamageDirectAddModifier = 0.2,
-		RangedSkillModifier = 20
+		DamageDirectAddModifier = 0.1,
+		RangedSkillModifier = 10
 	},
 	function create()
 	{


### PR DESCRIPTION
From 0.2 to 0.1 and from 20 to 10 respectively.

For a tier 1 perk this results in roughly 6 more HP damage through armor on body shots and 9 more HP damage on head shots from crossbows compared to without the perk. For Handgonnes the +10% chance to hit is quite impactful as it applies to all their targets.