### PR TITLE
fix: covering ally persisting even after shield is unequipped

### DIFF
--- a/scripts/skills/effects/rf_covering_ally_effect.nut
+++ b/scripts/skills/effects/rf_covering_ally_effect.nut
@@ -104,4 +104,13 @@ this.rf_covering_ally_effect <- ::inherit("scripts/skills/skill", {
 			}
 		}
 	}
+
+// MSU Functions
+	function onUnequip( _item )
+	{
+		if (_item.isItemType(::Const.Items.ItemType.Shield))
+		{
+			this.removeSelf();
+		}
+	}
 });


### PR DESCRIPTION
Currently you can unequip your shield or have it break and keep the buff on yourself and your ally.
This change fixes that. 
Swapping shields is also not allowed