### PR TITLE
feat: prevent ai from swapping to ranged when near melee opponents

### DIFF
--- a/mod_reforged/hooks/ai/tactical/behaviors/ai_switchto_ranged.nut
+++ b/mod_reforged/hooks/ai/tactical/behaviors/ai_switchto_ranged.nut
@@ -6,7 +6,6 @@
 		this.m.WeaponToEquip = null;
 
 		local myTile = _entity.getTile();
-		local switchMaxDangerDist = ::Math.max(_entity.getIdealRange(), ::Const.AI.Behavior.SwitchToRangedMaxDangerDist);
 
 		foreach (enemy in this.getAgent().getKnownOpponents())
 		{
@@ -15,13 +14,12 @@
 				continue;
 			}
 
-			if (enemy.Actor.getTile().getZoneOfControlCountOtherThan(enemy.Actor.getAlliedFactions()) >= ::Const.AI.Behavior.SwitchToRangedIgnoreDangerMinZones)
+			if (myTile.getDistanceTo(enemy.Tile) > ::Math.max(_entity.getIdealRange(), ::Const.AI.Behavior.SwitchToRangedMaxDangerDist))
 			{
 				continue;
 			}
 
-			local dist = myTile.getDistanceTo(enemy.Tile);
-			if (dist > switchMaxDangerDist)
+			if (enemy.Tile.getZoneOfControlCountOtherThan(enemy.Actor.getAlliedFactions()) >= ::Const.AI.Behavior.SwitchToRangedIgnoreDangerMinZones)
 			{
 				continue;
 			}

--- a/mod_reforged/hooks/ai/tactical/behaviors/ai_switchto_ranged.nut
+++ b/mod_reforged/hooks/ai/tactical/behaviors/ai_switchto_ranged.nut
@@ -10,7 +10,7 @@
 
 		foreach (enemy in this.getAgent().getKnownOpponents())
 		{
-			if (::MSU.isNull(enemy) || enemy.Actor.getMoraleState() == ::Const.MoraleState.Fleeing || enemy.Actor.isArmedWithRangedWeapon())
+			if (::MSU.isNull(enemy.Actor) || enemy.Actor.getMoraleState() == ::Const.MoraleState.Fleeing || enemy.Actor.isArmedWithRangedWeapon())
 			{
 				continue;
 			}

--- a/mod_reforged/hooks/ai/tactical/behaviors/ai_switchto_ranged.nut
+++ b/mod_reforged/hooks/ai/tactical/behaviors/ai_switchto_ranged.nut
@@ -1,0 +1,38 @@
+::Reforged.HooksMod.hook("scripts/ai/tactical/behaviors/ai_switchto_ranged", function(q) {
+	// Prevent AI from swapping to ranged weapon when close to enemy melee units
+	// because dropping your Reach is a bad idea in this case
+	q.onEvaluate = @(__original) function( _entity )
+	{
+		this.m.WeaponToEquip = null;
+
+		local myTile = _entity.getTile();
+		local switchMaxDangerDist = ::Math.max(_entity.getIdealRange(), ::Const.AI.Behavior.SwitchToRangedMaxDangerDist);
+
+		foreach (enemy in this.getAgent().getKnownOpponents())
+		{
+			if (::MSU.isNull(enemy) || enemy.Actor.getMoraleState() == ::Const.MoraleState.Fleeing || enemy.Actor.isArmedWithRangedWeapon())
+			{
+				continue;
+			}
+
+			if (enemy.Actor.getTile().getZoneOfControlCountOtherThan(enemy.Actor.getAlliedFactions()) >= ::Const.AI.Behavior.SwitchToRangedIgnoreDangerMinZones)
+			{
+				continue;
+			}
+
+			local dist = myTile.getDistanceTo(enemy.Tile);
+			if (dist > switchMaxDangerDist)
+			{
+				continue;
+			}
+
+			// If an enemy can reach us in 1 turn, don't swap to a ranged weapon
+			if (this.queryActorTurnsNearTarget(enemy.Actor, myTile, _entity).Turns <= 1)
+			{
+				return ::Const.AI.Behavior.Score.Zero;
+			}
+		}
+
+		return __original(_entity);
+	}
+});


### PR DESCRIPTION
Because it is a bad idea to lose your Reach when melee opponents can move to you and attack you.

I tested this in game and it works nicely. Enemies that ended their turn in a spot where I could reach them in 1 turn didn't swap to throwing weapons, but enemies which stayed behind them swapped properly.