### PR TITLE
onAnySkillExecuted various fixes 

### DIFF
--- a/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
+++ b/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
@@ -198,3 +198,15 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 		__original(_activeEntity, _targetTile);
 	}
 });
+
+::Reforged.HooksMod.hook("scripts/ai/tactical/agent", function(q) {
+	// Prevent the AI from executing a skill while the previously executed skill has not fully finished executing
+	// including all its delayed effects
+	q.think = @(__original) function( _evaluateOnly = false )
+	{
+		if (::Reforged.ScheduleSkills.len() != 0)
+			return;
+
+		__original(_evaluateOnly);
+	}
+});

--- a/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
+++ b/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
@@ -62,12 +62,7 @@ local function getSchedulerSkill()
 		}
 
 		local caller = infos.locals["this"];
-		if (caller in ::Reforged.ScheduleSkills)
-		{
-			return caller;
-		}
-
-		infos = ::getstackinfos(++level);
+		return caller in ::Reforged.ScheduleSkills ? caller : null;
 	}
 	while(infos != null);
 

--- a/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
+++ b/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
@@ -80,6 +80,12 @@ local function getSchedulerSkill()
 local scheduleEvent = ::Time.scheduleEvent;
 ::Time.scheduleEvent = function( _timeUnit, _time, _func, _data )
 {
+	if (_timeUnit == ::TimeUnit.Rounds)
+	{
+		scheduleEvent(_timeUnit, _time, _func, _data);
+		return;
+	}
+
 	local caller = getSchedulerSkill();
 	if (caller == null)
 	{


### PR DESCRIPTION
- Don't count scheduleEvent with `::TimeUnit.Rounds` as part of skill execution.
- Delayed events are only considered part of a skill execution if they are called from a function with the skill as the env variable (i.e. inside the skill script or a helper function with that skill as the env).
- Prevent the AI from executing a skill while another skill has delayed events (just like the player). Otherwise the AI overwrites the scheduled skill object and this causes the callback wrapper to throw an error.