### PR TITLE
feat: nerf throwing net range and AP cost and adjust angler and goblins

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -877,7 +877,8 @@ foreach (vanillaDesc in vanillaDescriptions)
 			{
 				Type = ::UPD.EffectType.Passive,
 				Description = [
-					"Enemies [netted|Skill+net_effect] by you have a " + ::MSU.Text.colorNegative("50%") + " increased [Action Point|Concept.ActionPoints] cost for using the [Break Free|Skill+break_free_skill] skill."
+					"You can [throw nets|Skill+throw_net] one further tile away up to a maximum of 3 tiles.",
+					"Enemies [netted|Skill+net_effect] by you at a distance of 2 or fewer tiles have a " + ::MSU.Text.colorNegative("50%") + " increased [Action Point|Concept.ActionPoints] cost for using the [Break Free|Skill+break_free_skill] skill."
 				]
 			},
 			{

--- a/mod_reforged/hooks/entity/tactical/goblin.nut
+++ b/mod_reforged/hooks/entity/tactical/goblin.nut
@@ -49,6 +49,7 @@
 		// Reforged
 		this.m.BaseProperties.Reach = ::Reforged.Reach.Default.Goblin;
 
+		this.m.Skills.add(::new("scripts/skills/racial/rf_goblin_racial"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_footwork"));
 	}
 

--- a/mod_reforged/hooks/skills/actives/throw_net.nut
+++ b/mod_reforged/hooks/skills/actives/throw_net.nut
@@ -2,6 +2,8 @@
 	q.create = @(__original) function()
 	{
 		__original();
+		this.m.ActionPointCost = 5; // vanilla is 4
+		this.m.MaxRange = 2; // vanilla is 3
 		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.ThrowNet;
 	}
 

--- a/scripts/skills/perks/perk_rf_angler.nut
+++ b/scripts/skills/perks/perk_rf_angler.nut
@@ -1,6 +1,7 @@
 this.perk_rf_angler <- ::inherit("scripts/skills/skill", {
 	m = {
-		BreakFreeAPCostMult = 1.5
+		BreakFreeAPCostMult = 1.5,
+		MaxDistanceForAPCostMult = 2
 	},
 	function create()
 	{
@@ -14,13 +15,22 @@ this.perk_rf_angler <- ::inherit("scripts/skills/skill", {
 
 	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
 	{
-		if (_skill.getID() == "actives.throw_net")
+		if (_skill.getID() == "actives.throw_net" && _targetTile.getDistanceTo(this.getContainer().getActor().getTile()) <= this.m.MaxDistanceForAPCostMult)
 		{
 			local breakFreeSkill = _targetEntity.getSkills().getSkillByID("actives.break_free");
 			if (breakFreeSkill != null)
 			{
 				breakFreeSkill.setBaseValue("ActionPointCost", ::Math.floor(breakFreeSkill.getBaseValue("ActionPointCost") * this.m.BreakFreeAPCostMult));
 			}
+		}
+	}
+
+	function onAfterUpdate( _properties )
+	{
+		local throwNet = this.getSkills().getSkillByID("actives.throw_net");
+		if (throwNet != null && throwNet.m.MaxRange < 3)
+		{
+			throwNet.m.MaxRange += 1;
 		}
 	}
 
@@ -35,6 +45,19 @@ this.perk_rf_angler <- ::inherit("scripts/skills/skill", {
 		if (_item.getSlotType() == ::Const.ItemSlot.Offhand && this.getContainer().hasSkill("actives.throw_net"))
 		{
 			_item.addSkill(::new("scripts/skills/actives/rf_net_pull_skill"));
+		}
+	}
+
+	function onQueryTooltip( _skill, _tooltip )
+	{
+		if (_skill.getID() == "actives.throw_net")
+		{
+			_tooltip.push({
+				id = 100,
+				type = "text",
+				icon = this.getIconColored(),
+				text = ::Reforged.Mod.Tooltips.parseString("When used at a distance of " + this.m.MaxDistanceForAPCostMult + " or fewer tiles the target must spend " + ::MSU.Text.colorizeMultWithText(this.m.BreakFreeAPCostMult) + " [Action Points|Concept.ActionPoints] to [break free|Skill+break_free_skill]")
+			});
 		}
 	}
 });

--- a/scripts/skills/racial/rf_goblin_racial.nut
+++ b/scripts/skills/racial/rf_goblin_racial.nut
@@ -1,0 +1,33 @@
+this.rf_goblin_racial <- ::inherit("scripts/skills/skill", {
+	m = {},
+	function create()
+	{
+		this.m.ID = "racial.rf_goblin";
+		this.m.Name = "Goblin";
+		this.m.Description = "This character is a goblin.";
+		this.m.Icon = "ui/orientation/goblin_01_orientation.png";
+		this.m.Type = ::Const.SkillType.Racial | ::Const.SkillType.StatusEffect;
+		this.m.Order = ::Const.SkillOrder.Last;
+	}
+
+	function getTooltip()
+	{
+		local ret = this.skill.getTooltip();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("The range of [throw net|Skill+throw_net] is increased by 1 up to a maximum of 3 tiles")
+		});
+		return ret;
+	}
+
+	function onAfterUpdate( _properties )
+	{
+		local throwNet = this.getSkills().getSkillByID("actives.throw_net");
+		if (throwNet != null && throwNet.m.MaxRange < 3)
+		{
+			throwNet.m.MaxRange += 1;
+		}
+	}
+});


### PR DESCRIPTION
- Increase the AP cost of Throw Net from 4 to 5 and reduce the MaxRange from 3 to 2.
- Goblins can still throw at a range of 3 tiles. This is achieved by adding a new rf_goblin_racial skill.
- Angler perk now increases the range by 1 tile and only applies its 50% increased AP cost of Break Free when throwing the net at a distance of 2 or fewer tiles.

Nets are extremely powerful and are a bit too easy/flexible to use to eliminate high threat targets. This PR nerfs them by not modifying their efficacy, but making them harder to use i.e. they are now more challenging to pull off. At the same time the player has options via perks to get back to the original strength for dedicated utility net bros.

| Situation | Old | New |
| ---- | ---- | ---- |
| Net in bag | Swap to net (4), throw (4) and end your turn. 1 Netting | Same result, uses 9 AP instead of 8 |
| Net in hand | Throw (4), swap (4), end turn.  1 Netting With Quick Hands you could do 2 nettings, throw (4), swap (0), throw (4).| Same except Quick Hands version can't do 2 nettings |
| Net in bag + Offhand Training | Swap to a net (4), throw (0), swap (4). Or with Quick Hands, swap (0), throw (0), swap (4), throw (4) for 2 nettings total. | Same result, uses 9 AP instead of 8 |
| Net in hand + Offhand Training | Throw (0), swap (4), throw (4) for 2 nettings. With Quick Hands, throw (0), swap (0), throw (4), swap (4) or attack for 2 nettings. | Same result, uses 9 AP instead of 8 |

So the only situation where you can throw twice is if you have Offhand Training (or another perk that reduces the AP cost of Throw Net).