### PR TITLE
fix: potential stack overflow due to RF_onSpawn

### DIFF
--- a/mod_reforged/hooks/experimental_modules/onSpawnEntity.nut
+++ b/mod_reforged/hooks/experimental_modules/onSpawnEntity.nut
@@ -68,7 +68,12 @@
 				// This actor MUST NOT get killed during this if this spawning is via a resurrection because
 				// tactical_entity_manager.onResurrect calls entity.riseFromGround after entity.onResurrected
 				// and riseFromGround tries to access the entity's tile.
+
+				// We block the other actor from triggering his RF_onSpawn due to the update from his onActorSpawned event
+				// otherwise the stack keeps getting bigger and bigger and may lead to a stack overflow with too many actors.
+				actor.m.RF_OnSpawnBlockerCount++;
 				actor.getSkills().onActorSpawned(this);
+				actor.m.RF_OnSpawnBlockerCount--;
 			}
 		}
 	}


### PR DESCRIPTION
When combat is started it calls onCombatStarted for all the actors. This triggers a skill_container.update(). This leads to the first actor calling his RF_onSpawn which then calls onActorSpawned on all the other actors, leading to them triggering a skill_container.update() which then triggers their own RF_onSpawn which triggers it for all others leading to the stack getting bigger and bigger. At a certain number of entities this can lead to stack overflow.

We now block the other actor from triggering his RF_onSpawn due to the update from his onActorSpawned event. This means that every actor gets his RF_onSpawn due to the original onCombatStarted call, leading to a sensible stack.