### PR TITLE
refactor: mention zombie ability to resurrect slain humans as zombies

### DIFF
--- a/scripts/skills/racial/rf_zombie_racial.nut
+++ b/scripts/skills/racial/rf_zombie_racial.nut
@@ -47,6 +47,13 @@ this.rf_zombie_racial <- ::inherit("scripts/skills/skill", {
 			});
 		}
 
+		ret.push({
+			id = 12,
+			type = "text",
+			icon = "ui/orientation/zombie_01_orientation.png",
+			text = "Humans killed by you will rise as Wiedergangers after some time",	// This is implemented in onActorKilled of zombie.nut
+		});
+
 		ret.extend([
 			{
 				id = 20,

--- a/scripts/skills/racial/rf_zombie_racial.nut
+++ b/scripts/skills/racial/rf_zombie_racial.nut
@@ -23,7 +23,7 @@ this.rf_zombie_racial <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/fatigue.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Builds no [Fatigue|Concept.Fatigue]")
+				text = ::Reforged.Mod.Tooltips.parseString("Build no [Fatigue|Concept.Fatigue]")
 			});
 		}
 		else if (this.m.FatigueEffectMult != 1.0)
@@ -43,7 +43,7 @@ this.rf_zombie_racial <- ::inherit("scripts/skills/skill", {
 				id = 11,
 				type = "text",
 				icon = "ui/icons/fatigue.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Inflicts " + ::MSU.Text.color(::Const.UI.Color.DamageValue, bonusFatiguePerHit) + " extra [Fatigue|Concept.Fatigue] on a hit")
+				text = ::Reforged.Mod.Tooltips.parseString("Inflict " + ::MSU.Text.color(::Const.UI.Color.DamageValue, bonusFatiguePerHit) + " extra [Fatigue|Concept.Fatigue] on a hit")
 			});
 		}
 


### PR DESCRIPTION
Zombie have an undocumented ability, build in their `zombie.nut` script (therefor affecting everything inheriting this), which causes 
- any humans and any player characters slain (last hitted) by them to resurrect in 2 - 3 turns
- this only affects those that actually can be resurrected
  - struck down players wont resurrect
  - headless characters will also not resurrect this way
  
This PR will mention this effect in the zombie_racial. Although it might happen that at some point an enemy receives the `zombie_racial`, but isnt inheriting from `zombie.nut`. Then we have to revisit this built-in effect

Here the tooltip how it looks now (after first adjustment)
![image](https://github.com/user-attachments/assets/6f54e123-b209-4a20-aac9-b536da01c966)