### PR TITLE
balance: require surrounded enemy for ghostlike damage buff on movement

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1398,7 +1398,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Type = ::UPD.EffectType.Passive,
 			Description = [
 				"When the number of adjacent allies is greater than or equal to the number of adjacent enemies, you may ignore [Zone of Control|Concept.ZoneOfControl] for your next movement action."
-				"When wielding a melee weapon with up to 4 [Reach|Concept.Reach] when you end your movement adjacent to an enemy, the next attack against that enemy deals " + ::MSU.Text.colorPositive("25%") + " more damage and " + ::MSU.Text.colorPositive("+20%") + " damage ignoring armor. This bonus expires upon taking any action other than an attack."
+				"When wielding a melee weapon with up to 4 [Reach|Concept.Reach] when you end your movement next to a [surrounded|Concept.Surrounding] enemy, the next attack against that enemy deals " + ::MSU.Text.colorPositive("25%") + " more damage and " + ::MSU.Text.colorPositive("+20%") + " damage ignoring armor. This bonus expires upon taking any action other than an attack."
 			]
 		}]
 	}),

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1398,7 +1398,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Type = ::UPD.EffectType.Passive,
 			Description = [
 				"When the number of adjacent allies is greater than or equal to the number of adjacent enemies, you may ignore [Zone of Control|Concept.ZoneOfControl] for your next movement action."
-				"When wielding a melee weapon with up to 4 [Reach|Concept.Reach] when you end your movement next to a [surrounded|Concept.Surrounding] enemy, the next attack against that enemy deals " + ::MSU.Text.colorPositive("25%") + " more damage and " + ::MSU.Text.colorPositive("+20%") + " damage ignoring armor. This bonus expires upon taking any action other than an attack."
+				"When wielding a melee weapon with up to 4 [Reach|Concept.Reach] and ending your movement next to a [surrounded|Concept.Surrounding] enemy, the next attack against that enemy deals " + ::MSU.Text.colorPositive("25%") + " more damage and " + ::MSU.Text.colorPositive("+20%") + " damage ignoring armor. This bonus expires upon taking any action other than an attack."
 			]
 		}]
 	}),

--- a/scripts/skills/perks/perk_rf_ghostlike.nut
+++ b/scripts/skills/perks/perk_rf_ghostlike.nut
@@ -134,7 +134,7 @@ this.perk_rf_ghostlike <- ::inherit("scripts/skills/skill", {
 
 		foreach (tile in ::MSU.Tile.getNeighbors(this.getContainer().getActor().getTile()))
 		{
-			if (tile.IsOccupiedByActor && !tile.getEntity().isAlliedWith(this.getContainer().getActor()))
+			if (tile.IsOccupiedByActor && !tile.getEntity().isAlliedWith(this.getContainer().getActor()) && tile.getEntity().getSurroundedCount() != 0)
 			{
 				this.m.Enemies.push(tile.getEntity().getID());
 			}


### PR DESCRIPTION
Currently, Ghostlike allows you to enter the ZoC of an enemy and simply get a huge damage boost on your first attack. This doesn't seem good. This PR makes it so that you only get the buff when entering the ZoC of an enemy who is surrounded i.e. is in the ZoC of at least one other enemy. This will also now interact with perks that change the surrounding count of a character e.g. Phalanx which ignores the surrounding from x enemies, and I think that is neat.