### PR TITLE
Bleeding improvements and resilient perk

### DIFF
--- a/mod_reforged/hooks/config/character.nut
+++ b/mod_reforged/hooks/config/character.nut
@@ -10,6 +10,7 @@ local original_getClone = ::Const.CharacterProperties.getClone;
 	DefensiveReachIgnore = 0,
 	OffensiveReachIgnore = 0,
 	BonusPerReachAdvantage = 0,
+	RF_BleedingEffectMult = 1.0
 
 	function getReach()
 	{

--- a/mod_reforged/hooks/config/character.nut
+++ b/mod_reforged/hooks/config/character.nut
@@ -1,34 +1,37 @@
-::Const.CharacterProperties.PositiveMoraleCheckBravery <- array(::Const.MoraleCheckType.len(), 0);
-::Const.CharacterProperties.PositiveMoraleCheckBraveryMult <- array(::Const.MoraleCheckType.len(), 1.0);
-::Const.CharacterProperties.NegativeMoraleCheckBravery <- array(::Const.MoraleCheckType.len(), 0);
-::Const.CharacterProperties.NegativeMoraleCheckBraveryMult <- array(::Const.MoraleCheckType.len(), 1.0);
+local original_getClone = ::Const.CharacterProperties.getClone;
+::MSU.Table.merge(::Const.CharacterProperties, {
+	PositiveMoraleCheckBravery = array(::Const.MoraleCheckType.len(), 0),
+	PositiveMoraleCheckBraveryMult = array(::Const.MoraleCheckType.len(), 1.0),
+	NegativeMoraleCheckBravery = array(::Const.MoraleCheckType.len(), 0),
+	NegativeMoraleCheckBraveryMult =array(::Const.MoraleCheckType.len(), 1.0),
+	Reach = 0,
+	ReachMult = 1.0,
+	IsAffectedByReach = true,
+	DefensiveReachIgnore = 0,
+	OffensiveReachIgnore = 0,
+	BonusPerReachAdvantage = 0,
 
-::Const.CharacterProperties.getFatigueRecoveryRate <- function()
-{
-	return ::Math.floor(this.FatigueRecoveryRate * this.FatigueRecoveryRateMult);
-}
+	function getReach()
+	{
+		return ::Math.floor(this.Reach * this.ReachMult);
+	}
 
-local getClone = ::Const.CharacterProperties.getClone;
-::Const.CharacterProperties.getClone = function()
-{
-	local ret = getClone();
-	ret.PositiveMoraleCheckBravery = clone this.PositiveMoraleCheckBravery;
-	ret.PositiveMoraleCheckBraveryMult = clone this.PositiveMoraleCheckBraveryMult;
-	ret.NegativeMoraleCheckBravery = clone this.NegativeMoraleCheckBravery;
-	ret.NegativeMoraleCheckBraveryMult = clone this.NegativeMoraleCheckBraveryMult;
-	return ret;
-}
+	function getFatigueRecoveryRate()
+	{
+		return ::Math.floor(this.FatigueRecoveryRate * this.FatigueRecoveryRateMult);
+	}
 
-::Const.CharacterProperties.Reach <- 0;
-::Const.CharacterProperties.ReachMult <- 1.0;
-::Const.CharacterProperties.getReach <- function()
-{
-	return ::Math.floor(this.Reach * this.ReachMult);
-}
-::Const.CharacterProperties.IsAffectedByReach <- true;
-::Const.CharacterProperties.DefensiveReachIgnore <- 0;
-::Const.CharacterProperties.OffensiveReachIgnore <- 0;
-::Const.CharacterProperties.BonusPerReachAdvantage <- 0;
+	function getClone()
+	{
+		local ret = original_getClone();
+		ret.PositiveMoraleCheckBravery = clone this.PositiveMoraleCheckBravery;
+		ret.PositiveMoraleCheckBraveryMult = clone this.PositiveMoraleCheckBraveryMult;
+		ret.NegativeMoraleCheckBravery = clone this.NegativeMoraleCheckBravery;
+		ret.NegativeMoraleCheckBraveryMult = clone this.NegativeMoraleCheckBraveryMult;
+		return ret;
+	}
+});
+
 
 ::Const.ProjectileType.FlamingArrow <- ::Const.ProjectileType.COUNT;
 ::Const.ProjectileType.COUNT += 1;

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -416,7 +416,8 @@ local vanillaDescriptions = [
 				Type = ::UPD.EffectType.Passive,
 				Description = [
 					"Any negative [status effect|Concept.StatusEffect] with a finite duration (e.g. [Disarmed,|Skill+disarmed_effect] [Charmed|Skill+charmed_effect]) has its duration reduced to " + ::MSU.Text.colorPositive(1) + " [turn.|Concept.Turn]",
-					"[Status effects|Concept.StatusEffect] that have their effects grow weaker over several [turns|Concept.Turn] (e.g. [Goblin Poison|Skill+goblin_poison_effect]) are at their weakest state from the start."
+					"[Status effects|Concept.StatusEffect] that have their effects grow weaker over several [turns|Concept.Turn] (e.g. [Goblin Poison|Skill+goblin_poison_effect]) are at their weakest state from the start.",
+					"The effects of [Bleeding|Skill+bleeding_effect] are " + ::MSU.Text.colorPositive("halved") + "."
 				]
 			}]
 		})

--- a/mod_reforged/hooks/skills/effects/hyena_potion_effect.nut
+++ b/mod_reforged/hooks/skills/effects/hyena_potion_effect.nut
@@ -1,0 +1,21 @@
+::Reforged.HooksMod.hook("scripts/skills/effects/hyena_potion_effect", function(q) {
+	q.getTooltip = @(__original) function()
+	{
+		local ret = __original();
+		foreach (entry in ret)
+		{
+			if (entry.id == 11)
+			{
+				entry.text = ::Reforged.Mod.Tooltips.parseString("The effects of [Bleeding|Skill+bleeding_effect] are " + ::MSU.Text.colorPositive("halved"));
+				break;
+			}
+		}
+		return ret;
+	}
+
+	q.onUpdate = @(__original) function( _properties )
+	{
+		__original(_properties);
+		_properties.RF_BleedingEffectMult *= 0.5;
+	}
+});

--- a/mod_reforged/hooks/skills/perks/perk_hold_out.nut
+++ b/mod_reforged/hooks/skills/perks/perk_hold_out.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/skills/perks/perk_hold_out", function(q) {
+	q.onUpdate = @(__original) function( _properties )
+	{
+		__original(_properties);
+		_properties.RF_BleedingEffectMult *= 0.5;
+	}
+});

--- a/mod_reforged/hooks/skills/traits/bleeder_trait.nut
+++ b/mod_reforged/hooks/skills/traits/bleeder_trait.nut
@@ -5,6 +5,12 @@
 		this.m.Description = "This character is prone to bleeding and will do so more than most others."; // "more than" as opposed to vanilla "longer than"
 	}
 
+	q.onUpdate = @(__original) function( _properties )
+	{
+		__original(_properties);
+		_properties.RF_BleedingEffectMult *= 2.0;
+	}
+
 	q.getPerkGroupMultiplier = @() function( _groupID, _perkTree )
 	{
 		switch (_groupID)
@@ -21,7 +27,7 @@
 		{
 			if (entry.id == 10)
 			{
-				entry.text = ::Reforged.Mod.Tooltips.parseString("Will receive " + ::MSU.Text.colorNegative("double") + " damage from [Bleeding|Skill+bleeding_effect]");
+				entry.text = ::Reforged.Mod.Tooltips.parseString("The effects of [Bleeding|Skill+bleeding_effect] are " + ::MSU.Text.colorNegative("doubled"));
 				break;
 			}
 		}


### PR DESCRIPTION
- Add new character property `RF_BleedingEffectMult` that is a multiplier for damage from bleeding and maluses from bleeding. This includes the threshold for the number of stacks received in a single turn to trigger a morale check (by default 3).
  - Move the effects of Bleeder Trait and Hyena Potion into their respective files using this property.
- Resilient perk now multiplies this property by 0.5 i.e. the character receives half damage and half malus from bleeding and requires double the number of stacks for a morale check.
- Similarly, Bleeder now receives a morale check even upon receiving a single Bleed (floor(3 * 0.5) = 1). And Hyena Potion doubles it to 6. Someone with Bleeder + Resilient arrives at the base 3 stacks for morale check. Someone with Hyena Potion + Resilient will get to 12 stacks in a single turn in order to receive a morale check.