### PR TITLE
feat: use fixed seed for location terrain

### DIFF
--- a/mod_reforged/hooks/states/tactical_state.nut
+++ b/mod_reforged/hooks/states/tactical_state.nut
@@ -1,4 +1,28 @@
 ::Reforged.HooksMod.hook("scripts/states/tactical_state", function(q) {
+	q.initMap = @(__original) function()
+	{
+		// Feat: the same location will always produce the exact same layout
+		// This has no influence over troop spawning as those will be seeded by "combatSeed" later on
+		// Our seeding always happens first. If vanilla then chooses to use their own fixed seed, they will replace our attempt
+		foreach (party in this.m.StrategicProperties.Parties)
+		{
+			if (party.isLocation())
+			{
+				::Reforged.Math.seedRandom(
+					"RF_FixedLocationSeed",		// Fixed salt, specific to use-case
+					party.getTypeID(),			// Location specific salt
+					party.getName(),			// Location specific salt
+					party.getFaction(),			// Faction specific salt
+					party.getTile().X * 200,	// Position specific salt
+					party.getTile().Y			// Position specific salt
+				);
+				break;
+			}
+		}
+
+		__original();
+	}
+
 	q.showRetreatScreen = @(__original) function ( _tag = null )
 	{
 		this.m.TacticalScreen.getTopbarOptionsModule().changeFleeButtonToWin();


### PR DESCRIPTION
### Upside
- Prevents cheese of reloading autosaves in hopes for better terrain
- Prevents fleeing from battle when terrain is bad (mostly against hill locations)
- Introduces more realism/persistance into the world. Terrain doesnt magically change from one moment to the next
- Introduces option to scout location before sending everyone inside

### Potential Downside
- The option to scout locations might become required and unfun busywork if you want to play optimal
  - Can screenshot starting area to then 
    - position full squad perfectly in the real fight
    - visit the location much later into the campaign
- In some rare situation a location might come with an unbeatably hard terrain, bricking it effectively


All-in-All I'm all for trying this out.
Maybe we can discourage the need for scouting a location with other means down the line