### PR TITLE
balance: apply bulwark bonus only during morale checks

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1067,7 +1067,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Gain " + ::MSU.Text.colorPositive("5%") + " of your current combined head and body armor durability as [Resolve|Concept.Bravery] during positive [morale checks.|Concept.Morale]",
+				"Gain " + ::MSU.Text.colorPositive("5%") + " of your current combined head and body armor durability as [Resolve|Concept.Bravery] during [morale checks.|Concept.Morale]",
 				"This bonus is doubled against negative morale checks except mental attacks."
 			]
 		}]

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1067,7 +1067,7 @@ foreach (vanillaDesc in vanillaDescriptions)
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"Gain " + ::MSU.Text.colorPositive("5%") + " of your current combined head and body armor durability as [Resolve.|Concept.Bravery]",
+				"Gain " + ::MSU.Text.colorPositive("5%") + " of your current combined head and body armor durability as [Resolve|Concept.Bravery] during positive [morale checks.|Concept.Morale]",
 				"This bonus is doubled against negative morale checks except mental attacks."
 			]
 		}]

--- a/scripts/skills/perks/perk_rf_bulwark.nut
+++ b/scripts/skills/perks/perk_rf_bulwark.nut
@@ -27,7 +27,7 @@ this.perk_rf_bulwark <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/bravery.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive("+" + bonus) + " [Resolve|Concept.Bravery]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive("+" + bonus) + " [Resolve|Concept.Bravery] at positive [morale checks|Concept.Morale]")
 		});
 
 		ret.push({
@@ -50,12 +50,11 @@ this.perk_rf_bulwark <- ::inherit("scripts/skills/skill", {
 	{
 		local bonus = this.getBonus();
 
-		_properties.Bravery += bonus;
-
 		foreach (moraleCheckType in ::Const.MoraleCheckType)
 		{
 			if (moraleCheckType != ::Const.MoraleCheckType.MentalAttack)
 			{
+				_properties.MoraleCheckBravery[moraleCheckType] += bonus;
 				_properties.NegativeMoraleCheckBravery[moraleCheckType] += bonus;
 			}
 		}

--- a/scripts/skills/perks/perk_rf_bulwark.nut
+++ b/scripts/skills/perks/perk_rf_bulwark.nut
@@ -27,7 +27,7 @@ this.perk_rf_bulwark <- ::inherit("scripts/skills/skill", {
 			id = 10,
 			type = "text",
 			icon = "ui/icons/bravery.png",
-			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive("+" + bonus) + " [Resolve|Concept.Bravery] at positive [morale checks|Concept.Morale]")
+			text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorPositive("+" + bonus) + " [Resolve|Concept.Bravery] at [morale checks|Concept.Morale]")
 		});
 
 		ret.push({


### PR DESCRIPTION
The flat Resolve bonus is too high and some players have given the feedback that it is too much of a stat boost. It also competes this way with Fortified Mind. Another egregious use case is putting it on a Bannerman in heavy armor for a large boost to Resolve. Changing it to affect Resolve only during morale checks keeps the perk strong for its purpose while resolving the issues around it and giving it more of a unique identity.