### PR TITLE
refactor: show neutral towns in relation screen with recent changes

### DIFF
--- a/mod_reforged/hooks/factions/faction.nut
+++ b/mod_reforged/hooks/factions/faction.nut
@@ -1,0 +1,7 @@
+::Reforged.HooksMod.hook("scripts/factions/faction", function (q) {
+	// Overwrite, because we only want to hide certain settlements at 50 relation, if they didn't have a recent relationship change with the player
+	q.isHidden = @() function()
+	{
+		return this.m.IsHidden || (this.m.IsHiddenIfNeutral && this.m.PlayerRelation == 50 && this.m.PlayerRelationChanges.len() == 0);
+	}
+});


### PR DESCRIPTION
Vanilla decided to not display all factions at all times in your relation screen. Probably because that would be too much scrolling.
Civilian factions (every non-military settlement comes with its own one) are hidden, if you have exactly 50 relation with them (which is the default/neutral)

In some situations however this can be confusing:
- If you completed a contract with a settlement that you previously had 40 relation with, it will now bow at 50 relation and no longer show up in the relation screen. When to try to see how that contract impacted your relation you wont be able to see it
- Same it true for when one of your actions reduced the relation of a settlement down to exactly 50

With this change neutral village factions now always show in the relation ship screen if their relation ship changed with you in the last 10 days (not counting decay).
Or in other words: If they have a relationship change entry with a flavor description, then they will not be hidden.

Like for example in this screenshot (using the fix)
![image](https://github.com/user-attachments/assets/3e2749d7-46ad-42e9-924a-3e31e1201a60)

In the same playthrough I also have other villages with 50 relationship but which dont appear in the relationship screen. That does check out because I probably havent done anything for them in the last 10 days.