### PR TITLE
fix: vigorous assault not applying ap reduction if it would drop it <=0

### DIFF
--- a/scripts/skills/perks/perk_rf_vigorous_assault.nut
+++ b/scripts/skills/perks/perk_rf_vigorous_assault.nut
@@ -130,10 +130,9 @@ this.perk_rf_vigorous_assault <- ::inherit("scripts/skills/skill", {
 		{
 			if (this.isSkillValid(skill))
 			{
-				local actionPointCostModifier = this.getActionPointCostModifier();
-				if (skill.m.ActionPointCost + actionPointCostModifier > 0)
+				if (skill.m.ActionPointCost > 1)
 				{
-					skill.m.ActionPointCost += actionPointCostModifier;
+					skill.m.ActionPointCost = ::Math.max(1, skill.m.ActionPointCost + this.getActionPointCostModifier());
 				}
 				skill.m.FatigueCostMult *= this.getFatigueCostMultMult();
 			}


### PR DESCRIPTION
Whereas the expected behavior is that it should drop the AP cost down to a minimum of 1.