### PR TITLE
refactor: use msu LevelUpsSpent spent variable instead of new flag

### DIFF
--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -111,7 +111,5 @@
 		__original(_v);
 		local discoveredTalent = this.getSkills().getSkillByID("perk.rf_discovered_talent");
 		if (discoveredTalent != null) discoveredTalent.addStars();
-
-		this.getFlags().set("RF_HasSpentLevelUp", true);
 	}
 });

--- a/mod_reforged/hooks/skills/backgrounds/character_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/character_background.nut
@@ -124,7 +124,7 @@
 		}
 		else if (showBaseAttributeRangeRegular == "Only New Recruits")
 		{
-			if (!this.getContainer().getActor().getFlags().has("RF_HasSpentLevelUp"))
+			if (!this.getContainer().getActor().m.LevelUpsSpent > 0)
 			{
 				ret.extend(this.getBaseAttributesTooltip(false));
 			}

--- a/mod_reforged/hooks/skills/backgrounds/character_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/character_background.nut
@@ -124,7 +124,7 @@
 		}
 		else if (showBaseAttributeRangeRegular == "Only New Recruits")
 		{
-			if (!this.getContainer().getActor().m.LevelUpsSpent > 0)
+			if (!this.getContainer().getActor().m.LevelUpsSpent > 0) // LevelUpsSpent is added by MSU
 			{
 				ret.extend(this.getBaseAttributesTooltip(false));
 			}


### PR DESCRIPTION
This feature has been present in MSU for a long time so we can simply use it instead of adding a new flag.