### PR TITLE
refactor: change hook to overwrite for function present in parent class

### DIFF
--- a/mod_reforged/hooks/items/accessory/wardog_item.nut
+++ b/mod_reforged/hooks/items/accessory/wardog_item.nut
@@ -5,7 +5,7 @@
 		this.m.StaminaModifier = -3;
 	}
 
-	q.getStaminaModifier <- function()
+	q.getStaminaModifier = @() function()
 	{
 		return this.isUnleashed() ? 0 : this.accessory.getStaminaModifier();
 	}

--- a/mod_reforged/hooks/items/accessory/warhound_item.nut
+++ b/mod_reforged/hooks/items/accessory/warhound_item.nut
@@ -5,7 +5,7 @@
 		this.m.StaminaModifier = -3;
 	}
 
-	q.getStaminaModifier <- function()
+	q.getStaminaModifier = @() function()
 	{
 		return this.isUnleashed() ? 0 : this.accessory.getStaminaModifier();
 	}

--- a/mod_reforged/hooks/items/accessory/wolf_item.nut
+++ b/mod_reforged/hooks/items/accessory/wolf_item.nut
@@ -5,7 +5,7 @@
 		this.m.StaminaModifier = -3;
 	}
 
-	q.getStaminaModifier <- function()
+	q.getStaminaModifier = @() function()
 	{
 		return this.isUnleashed() ? 0 : this.accessory.getStaminaModifier();
 	}

--- a/mod_reforged/hooks/items/tools/acid_flask_item.nut
+++ b/mod_reforged/hooks/items/tools/acid_flask_item.nut
@@ -5,7 +5,7 @@
 		this.m.Value = 275; // approximately 30% reduced from vanilla value of 400
 	}
 
-	q.onPutIntoBag <- function()
+	q.onPutIntoBag = @() function()
 	{
 		local skill = ::new("scripts/skills/actives/rf_sling_acid_flask_skill");
 		skill.setItem(this);

--- a/mod_reforged/hooks/items/tools/daze_bomb_item.nut
+++ b/mod_reforged/hooks/items/tools/daze_bomb_item.nut
@@ -5,7 +5,7 @@
 		this.m.Value = 350; // approximately 30% reduced from vanilla value of 500
 	}
 
-	q.onPutIntoBag <- function()
+	q.onPutIntoBag = @() function()
 	{
 		local skill = ::new("scripts/skills/actives/rf_sling_daze_bomb_skill");
 		skill.setItem(this);

--- a/mod_reforged/hooks/items/tools/faction_banner.nut
+++ b/mod_reforged/hooks/items/tools/faction_banner.nut
@@ -5,7 +5,7 @@
 		this.m.Reach = 6;
 	}
 
-	q.onCombatStarted <- function()
+	q.onCombatStarted = @() function()
 	{
 		foreach (ally in ::Tactical.Entities.getInstancesOfFaction(this.getContainer().getActor().getFaction()))
 		{

--- a/mod_reforged/hooks/items/tools/fire_bomb_item.nut
+++ b/mod_reforged/hooks/items/tools/fire_bomb_item.nut
@@ -5,7 +5,7 @@
 		this.m.Value = 420; // approximately 30% reduced from vanilla value of 600
 	}
 
-	q.onPutIntoBag <- function()
+	q.onPutIntoBag = @() function()
 	{
 		local skill = ::new("scripts/skills/actives/rf_sling_fire_bomb_skill");
 		skill.setItem(this);

--- a/mod_reforged/hooks/items/tools/holy_water_item.nut
+++ b/mod_reforged/hooks/items/tools/holy_water_item.nut
@@ -1,6 +1,6 @@
 
 ::Reforged.HooksMod.hook("scripts/items/tools/holy_water_item", function(q) {
-	q.onPutIntoBag <- function()
+	q.onPutIntoBag = @() function()
 	{
 		local skill = ::new("scripts/skills/actives/rf_sling_holy_water_skill");
 		skill.setItem(this);

--- a/mod_reforged/hooks/items/tools/smoke_bomb_item.nut
+++ b/mod_reforged/hooks/items/tools/smoke_bomb_item.nut
@@ -5,7 +5,7 @@
 		this.m.Value = 275; // approximately 30% reduced from vanilla value of 400
 	}
 
-	q.onPutIntoBag <- function()
+	q.onPutIntoBag = @() function()
 	{
 		local skill = ::new("scripts/skills/actives/rf_sling_smoke_bomb_skill");
 		skill.setItem(this);

--- a/mod_reforged/hooks/skills/actives/cascade_skill.nut
+++ b/mod_reforged/hooks/skills/actives/cascade_skill.nut
@@ -64,7 +64,7 @@
 	}
 
 	// Set IsUsingHitChance to true before target hit so that the Nimble perk works properly
-	q.onBeforeTargetHit <- function( _skill, _targetEntity, _hitInfo )
+	q.onBeforeTargetHit = @() function( _skill, _targetEntity, _hitInfo )
 	{
 		this.m.IsUsingHitchance = true;
 	}

--- a/mod_reforged/hooks/skills/actives/hail_skill.nut
+++ b/mod_reforged/hooks/skills/actives/hail_skill.nut
@@ -64,7 +64,7 @@
 	}
 
 	// Set IsUsingHitChance to true before target hit so that the Nimble perk works properly
-	q.onBeforeTargetHit <- function( _skill, _targetEntity, _hitInfo )
+	q.onBeforeTargetHit = @() function( _skill, _targetEntity, _hitInfo )
 	{
 		this.m.IsUsingHitchance = true;
 	}

--- a/mod_reforged/hooks/skills/actives/rally_the_troops.nut
+++ b/mod_reforged/hooks/skills/actives/rally_the_troops.nut
@@ -19,7 +19,7 @@
 		return __original() && this.m.TurnsRemaining == 0;
 	}
 
-	q.onTurnEnd <- function()
+	q.onTurnEnd = @() function()
 	{
 		this.m.TurnsRemaining = ::Math.max(0, this.m.TurnsRemaining - 1);
 	}

--- a/mod_reforged/hooks/skills/actives/root_skill.nut
+++ b/mod_reforged/hooks/skills/actives/root_skill.nut
@@ -34,12 +34,12 @@
 		return __original(_user, _targetTile);
 	}
 
-	q.isUsable <- function()
+	q.isUsable = @() function()
 	{
 		return this.skill.isUsable() && this.m.TurnsRemaining == 0;
 	}
 
-	q.onTurnEnd <- function()
+	q.onTurnEnd = @() function()
 	{
 		this.m.TurnsRemaining = ::Math.max(0, this.m.TurnsRemaining - 1);
 	}

--- a/mod_reforged/hooks/skills/actives/shieldwall.nut
+++ b/mod_reforged/hooks/skills/actives/shieldwall.nut
@@ -33,13 +33,13 @@
 		}
 	}
 
-	q.onTurnStart <- function()
+	q.onTurnStart = @() function()
 	{
 		// Part of perk_rf_shield_sergeant functionality
 		this.RF_checkForShieldSergeant();
 	}
 
-	q.onTurnEnd <- function()
+	q.onTurnEnd = @() function()
 	{
 		// Part of perk_rf_shield_sergeant functionality
 		this.RF_checkForShieldSergeant();

--- a/mod_reforged/hooks/skills/actives/uproot_zoc_skill.nut
+++ b/mod_reforged/hooks/skills/actives/uproot_zoc_skill.nut
@@ -33,7 +33,7 @@
 		return ret;
 	}
 
-	q.onTargetHit <- function( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
+	q.onTargetHit = @() function( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
 	{
 		if (_skill == this && _targetEntity.isAlive() && _targetEntity.getType() != ::Const.EntityType.Schrat && _targetEntity.getType() != ::Const.EntityType.SchratSmall)
 		{

--- a/mod_reforged/hooks/skills/backgrounds/hedge_knight_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/hedge_knight_background.nut
@@ -70,7 +70,7 @@
 		return ret;
 	}
 
-	q.onBuildPerkTree <- function()
+	q.onBuildPerkTree = @() function()
 	{
 		local perkTree = this.getContainer().getActor().getPerkTree();
 		if (perkTree.hasPerk("perk.lone_wolf"))

--- a/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/swordmaster_background.nut
@@ -94,7 +94,7 @@
 		return __original();
 	}
 
-	q.onBuildPerkTree <- function()
+	q.onBuildPerkTree = @() function()
 	{
 		local perkTree = this.getContainer().getActor().getPerkTree();
 		if (perkTree.hasPerk("perk.rf_professional"))

--- a/mod_reforged/hooks/skills/effects/berserker_rage_effect.nut
+++ b/mod_reforged/hooks/skills/effects/berserker_rage_effect.nut
@@ -10,7 +10,7 @@
 		return this.skill.getDescription();
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([

--- a/mod_reforged/hooks/skills/effects/bleeding_effect.nut
+++ b/mod_reforged/hooks/skills/effects/bleeding_effect.nut
@@ -14,7 +14,7 @@
 		this.m.IsStacking = false;
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.push({
@@ -59,7 +59,7 @@
 		return ret;
 	}
 
-	q.getName <- function()
+	q.getName = @() function()
 	{
 		return this.m.Stacks == 1 ? this.m.Name : this.m.Name + " (x" + this.m.Stacks + ")";
 	}
@@ -141,7 +141,7 @@
 		this.m.SkillCount = ::Const.SkillCounter;
 	}
 
-	q.onRefresh <- function()
+	q.onRefresh = @() function()
 	{
 		local actor = this.getContainer().getActor();
 		if (actor.getCurrentProperties().IsResistantToAnyStatuses && ::Math.rand(1, 100) <= 50)
@@ -175,7 +175,7 @@
 			actor.checkMorale(-1, ::Const.Morale.OnHitBaseDifficulty * (1.0 - actor.getHitpoints() / actor.getHitpointsMax()));
 	}
 
-	q.onTurnStart <- function()
+	q.onTurnStart = @() function()
 	{
 		this.m.StacksThisTurn = 0;
 	}

--- a/mod_reforged/hooks/skills/effects/possessed_undead_effect.nut
+++ b/mod_reforged/hooks/skills/effects/possessed_undead_effect.nut
@@ -5,7 +5,7 @@
 		this.m.Description = ::Reforged.Mod.Tooltips.parseString("This character is possessed until the end of their [turn.|Concept.Turn]")
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([

--- a/mod_reforged/hooks/skills/perks/perk_anticipation.nut
+++ b/mod_reforged/hooks/skills/perks/perk_anticipation.nut
@@ -20,22 +20,22 @@
 		this.addType(::Const.SkillType.StatusEffect);	// We now want this effect to show up on entities
 	}
 
-	q.isHidden <- function()
+	q.isHidden = @() function()
 	{
 		return (this.isEnabled() == false);
 	}
 
-	q.onCombatStarted <- function()
+	q.onCombatStarted = @() function()
 	{
 		this.m.UsesRemaining = this.m.UsesMax;
 	}
 
-	q.onCombatFinished <- function()
+	q.onCombatFinished = @() function()
 	{
 		this.m.UsesRemaining = this.m.UsesMax;	// So that for the purposes of the tooltip everything looks good
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 
@@ -64,7 +64,7 @@
 		return ret;
 	}
 
-	q.onBeforeDamageReceived <- function( _attacker, _skill, _hitinfo, _properties )
+	q.onBeforeDamageReceived = @() function( _attacker, _skill, _hitinfo, _properties )
 	{
 		if (!this.isEnabled() || _skill == null || !_skill.isAttack())		// _skill can be null, for example when burning damage is applied
 		{
@@ -78,7 +78,7 @@
 		this.m.IsAboutToConsumeUse = true;	// We need this variable because in "onDamageReceived" we have no information whether that was caused by an "attack"
 	}
 
-	q.onDamageReceived <- function( _attacker, _damageHitpoints, _damageArmor )
+	q.onDamageReceived = @() function( _attacker, _damageHitpoints, _damageArmor )
 	{
 		if (this.m.IsAboutToConsumeUse == false) return;	// We only consume one use for each registered attack. But a single attack that deals damage multiple times will therefor have the damage of all instances reduced
 		this.m.IsAboutToConsumeUse = false;

--- a/mod_reforged/hooks/skills/perks/perk_battle_forged.nut
+++ b/mod_reforged/hooks/skills/perks/perk_battle_forged.nut
@@ -15,7 +15,7 @@
 		return ret;
 	}
 
-	q.onAnySkillUsed <- function( _skill, _targetEntity, _properties )
+	q.onAnySkillUsed = @() function( _skill, _targetEntity, _properties )
 	{
 		if (_targetEntity != null && _skill.isAttack() && !_skill.isRanged())
 		{

--- a/mod_reforged/hooks/skills/perks/perk_dodge.nut
+++ b/mod_reforged/hooks/skills/perks/perk_dodge.nut
@@ -1,7 +1,7 @@
 ::Reforged.HooksMod.hook("scripts/skills/perks/perk_dodge", function(q) {
 	// Add dodge in onAdded instead of onCombatStarted so that its effect
 	// is applied and is visible even on the world map
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		this.getContainer().add(::new("scripts/skills/effects/dodge_effect"));
 	}

--- a/mod_reforged/hooks/skills/perks/perk_fast_adaption.nut
+++ b/mod_reforged/hooks/skills/perks/perk_fast_adaption.nut
@@ -1,5 +1,5 @@
 ::Reforged.HooksMod.hook("scripts/skills/perks/perk_fast_adaption", function(q) {
-	q.onGetHitFactors <- function( _skill, _targetTile, _tooltip )
+	q.onGetHitFactors = @() function( _skill, _targetTile, _tooltip )
 	{
 		if (_skill.isAttack() && this.m.Stacks != 0)
 		{

--- a/mod_reforged/hooks/skills/perks/perk_inspiring_presence.nut
+++ b/mod_reforged/hooks/skills/perks/perk_inspiring_presence.nut
@@ -10,12 +10,12 @@
 		this.m.IconMini = "perk_rf_inspiring_presence_mini";
 	}
 
-	q.isHidden <- function()
+	q.isHidden = @() function()
 	{
 		return !this.isEnabled();
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.push({

--- a/mod_reforged/hooks/skills/perks/perk_mastery_axe.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_axe.nut
@@ -1,11 +1,11 @@
 ::Reforged.HooksMod.hook("scripts/skills/perks/perk_mastery_axe", function(q) {
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local weapon = this.getContainer().getActor().getMainhandItem();
 		if (weapon != null) this.onEquip(weapon);
 	}
 
-	q.onEquip <- function( _item )
+	q.onEquip = @() function( _item )
 	{
 		if (_item.isItemType(::Const.Items.ItemType.Weapon) && _item.isWeaponType(::Const.Items.WeaponType.Axe))
 		{

--- a/mod_reforged/hooks/skills/perks/perk_mastery_bow.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_bow.nut
@@ -6,7 +6,7 @@
 		if (weapon != null) this.onEquip(weapon);
 	}
 
-	q.onEquip <- function( _item )
+	q.onEquip = @() function( _item )
 	{
 		if (_item.isItemType(::Const.Items.ItemType.Weapon) && _item.isWeaponType(::Const.Items.WeaponType.Bow))
 		{

--- a/mod_reforged/hooks/skills/perks/perk_mastery_crossbow.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_crossbow.nut
@@ -11,7 +11,7 @@
 		this.getContainer().removeByID("actives.rf_take_aim");
 	}
 
-	q.onAfterUpdate <- function( _properties )
+	q.onAfterUpdate = @() function( _properties )
 	{
 		local reload = this.getContainer().getSkillByID("actives.reload_bolt");
 		if (reload != null && reload.m.ActionPointCost > 4 && reload.getBaseValue("ActionPointCost") > 4)

--- a/mod_reforged/hooks/skills/perks/perk_nimble.nut
+++ b/mod_reforged/hooks/skills/perks/perk_nimble.nut
@@ -94,7 +94,7 @@
 		_properties.DamageReceivedArmorMult *= this.getArmorDamage();
 	}
 
-	q.onAnySkillUsed <- function( _skill, _targetEntity, _properties )
+	q.onAnySkillUsed = @() function( _skill, _targetEntity, _properties )
 	{
 		if (!this.isHidden() && _targetEntity != null && _skill.isAttack() && !_skill.isRanged() && _targetEntity.getInitiative() < this.getContainer().getActor().getInitiative())
 		{

--- a/mod_reforged/hooks/skills/perks/perk_nine_lives.nut
+++ b/mod_reforged/hooks/skills/perks/perk_nine_lives.nut
@@ -13,7 +13,7 @@
 	}
 
 	// Nine lives now shows up as an effect while available. Therefore we give it a custom more detailed description
-	q.getDescription <- function()
+	q.getDescription = @() function()
 	{
 		return ::Reforged.Mod.Tooltips.parseString("Upon receiving the next killing blow, this character will survive with " + ::MSU.Text.colorPositive(this.m.MinHP + "-" + this.m.MaxHP) + " [Hitpoints|Concept.Hitpoints], all damage over time [effects|Concept.StatusEffect] wil be removed, and [Melee Skill,|Concept.MeleeSkill] [Melee Defense,|Concept.MeleeDefense] [Resolve|Concept.Bravery] and [Initiative|Concept.Initiative] will be increased until the start of their next [turn.|Concept.Turn]");
 	}

--- a/mod_reforged/hooks/skills/perks/perk_shield_expert.nut
+++ b/mod_reforged/hooks/skills/perks/perk_shield_expert.nut
@@ -8,7 +8,7 @@
 		if (shield != null) this.onEquip(shield);
 	}
 
-	q.onEquip <- function( _item )
+	q.onEquip = @() function( _item )
 	{
 		if (_item.isItemType(::Const.Items.ItemType.Shield) && _item.getID().find("buckler") == null)
 		{
@@ -18,7 +18,7 @@
 
 	// This is called via skill_container.buildPropertiesForDefense
 	// If the attack misses, we will recover the character's fatigue back to this value
-	q.onBeingAttacked <- function( _attacker, _skill, _properties )
+	q.onBeingAttacked = @() function( _attacker, _skill, _properties )
 	{
 		this.m.FatigueBeforeMiss = this.getContainer().getActor().getFatigue();
 	}
@@ -28,7 +28,7 @@
 	// actor.onMissed. So instead of that, this recover system is cleaner for now.
 	// If MSU adds another character property `FatigueLossOnBeingMissed` and hooks actor.onMissed
 	// to incorporate that then we can use that for a more accurate solution.
-	q.onMissed <- function( _attacker, _skill )
+	q.onMissed = @() function( _attacker, _skill )
 	{
 		local actor = this.getContainer().getActor();
 		if (actor.getFatigue() > this.m.FatigueBeforeMiss)

--- a/mod_reforged/hooks/skills/racial/alp_racial.nut
+++ b/mod_reforged/hooks/skills/racial/alp_racial.nut
@@ -7,7 +7,7 @@
 		this.m.IsHidden = false;
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([
@@ -75,7 +75,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();
 

--- a/mod_reforged/hooks/skills/racial/champion_racial.nut
+++ b/mod_reforged/hooks/skills/racial/champion_racial.nut
@@ -1,5 +1,5 @@
 ::Reforged.HooksMod.hook("scripts/skills/racial/champion_racial", function(q) {
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([

--- a/mod_reforged/hooks/skills/racial/ghost_racial.nut
+++ b/mod_reforged/hooks/skills/racial/ghost_racial.nut
@@ -9,7 +9,7 @@
 			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([
@@ -84,7 +84,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local actor = this.getContainer().getActor();
 		actor.m.MoraleState = ::Const.MoraleState.Ignore;

--- a/mod_reforged/hooks/skills/racial/golem_racial.nut
+++ b/mod_reforged/hooks/skills/racial/golem_racial.nut
@@ -89,7 +89,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local actor = this.getContainer().getActor();
 		actor.m.MoraleState = ::Const.MoraleState.Ignore;

--- a/mod_reforged/hooks/skills/racial/lindwurm_racial.nut
+++ b/mod_reforged/hooks/skills/racial/lindwurm_racial.nut
@@ -11,7 +11,7 @@
 			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([
@@ -55,7 +55,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();
 

--- a/mod_reforged/hooks/skills/racial/schrat_racial.nut
+++ b/mod_reforged/hooks/skills/racial/schrat_racial.nut
@@ -12,13 +12,13 @@
 		return this.skill.isHidden();
 	}
 
-	q.getName <- function()
+	q.getName = @() function()
 	{
 		if (this.getContainer().getActor().isArmedWithShield()) return (this.skill.getName() + " (Shielded)");
 		return this.skill.getName();
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([
@@ -101,7 +101,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();
 

--- a/mod_reforged/hooks/skills/racial/serpent_racial.nut
+++ b/mod_reforged/hooks/skills/racial/serpent_racial.nut
@@ -9,7 +9,7 @@
 			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([
@@ -41,7 +41,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();
 

--- a/mod_reforged/hooks/skills/racial/skeleton_racial.nut
+++ b/mod_reforged/hooks/skills/racial/skeleton_racial.nut
@@ -9,7 +9,7 @@
 			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([
@@ -66,7 +66,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local actor = this.getContainer().getActor();
 		actor.m.MoraleState = ::Const.MoraleState.Ignore;

--- a/mod_reforged/hooks/skills/racial/spider_racial.nut
+++ b/mod_reforged/hooks/skills/racial/spider_racial.nut
@@ -11,7 +11,7 @@
 			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([
@@ -49,7 +49,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local baseProperties = this.getContainer().getActor().getBaseProperties();
 

--- a/mod_reforged/hooks/skills/racial/unhold_racial.nut
+++ b/mod_reforged/hooks/skills/racial/unhold_racial.nut
@@ -8,7 +8,7 @@
 		this.addType(::Const.SkillType.StatusEffect);	// We now want this effect to show up on the enemies
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.push({
@@ -48,7 +48,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local actor = this.getContainer().getActor();
 		local baseProperties = actor.getBaseProperties();

--- a/mod_reforged/hooks/skills/racial/vampire_racial.nut
+++ b/mod_reforged/hooks/skills/racial/vampire_racial.nut
@@ -13,7 +13,7 @@
 			this.removeType(::Const.SkillType.Perk);	// This effect having the type 'Perk' serves no purpose and only causes issues in modding
 	}
 
-	q.getTooltip <- function()
+	q.getTooltip = @() function()
 	{
 		local ret = this.skill.getTooltip();
 		ret.extend([
@@ -51,7 +51,7 @@
 		return ret;
 	}
 
-	q.onAdded <- function()
+	q.onAdded = @() function()
 	{
 		local actor = this.getContainer().getActor();
 		actor.m.MoraleState = ::Const.MoraleState.Ignore;

--- a/mod_reforged/hooks/skills/special/double_grip.nut
+++ b/mod_reforged/hooks/skills/special/double_grip.nut
@@ -61,7 +61,7 @@
 		return offhand.getStaminaModifier() > -10 && weapon.isItemType(::Const.Items.ItemType.RF_Southern) && weapon.isWeaponType(::Const.Items.WeaponType.Sword) && this.getContainer().hasSkill("perk.rf_en_garde");
 	}
 
-	q.applyBonusOnUpdate <- function( _properties )
+	q.applyBonusonUpdate = @() function( _properties )
 	{
 		switch (this.m.CurrWeaponType)
 		{


### PR DESCRIPTION
Basically a function that is present in a class or its parent should be overwritten in Modern Hooks using the `= @()` style instead of by adding the function to the child class via `<-`. This PR replaces all such instances of new slots with overwrite style hook.