### PR TITLE
feat: add mod setting to display actor basic values as numbers or words

### DIFF
--- a/mod_reforged/hooks/config/character.nut
+++ b/mod_reforged/hooks/config/character.nut
@@ -38,3 +38,10 @@ local getClone = ::Const.CharacterProperties.getClone;
 ::Const.Movement.AutoEndTurnBelowAP = 1;
 
 ::Const.Morale.RF_AllyFleeingBraveryModifierPerAlly <- 1;
+
+::Const.RF_ActionPointsStateName <- [
+	"Spent",
+	"Slowing Down",
+	"Measured",
+	"Primed"
+];

--- a/mod_reforged/hooks/config/tip_of_the_day.nut
+++ b/mod_reforged/hooks/config/tip_of_the_day.nut
@@ -83,6 +83,7 @@ for (local index = (::Const.TipOfTheDay.len() - 1); index >= 0; index--)
 	"Reforged: Tavern rumors will never be about legendary locations you have already discovered.",
 	"Reforged: Enemies will drop loot only if your faction has dealt at least 50% of the total damage received by that enemy, regardless of the killer.",
 	"Reforged: Experience from slain enemies is awarded depending on how much damage was dealt to them by your brothers.",
+	"Reforged: You can customize the tactical tooltips of your characters and enemies in the Mod Options.",
 	"If you see colorful squares, do NOT save the game or you might end up with a corrupted save file.",
 	"Reforged: Weapons worn by your characters will always drop and be recovered after the battle, even if they break."
 ]);

--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -60,14 +60,31 @@
 			}
 		}
 
+		local isShowingValue = false;
+		switch (::Reforged.Mod.ModSettings.getSetting("TacticalTooltip_Values").getValue())
+		{
+			case "All":
+				isShowingValue = true;
+				break;
+			case "Player Only":
+				isShowingValue = ::isKindOf(this, "player");
+				break;
+			case "AI Only":
+				isShowingValue = !::isKindOf(this, "player");
+				break;
+		}
+
 		// Adjust existing progressbars displayed by Vanilla
 		for (local index = (ret.len() - 1); index >= 0; index--)	// we move through it backwards to safely remove entries during it
 		{
 			local entry = ret[index];
 			// Display the actual values for Armor (5, 6), Health (7) and Fatigue (9)
-			if (entry.id == 5 || entry.id == 6 || entry.id == 7 || entry.id == 9)
+			if (isShowingValue)
 			{
-				entry.text = " " + entry.value + " / " + entry.valueMax;
+				if (entry.id == 5 || entry.id == 6 || entry.id == 7 || entry.id == 9)
+				{
+					entry.text = " " + entry.value + " / " + entry.valueMax;
+				}
 			}
 
 			// Insert reach information
@@ -78,12 +95,10 @@
 
 			if (entry.id == 8)	// Replace Morale-Bar with Action-Point-Bar
 			{
-				local turnsToGo = ::Tactical.TurnSequenceBar.getTurnsUntilActive(this.getID());
-
 				entry.icon = "ui/icons/action_points.png",
 				entry.value = this.getActionPoints(),
 				entry.valueMax = this.getActionPointsMax(),
-				entry.text = "" + this.getActionPoints() + " / " + this.getActionPointsMax() + "",
+				entry.text = isShowingValue ? (this.getActionPoints() + " / " + this.getActionPointsMax()) : ::Const.RF_ActionPointsStateName[this.RF_getActionPointsState()],
 				entry.style = "action-points-slim";
 				continue;
 			}
@@ -245,6 +260,11 @@
 	q.setWaitTurn <- function( _bool )
 	{
 		this.m.IsWaitingTurn = _bool;
+	}
+
+	q.RF_getActionPointsState <- function()
+	{
+		return ::Math.min(::Const.RF_ActionPointsStateName.len() - 1, ::Math.max(0, ::Math.floor(this.getActionPoints() / (this.getActionPointsMax() * 1.0) * (::Const.RF_ActionPointsStateName.len() - 1))));
 	}
 
 	// Functionality to restrict loot drops based on damage dealt by players to this actor.

--- a/mod_reforged/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/mod_reforged/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -36,6 +36,31 @@
 		ret.moraleMax = 15; // arbitrary maximum value
 		ret.moraleLabel = reach + " (" + reachAtk + ", " + reachDef + ")";
 
+		local isShowingValue = false;
+		switch (::Reforged.Mod.ModSettings.getSetting("TacticalTooltip_Values").getValue())
+		{
+			case "All":
+				isShowingValue = true;
+				break;
+			case "Player Only":
+				isShowingValue = ::MSU.isKindOf(_entity, "player");
+				break;
+			case "AI Only":
+				isShowingValue = !::MSU.isKindOf(_entity, "player");
+				break;
+		}
+
+		if (!isShowingValue)
+		{
+			// All these entries are not added by vanilla in this function, but they are used by vanilla
+			// in the js function. So if we just add them here, it works automatically.
+			ret.armorHeadLabel <-  ::Const.ArmorStateName[_entity.getArmorState(::Const.BodyPart.Head)];
+			ret.armorBodyLabel <- ::Const.ArmorStateName[_entity.getArmorState(::Const.BodyPart.Body)];
+			ret.fatigueLabel <-  ::Const.FatigueStateName[_entity.getFatigueState()];
+			ret.hitpointsLabel <- ::Const.HitpointsStateName[_entity.getHitpointsState()];
+			ret.actionPointsLabel <- ::Const.RF_ActionPointsStateName[_entity.RF_getActionPointsState()];
+		}
+
 		return ret;
 	}
 

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -11,6 +11,7 @@
 {	// Tactical Tooltips
 	local tacticalTooltipPage = ::Reforged.Mod.ModSettings.addPage("Tactical Tooltips");
 
+	tacticalTooltipPage.addEnumSetting("TacticalTooltip_Values", "All", ["All", "AI Only", "Player Only", "None"], "Show Values", "Show Hitpoints, Armor etc. as values instead of immersive words.");
 	tacticalTooltipPage.addEnumSetting("TacticalTooltip_Attributes", "All", ["All", "AI Only", "Player Only", "None"], "Show Attributes", "Show attributes such as Melee Skill, Melee Defense etc. for entities in the Tactical Tooltip.");
 	tacticalTooltipPage.addEnumSetting("TacticalTooltip_Effects", "All", ["All", "AI Only", "Player Only", "None"], "Show Effects", "Show status effects for entities in the Tactical Tooltip.");
 	tacticalTooltipPage.addEnumSetting("TacticalTooltip_Perks", "All", ["All", "AI Only", "Player Only", "None"], "Show Perks", "Show perks for entities in the Tactical Tooltip.");


### PR DESCRIPTION
We absolutely should have this as a mod setting and it was also requested by a member of the community not long ago. I have also added custom words for the Action Points state.

This setting allows the player to customize whether the Head Armor, Body Armor, Hitpoints, Fatigue and Action Points of a character in the tooltip are shown as numbers or as words (just line in vanilla). The setting allows to customize whether it is shown as numbers for All characters, Player Only, AI Only, or None.