### PR TITLE
feat: rework battle fervor to gain stack at turn start with morale check

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -900,6 +900,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 			Type = ::UPD.EffectType.Passive,
 			Description = [
 				"Receive a [morale check|Concept.Morale] at the start of every [turn|Concept.Turn] if you are [Confident.|Concept.Morale] and if successful, gain a stack. For each stack, [Resolve,|Concept.Bravery] [Melee Skill,|Concept.MeleeSkill] [Ranged Skill,|Concept.RangeSkill] [Melee Defense|Concept.MeleeDefense] and [Ranged Defense|Concept.RangeDefense] are increased by " + ::MSU.Text.colorPositive("5%") + ".",
+				"Lose " + ::MSU.Text.colorNegative(1) + " stack upon ending a [turn|Concept.Turn] without having attacked.",
 				"Cannot have more than 4 stacks."
 			]
 		}]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -899,7 +899,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Receive a [morale check|Concept.Morale] at the start of every [turn|Concept.Turn] if you are [Confident.|Concept.Morale] and if successful, gain a stack. For each stack, [Resolve,|Concept.Bravery] [Melee Skill,|Concept.MeleeSkill] [Ranged Skill,|Concept.RangeSkill] [Melee Defense|Concept.MeleeDefense] and [Ranged Defense|Concept.RangeDefense] are increased by " + ::MSU.Text.colorPositive("5%") + ".",
+				"Receive a [morale check|Concept.Morale] at the start of every [turn|Concept.Turn] if you are [Confident|Concept.Morale] and if successful, gain a stack. For each stack, [Resolve,|Concept.Bravery] [Melee Skill,|Concept.MeleeSkill] [Ranged Skill,|Concept.RangeSkill] [Melee Defense|Concept.MeleeDefense] and [Ranged Defense|Concept.RangeDefense] are increased by " + ::MSU.Text.colorPositive("5%") + ".",
 				"Lose " + ::MSU.Text.colorNegative(1) + " stack upon ending a [turn|Concept.Turn] without having attacked.",
 				"Cannot have more than 4 stacks."
 			]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -899,9 +899,8 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"[Resolve|Concept.Bravery] is increased by " + ::MSU.Text.colorPositive("10%") + " at all times.",
-				"Additionally, at positive morale checks, [Resolve|Concept.Bravery] is increased by a further " + ::MSU.Text.colorPositive("+10") + ".",
-				"When at Confident Morale, all the bonuses of this perk are doubled, and [Melee Skill,|Concept.MeleeSkill] [Ranged Skill,|Concept.RangeSkill] [Melee Defense,|Concept.MeleeDefense] and [Ranged Defense|Concept.RangeDefense] are increased by " + ::MSU.Text.colorPositive("5%") + "."
+				"Receive a [morale check|Concept.Morale] at the start of every [turn|Concept.Turn] if you are [Confident.|Concept.Morale] and if successful, gain a stack. For each stack, [Resolve,|Concept.Bravery] [Melee Skill,|Concept.MeleeSkill] [Ranged Skill,|Concept.RangeSkill] [Melee Defense|Concept.MeleeDefense] and [Ranged Defense|Concept.RangeDefense] are increased by " + ::MSU.Text.colorPositive("5%") + ".",
+				"Cannot have more than 4 stacks."
 			]
 		}]
 	}),

--- a/scripts/skills/perks/perk_rf_battle_fervor.nut
+++ b/scripts/skills/perks/perk_rf_battle_fervor.nut
@@ -134,6 +134,6 @@ this.perk_rf_battle_fervor <- ::inherit("scripts/skills/skill", {
 
 	function RF_getMult()
 	{
-		return 1.0 + this.m.Stacks * this.m.MultPerStack;
+		return 1.0 + this.m.Stacks * this.m.PctPerStack;
 	}
 });

--- a/scripts/skills/perks/perk_rf_battle_fervor.nut
+++ b/scripts/skills/perks/perk_rf_battle_fervor.nut
@@ -1,9 +1,10 @@
 this.perk_rf_battle_fervor <- ::inherit("scripts/skills/skill", {
 	m = {
 		Stacks = 0,
+		HasAttackedThisTurn = false,
 
 		MaxStacks = 4,
-		MultPerStack = 0.05
+		PctPerStack = 0.05 // Stats are increased by this much percent for every stack
 	},
 	function create()
 	{
@@ -69,15 +70,42 @@ this.perk_rf_battle_fervor <- ::inherit("scripts/skills/skill", {
 				text = ::Reforged.Mod.Tooltips.parseString("Will expire upon losing [Confident|Concept.Morale] morale")
 			}
 		]);
+
+		if (!this.m.HasAttackedThisTurn)
+		{
+			ret.push({
+				id = 21,
+				type = "text",
+				icon = "ui/icons/warning.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Unless this character attacks, one stack will be lost upon ending this [turn|Concept.Turn]")
+			});
+		}
 		return ret;
 	}
 
 	function onTurnStart()
 	{
+		this.m.HasAttackedThisTurn = false;
 		if (this.m.Stacks < this.m.MaxStacks && this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Confident)
 		{
 			this.m.Stacks++;
 			this.spawnIcon(this.m.Overlay, this.getContainer().getActor().getTile());
+		}
+	}
+
+	function onTurnEnd()
+	{
+		if (this.m.Stacks != 0 && !this.m.HasAttackedThisTurn)
+		{
+			this.m.Stacks--;
+		}
+	}
+
+	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
+	{
+		if (_skill.isAttack())
+		{
+			this.m.HasAttackedThisTurn = true;
 		}
 	}
 
@@ -101,6 +129,7 @@ this.perk_rf_battle_fervor <- ::inherit("scripts/skills/skill", {
 	{
 		this.skill.onCombatFinished();
 		this.m.Stacks = 0;
+		this.m.HasAttackedThisTurn = false;
 	}
 
 	function RF_getMult()

--- a/scripts/skills/perks/perk_rf_battle_fervor.nut
+++ b/scripts/skills/perks/perk_rf_battle_fervor.nut
@@ -16,6 +16,11 @@ this.perk_rf_battle_fervor <- ::inherit("scripts/skills/skill", {
 		this.m.Order = ::Const.SkillOrder.Perk;
 	}
 
+	function getName()
+	{
+		return this.m.Stacks <= 1 ? this.m.Name : this.m.Name + " (x" + this.m.Stacks + ")";
+	}
+
 	function isHidden()
 	{
 		return this.m.Stacks == 0;

--- a/scripts/skills/perks/perk_rf_battle_fervor.nut
+++ b/scripts/skills/perks/perk_rf_battle_fervor.nut
@@ -1,90 +1,105 @@
 this.perk_rf_battle_fervor <- ::inherit("scripts/skills/skill", {
-	m = {},
+	m = {
+		Stacks = 0,
+
+		MaxStacks = 4,
+		MultPerStack = 0.05
+	},
 	function create()
 	{
 		this.m.ID = "perk.rf_battle_fervor";
 		this.m.Name = ::Const.Strings.PerkName.RF_BattleFervor;
 		this.m.Description = "This character will stop at nothing short of absolute victory.";
 		this.m.Icon = "ui/perks/perk_rf_battle_fervor.png";
+		this.m.Overlay = "perk_rf_battle_fervor";
 		this.m.Type = ::Const.SkillType.Perk | ::Const.SkillType.StatusEffect;
 		this.m.Order = ::Const.SkillOrder.Perk;
+	}
+
+	function isHidden()
+	{
+		return this.m.Stacks == 0;
 	}
 
 	function getTooltip()
 	{
 		local ret = this.skill.getTooltip();
 
-		local isConfident = this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Confident;
-
+		local mult = this.RF_getMult();
 		ret.extend([
-			{
-				id = 10,
-				type = "text",
-				icon = "ui/icons/bravery.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive((isConfident ? 20 : 10) + "%") + " more [Resolve|Concept.Bravery]")
-			},
 			{
 				id = 11,
 				type = "text",
 				icon = "ui/icons/bravery.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive("+" + (isConfident ? 20 : 10)) + " [Resolve|Concept.Bravery] at positive [morale checks|Concept.Morale]")
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMultWithText(mult) + " [Resolve|Concept.Bravery]")
+			},
+			{
+				id = 12,
+				type = "text",
+				icon = "ui/icons/melee_skill.png",
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMultWithText(mult) + " [Melee Skill|Concept.MeleeSkill]")
+			},
+			{
+				id = 13,
+				type = "text",
+				icon = "ui/icons/ranged_skill.png",
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMultWithText(mult) + " [Ranged Skill|Concept.RangeSkill]")
+			},
+			{
+				id = 14,
+				type = "text",
+				icon = "ui/icons/melee_defense.png",
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMultWithText(mult) + " [Melee Defense|Concept.MeleeDefense]")
+			},
+			{
+				id = 15,
+				type = "text",
+				icon = "ui/icons/ranged_defense.png",
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMultWithText(mult) + " [Ranged Defense|Concept.RangeDefense]")
+			},
+			{
+				id = 20,
+				type = "text",
+				icon = "ui/icons/warning.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Will expire upon losing [Confident|Concept.Morale] morale")
 			}
 		]);
-
-		if (isConfident)
-		{
-			ret.extend([
-				{
-					id = 12,
-					type = "text",
-					icon = "ui/icons/melee_skill.png",
-					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive("5%") + " more [Melee Skill|Concept.MeleeSkill]")
-				},
-				{
-					id = 13,
-					type = "text",
-					icon = "ui/icons/ranged_skill.png",
-					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive("5%") + " more [Ranged Skill|Concept.RangeSkill]")
-				},
-				{
-					id = 14,
-					type = "text",
-					icon = "ui/icons/melee_defense.png",
-					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive("5%") + " more [Melee Defense|Concept.MeleeDefense]")
-				},
-				{
-					id = 15,
-					type = "text",
-					icon = "ui/icons/ranged_defense.png",
-					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive("5%") + " more [Ranged Defense|Concept.RangeDefense]")
-				}
-			]);
-		}
-
 		return ret;
+	}
+
+	function onTurnStart()
+	{
+		if (this.m.Stacks < this.m.MaxStacks && this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Confident)
+		{
+			this.m.Stacks++;
+			this.spawnIcon(this.m.Overlay, this.getContainer().getActor().getTile());
+		}
 	}
 
 	function onUpdate( _properties )
 	{
-		if (this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Confident)
+		if (this.getContainer().getActor().getMoraleState() != ::Const.MoraleState.Confident)
 		{
-			_properties.BraveryMult *= 1.2;
-			_properties.MeleeSkillMult *= 1.05;
-			_properties.RangedSkillMult *= 1.05;
-			_properties.MeleeDefenseMult *= 1.05;
-			_properties.RangedDefenseMult *= 1.05;
-			foreach (moraleCheckType in ::Const.MoraleCheckType)
-			{
-				_properties.PositiveMoraleCheckBravery[moraleCheckType] += 20;
-			}
+			this.m.Stacks = 0;
+			return;
 		}
-		else
-		{
-			_properties.BraveryMult *= 1.1;
-			foreach (moraleCheckType in ::Const.MoraleCheckType)
-			{
-				_properties.PositiveMoraleCheckBravery[moraleCheckType] += 10;
-			}
-		}
+
+		local mult = this.RF_getMult();
+		_properties.BraveryMult *= mult;
+		_properties.MeleeSkillMult *= mult;
+		_properties.RangedSkillMult *= mult;
+		_properties.MeleeDefenseMult *= mult;
+		_properties.RangedDefenseMult *= mult;
+	}
+
+	function onCombatFinished()
+	{
+		this.skill.onCombatFinished();
+		this.m.Stacks = 0;
+	}
+
+	function RF_getMult()
+	{
+		return 1.0 + this.m.Stacks * this.m.MultPerStack;
 	}
 });

--- a/scripts/skills/perks/perk_rf_battle_fervor.nut
+++ b/scripts/skills/perks/perk_rf_battle_fervor.nut
@@ -86,10 +86,17 @@ this.perk_rf_battle_fervor <- ::inherit("scripts/skills/skill", {
 	function onTurnStart()
 	{
 		this.m.HasAttackedThisTurn = false;
-		if (this.m.Stacks < this.m.MaxStacks && this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Confident)
+		if (this.m.Stacks == this.m.MaxStacks)
+			return;
+
+		local actor = this.getContainer().getActor();
+		if (actor.getMoraleState() != ::Const.MoraleState.Confident || !actor.checkMorale(0, ::Const.Morale.RallyBaseDifficulty))
+			return;
+
+		this.m.Stacks++;
+		if (actor.isPlacedOnMap())
 		{
-			this.m.Stacks++;
-			this.spawnIcon(this.m.Overlay, this.getContainer().getActor().getTile());
+			this.spawnIcon(this.m.Overlay, actor.getTile());
 		}
 	}
 

--- a/scripts/skills/perks/perk_rf_battle_fervor.nut
+++ b/scripts/skills/perks/perk_rf_battle_fervor.nut
@@ -90,12 +90,9 @@ this.perk_rf_battle_fervor <- ::inherit("scripts/skills/skill", {
 			return;
 
 		local actor = this.getContainer().getActor();
-		if (actor.getMoraleState() != ::Const.MoraleState.Confident || !actor.checkMorale(0, ::Const.Morale.RallyBaseDifficulty))
-			return;
-
-		this.m.Stacks++;
-		if (actor.isPlacedOnMap())
+		if (actor.getMoraleState() == ::Const.MoraleState.Confident && actor.checkMorale(0, ::Const.Morale.RallyBaseDifficulty))
 		{
+			this.m.Stacks++;
 			this.spawnIcon(this.m.Overlay, actor.getTile());
 		}
 	}

--- a/unpacked_brushes/rf_ui/metadata.xml
+++ b/unpacked_brushes/rf_ui/metadata.xml
@@ -54,6 +54,7 @@
 	<sprite id="rf_voulge_cleave_skill" ic = "FF23165B" img="..\..\gfx\skills\rf_voulge_cleave_skill.png" />
 
 	<!-- Perks and their Minis -->
+	<sprite id="perk_rf_battle_fervor" ic = "FF23165B" img="..\..\gfx\ui\perks\perk_rf_battle_fervor.png" />
 	<sprite id="perk_rf_bloodlust_mini" ic = "FF23165B" img="skills\mini\perk_rf_bloodlust_mini.png" />
 	<sprite id="perk_rf_bolster" ic = "FF23165B" img="..\..\gfx\ui\perks\perk_rf_bolster.png" />
 	<sprite id="perk_rf_bulwark_mini" ic = "FF23165B" img="skills\mini\perk_rf_bulwark_mini.png" />


### PR DESCRIPTION
As long as you start each turn at Confident morale. Each stack increases attributes by 5%. Can have a maximum of 4 stacks. Expires upon losing Confident morale.