### PR TITLE
fix: damage type becoming null for between the eyes and deep impact

### DIFF
--- a/scripts/skills/actives/rf_between_the_eyes_skill.nut
+++ b/scripts/skills/actives/rf_between_the_eyes_skill.nut
@@ -88,7 +88,6 @@ this.rf_between_the_eyes_skill <- ::inherit("scripts/skills/skill", {
 		local aoo = this.getContainer().getAttackOfOpportunity();
 		if (aoo != null)
 		{
-			this.m.DamageType = aoo.getDamageType().weakref();
 			this.m.ActionPointCost += aoo.m.ActionPointCost;
 			this.m.FatigueCost += aoo.m.FatigueCost;
 			this.m.FatigueCostMult = aoo.m.FatigueCostMult;
@@ -97,10 +96,14 @@ this.rf_between_the_eyes_skill <- ::inherit("scripts/skills/skill", {
 			this.m.MaxRange = aoo.m.MaxRange;
 			this.m.IsShieldRelevant = aoo.m.IsShieldRelevant;
 		}
-		else
-		{
-			this.m.DamageType = null;
-		}
+	}
+
+	// MSU function
+	// overwrite to return AOO damage type instead of our own
+	function getDamageType()
+	{
+		local aoo = this.getContainer().getAttackOfOpportunity();
+		return aoo == null ? this.skill.getDamageType() : aoo.getDamageType();
 	}
 
 	function isUsable()

--- a/scripts/skills/actives/rf_deep_impact_skill.nut
+++ b/scripts/skills/actives/rf_deep_impact_skill.nut
@@ -78,16 +78,19 @@ this.rf_deep_impact_skill <- ::inherit("scripts/skills/skill", {
 		local aoo = this.getContainer().getAttackOfOpportunity();
 		if (aoo != null && this.isSkillValid(aoo))
 		{
-			this.m.DamageType = aoo.getDamageType().weakref();
 			this.m.ActionPointCost = aoo.m.ActionPointCost;
 			this.m.FatigueCostMult = aoo.m.FatigueCostMult;
 			this.m.MinRange = aoo.m.MinRange;
 			this.m.MaxRange = aoo.m.MaxRange;
 		}
-		else
-		{
-			this.m.DamageType = null;
-		}
+	}
+
+	// MSU function
+	// overwrite to return AOO damage type instead of our own
+	function getDamageType()
+	{
+		local aoo = this.getContainer().getAttackOfOpportunity();
+		return aoo != null && this.isSkillValid(aoo) ? aoo.getDamageType() : this.skill.getDamageType();
 	}
 
 	function isUsable()


### PR DESCRIPTION
The MSU-added DamageType for skills is never meant or expected to be null. Setting it to null creates issues within other perks or skills which try to access the damage type of skills, never expecting it to return null.

Related bug report on Discord: https://discord.com/channels/1006908336991645757/1283857645492502549/1366492777369702512