### PR TITLE
balance: disable free attack from spear mastery on 2h spears upon moving

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -652,7 +652,7 @@ local vanillaDescriptions = [
 				Description = [
 					"Skills build up " + ::MSU.Text.colorPositive("25%") + " less [Fatigue.|Concept.Fatigue]",
 					"[Spearwall|Skill+spearwall] is no longer disabled once an opponent manages to overcome it. Instead, [Spearwall|Skill+spearwall] can still be used and continues to give free attacks on any further opponent attempting to enter the [Zone of Control|Concept.ZoneOfControl]",
-					"When starting your [turn|Concept.Turn] with a spear equipped and not moving more than 1 tile from your position, the first piercing spear attack during your [turn|Concept.Turn] costs " + ::MSU.Text.colorPositive("no") + " [Action Points|Concept.ActionPoints] and builds " + ::MSU.Text.colorPositive("50%") + " less [Fatigue.|Concept.Fatigue]",
+					"When starting your [turn|Concept.Turn] with a spear equipped, the first piercing spear attack costs " + ::MSU.Text.colorPositive("no") + " [Action Points|Concept.ActionPoints] and builds " + ::MSU.Text.colorPositive("50%") + " less [Fatigue.|Concept.Fatigue] This expires upon moving from your position if using a two-handed spear, or moving more than 1 tile if using a one-handed spear.",
 					"The [Spetum|Item+spetum] and [Warfork|Item+warfork] no longer have a penalty for attacking targets directly adjacent."
 				]
 			}]

--- a/mod_reforged/hooks/skills/perks/perk_mastery_spear.nut
+++ b/mod_reforged/hooks/skills/perks/perk_mastery_spear.nut
@@ -1,7 +1,6 @@
 ::Reforged.HooksMod.hook("scripts/skills/perks/perk_mastery_spear", function(q) {
 	q.m.IsSpent <- true;
 	q.m.TilesMoved <- 0;
-	q.m.MaxTilesAllowed <- 1;
 	q.m.FatigueCostMultMult <- 0.5;
 
 	q.create = @(__original) function()
@@ -26,11 +25,13 @@
 			icon = "ui/icons/special.png",
 			text = ::Reforged.Mod.Tooltips.parseString("The next piercing spear attack costs " + ::MSU.Text.colorPositive("0") + " [Action Points|Concept.ActionPoints] and builds " + ::MSU.Text.colorizeMult(this.m.FatigueCostMultMult, {InvertColor = true}) + " less [Fatigue|Concept.Fatigue]")
 		});
+
+		local maxTilesAllowed = this.getMaxTilesAllowed();
 		ret.push({
 			id = 20,
 			type = "text",
 			icon = "ui/icons/warning.png",
-			text = "Will expire upon switching your weapon or moving" + (this.m.MaxTilesAllowed == 0 ? "" : "more than " + this.m.MaxTilesAllowed + " tile(s)")
+			text = "Will expire upon switching your weapon or moving" + (maxTilesAllowed == 0 ? "" : "more than " + maxTilesAllowed + " tile(s)")
 		});
 
 		return ret;
@@ -46,7 +47,7 @@
 		local actor = this.getContainer().getActor();
 		if (actor.isPreviewing())
 		{
-			if (actor.getPreviewMovement() != null && actor.getPreviewMovement().Tiles + this.m.TilesMoved >= this.m.MaxTilesAllowed)
+			if (actor.getPreviewMovement() != null && actor.getPreviewMovement().Tiles + this.m.TilesMoved >= this.getMaxTilesAllowed())
 				return;
 
 			if (actor.getPreviewSkill() != null && this.isSkillValid(actor.getPreviewSkill()))
@@ -88,7 +89,7 @@
 	q.onMovementStarted = @(__original) function( _tile, _numTiles )
 	{
 		this.m.TilesMoved += _numTiles;
-		if (this.m.TilesMoved > this.m.MaxTilesAllowed)
+		if (this.m.TilesMoved > this.getMaxTilesAllowed())
 			this.m.IsSpent = true;
 		__original(_tile, _numTiles);
 	}
@@ -122,5 +123,11 @@
 
 		local weapon = _skill.getItem();
 		return !::MSU.isNull(weapon) && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(::Const.Items.WeaponType.Spear);
+	}
+
+	q.getMaxTilesAllowed <- function()
+	{
+		local weapon = this.getMainhandItem();
+		return weapon == null || weapon.isItemType(::Const.Items.ItemType.OneHanded) ? 1 : 0;
 	}
 });


### PR DESCRIPTION
There was some [feedback](https://discord.com/channels/1006908336991645757/1296562347066003560/1373412867444838513) on Discord about this. This change further reins in the 2h spears, still giving them the free attack but in a more restricted way than before.