### PR TITLE
fix: expansion of the vanilla LevelXP array

### DIFF
--- a/mod_reforged/hooks/entity/tactical/player.nut
+++ b/mod_reforged/hooks/entity/tactical/player.nut
@@ -14,6 +14,10 @@
 		this.getSkills().add(::new("scripts/skills/effects/rf_encumbrance_effect"));
 		this.getSkills().add(::new("scripts/skills/special/rf_veteran_levels"));
 		this.getSkills().add(::new("scripts/skills/special/rf_naked"));
+
+		// +2 because we want to expand the array at least 1 level above this bro so that player.getXPForNextLevel works properly.
+		// We do this in onInit in so that when loading a game or spawning a player with high enough level, the array is expanded immediately.
+		::Reforged.expandLevelXP(this.m.Level + 2);
 	}
 
 	q.addXP = @(__original) function( _xp, _scale = true )
@@ -21,10 +25,8 @@
 		if (::Reforged.Config.XPOverride)
 			return;
 
-		while (this.m.Level >= ::Const.LevelXP.len())
-		{
-			::Const.LevelXP.push(::Const.LevelXP.top() + 4000 + 1000 * (::Const.LevelXP.len() - 11));
-		}
+		// +2 because we want to expand the array at least 1 level above this bro so that player.getXPForNextLevel works properly
+		::Reforged.expandLevelXP(this.m.Level + 2);
 
 		// Temporary buff to vanilla drill sergeant until our Retinue Rework
 		if (("State" in ::World) && ::World.State != null && _scale && ::World.Retinue.hasFollower("follower.drill_sergeant"))

--- a/mod_reforged/hooks/misc.nut
+++ b/mod_reforged/hooks/misc.nut
@@ -28,3 +28,13 @@
 	}
 	return ret;
 }
+
+// Expands the vanilla ::Const.LevelXP array to allow leveling characters beyond the vanilla max of 33
+// is called from player.addXP and player.onInit so the array is dynamically expanded when needed
+::Reforged.expandLevelXP <- function( _len )
+{
+	while (::Const.LevelXP.len() < _len)
+	{
+		::Const.LevelXP.push(::Const.LevelXP.top() + 4000 + 1000 * (::Const.LevelXP.len() - 11));
+	}
+}


### PR DESCRIPTION
- Expand the array at least 1 level above the current character's level so that the player.getXPForNextLevel function works properly.
- Expand the array as necessary upon loading a saved game or spawning a player with a high enough level.