### PR TITLE
fix: militia origin getting phalanx perk at tier 2 instead of 1

### DIFF
--- a/mod_reforged/hooks/scenarios/world/militia_scenario.nut
+++ b/mod_reforged/hooks/scenarios/world/militia_scenario.nut
@@ -16,6 +16,23 @@
 	q.onBuildPerkTree = @(__original) function( _perkTree )
 	{
 		__original(_perkTree);
-		_perkTree.addPerkGroup("pg.rf_militia");
+
+		// Instead of directly adding militia perk group, we iterate over its rows and add
+		// the perks to the perk tree because some perks may have come from other perk groups
+		// at tiers different from the tiers that militia perk group has them at.
+		foreach (i, row in ::DynamicPerks.PerkGroups.findById("pg.rf_militia").getTree())
+		{
+			foreach (perkID in row)
+			{
+				if (_perkTree.hasPerk(perkID))
+				{
+					if (_perkTree.getPerkTier(perkID) == i + 1)
+						continue;
+					else
+						_perkTree.removePerk(perkID);
+				}
+				_perkTree.addPerk(perkID, i + 1);
+			}
+		}
 	}
 });


### PR DESCRIPTION
Militia perk group has Phalanx at tier 1 but Shield perk group has it at tier 2, so during the Militia Origin which guarantees the Militia Perk Group on all characters, if the character already rolled the Shield perk group he'd have Phalanx at tier 2.