### PR TITLE
feat: allow the AI to evaluate in parallel but rethink if state changed

### DIFF
--- a/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
+++ b/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
@@ -31,9 +31,18 @@
 
 	function onScheduleComplete()
 	{
+		if (this.WasScheduled)
+			::Reforged.Mod.Debug.printLog(format("onScheduleComplete -- ID: %s, Count: %i", this.Skill.getID(), this.Count), "onAnySkillExecutedFully");
+		else
+			::Reforged.Mod.Debug.printLog(format("onScheduleComplete -- ID: %s, Count: %i -- Nothing was scheduled (normal skill)", this.Skill.getID(), this.Count), "onAnySkillExecutedFully");
 		// Check for <= 0 because when we call this manually, this.Count will be 0 and will drop to -1
 		if (--this.Count <= 0)
 		{
+			if (this.WasScheduled)
+				::Reforged.Mod.Debug.printLog(format("onScheduleComplete -- ID: %s, Count: %i - Schedule Complete", this.Skill.getID(), this.Count), "onAnySkillExecutedFully");
+			else
+				::Reforged.Mod.Debug.printLog(format("onScheduleComplete -- ID: %s, Count: %i - Schedule Complete -- Nothing was scheduled (normal skill)", this.Skill.getID(), this.Count), "onAnySkillExecutedFully");
+
 			if (!::MSU.isNull(this.Container))
 				this.Container.onAnySkillExecutedFully(this.Skill, this.TargetTile, this.TargetEntity, this.ForFree);
 			delete ::Reforged.ScheduleSkills[this.Skill];
@@ -126,6 +135,8 @@ local scheduleEvent = ::Time.scheduleEvent;
 		return;
 	}
 
+	::Reforged.Mod.Debug.printLog(format("scheduleEvent -- ID: %s, Count: %i", caller.getID(), ::Reforged.ScheduleSkills[caller].Count + 1), "onAnySkillExecutedFully");
+
 	scheduleEvent(_timeUnit, _time, getWrapper(caller, _func, 1), _data);
 }
 
@@ -139,6 +150,8 @@ local teleport = ::TacticalNavigator.teleport;
 		return;
 	}
 
+	::Reforged.Mod.Debug.printLog(format("teleport -- ID: %s, Count: %i", caller.getID(), ::Reforged.ScheduleSkills[caller].Count + 1), "onAnySkillExecutedFully");
+
 	teleport(_user, _targetTile, getWrapper(caller, _func, 2), _data, _bool, _float);
 }
 
@@ -151,6 +164,8 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 		switchEntities(_user, _targetEntity, _func, _data, _float);
 		return;
 	}
+
+	::Reforged.Mod.Debug.printLog(format("switchEntities -- ID: %s, Count: %i", caller.getID(), ::Reforged.ScheduleSkills[caller].Count + 2), "onAnySkillExecutedFully");
 
 	// Increase count by 2 because the callback is called for both entities
 	local cbEntry = [getWrapper(caller, _func, 2, 2), _data];
@@ -239,6 +254,7 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 
 	function save()
 	{
+		::Reforged.Mod.Debug.printLog(format("AgentState.save() -- %s (%i)", this.Agent.getActor().getName(), this.Agent.getActor().getID()), "onAnySkillExecutedFully");
 		local actor = this.Agent.getActor();
 		this.MoraleState = actor.getMoraleState();
 		this.ActionPoints = actor.getActionPoints();
@@ -249,12 +265,14 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 
 	function clear()
 	{
+		::Reforged.Mod.Debug.printWarning(format("AgentState.clear() -- %s (%i)", this.Agent.getActor().getName(), this.Agent.getActor().getID()), "onAnySkillExecutedFully");
 		this.__IsStateSaved = false;
 		this.__IsInvalid = false;
 	}
 
 	function invalidate()
 	{
+		::Reforged.Mod.Debug.printWarning(format("AgentState.invalidate() -- %s (%i)", this.Agent.getActor().getName(), this.Agent.getActor().getID()), "onAnySkillExecutedFully");
 		this.__IsInvalid = true;
 	}
 
@@ -355,6 +373,7 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 	// Then during agent.execute we will compare the state with this state to see if anything has changed.
 	q.evaluate = @(__original) function( _entity )
 	{
+		::Reforged.Mod.Debug.printLog(format("evaluate -- %s (%i), NextBehaviorToEvaluate: %i", this.getActor().getName(), this.getActor().getID(), this.m.NextBehaviorToEvaluate), "onAnySkillExecutedFully");
 		if (this.m.NextBehaviorToEvaluate == -3)
 		{
 			this.m.RF_AgentState.save();
@@ -387,6 +406,7 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 	// a new evaluation starts after this function returns true.
 	q.execute = @(__original) function( _entity )
 	{
+		::Reforged.Mod.Debug.printWarning(format("execute -- %s (%i), ActiveBehavior: %s", this.getActor().getName(), this.getActor().getID(), this.m.ActiveBehavior == null ? null : this.m.ActiveBehavior.getName()), "onAnySkillExecutedFully");
 		if (this.m.ActiveBehavior != null && this.m.RF_AgentState.isStateSaved())
 		{
 			// If state was changed then we reset and force a complete reevaluation and don't allow the behavior
@@ -425,6 +445,8 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 
 	q.RF_reset <- function()
 	{
+		::Reforged.Mod.Debug.printWarning(format("RF_reset -- %s (%i)", this.getActor().getName(), this.getActor().getID()), "onAnySkillExecutedFully");
+
 		// This resets the `agent.think` function to start its logic from the beginning
 		this.m.NextBehaviorToEvaluate = -3;
 		this.m.IsEvaluating = true;

--- a/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
+++ b/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
@@ -16,7 +16,18 @@
 	TargetTile = null;
 	TargetEntity = null;
 	ForFree = false;
+	Agent = null;
+
 	Count = 0;
+
+	// State of the actor as it was when the first delayed event was scheduled during a skill use
+	// Is used to tell the agent to restart its evaluation if something important changed on the battlefield
+	// which may make the results of previously evaluated behaviors potentially invalid.
+	APBefore = 0;
+	MoraleStateBefore = ::Const.MoraleState.Steady;
+	// The following is set to true when any actor dies or moves while a delayed event is scheduled.
+	// Is set from hooks on actor.onDeath and actor.onMovementFinish
+	ForceReevaluate = false;
 
 	constructor( _skill, _targetTile, _targetEntity, _forFree )
 	{
@@ -25,6 +36,7 @@
 		this.TargetTile = _targetTile;
 		this.TargetEntity = _targetEntity;
 		this.ForFree = _forFree;
+		this.Agent = this.Container.getActor().getAIAgent();
 	}
 
 	function onScheduleComplete()
@@ -34,8 +46,27 @@
 		{
 			if (!::MSU.isNull(this.Container))
 				this.Container.onAnySkillExecutedFully(this.Skill, this.TargetTile, this.TargetEntity, this.ForFree);
+			// this.Count == 0 check because if count is -1 that means no delayed event was scheduled.
+			if (this.Count == 0 && this.didStateChange())
+				this.Agent.m.RF_ForceReevaluate = true;
 			delete ::Reforged.ScheduleSkills[this.Skill];
 		}
+	}
+
+	function saveStartingState()
+	{
+		local actor = this.Container.getActor();
+		this.APBefore = actor.getActionPoints();
+		this.MoraleStateBefore = actor.getMoraleState();
+	}
+
+	function didStateChange()
+	{
+		local actor = this.Container.getActor();
+		if (::MSU.isNull(actor) || !actor.isAlive())
+			return true;
+
+		return this.ForceReevaluate || actor.getMoraleState() != this.MoraleStateBefore || actor.getActionPoints() != this.APBefore;
 	}
 };
 
@@ -69,6 +100,40 @@ local function getSchedulerSkill()
 	return null;
 }
 
+// Returns a wrapped callback function for schedule functions e.g. ::Time.scheduleEvent. The callback
+// is wrapped to trigger the onScheduleComplete() function for the schedule.
+// Also increments the schedule Count of the relevant skill and saves the actor state when at Count 0.
+// Note: _countBump is necessary as a param because ::Tactical.switchEntities needs to increase count by 2 on every call
+// as its callback is triggered twice: once for each entity being switched.
+local function getWrapper( _caller, _func, _numArgs, _countBump = 1 )
+{
+	local schedule = ::Reforged.ScheduleSkills[_caller];
+	if (schedule.Count == 0)
+	{
+		schedule.saveStartingState();
+	}
+	schedule.Count += _countBump;
+
+	if (_numArgs == 1)
+	{
+		return function( _arg1 )
+		{
+			if (_func != null)
+				_func(_arg1);
+			schedule.onScheduleComplete();
+		}
+	}
+	else
+	{
+		return function( _arg1, _arg2 )
+		{
+			if (_func != null)
+				_func(_arg1, _arg2);
+			schedule.onScheduleComplete();
+		}
+	}
+}
+
 // We overwrite the three functions `scheduleEvent`, `teleport` and `switchEntities` to add a custom callback function
 // that triggers the onScheduleComplete event inside ScheduledSkill class.
 
@@ -88,16 +153,7 @@ local scheduleEvent = ::Time.scheduleEvent;
 		return;
 	}
 
-	::Reforged.ScheduleSkills[caller].Count++;
-
-	local function scheduledCallbackWrapper( _arg1 )
-	{
-		if (_func != null)
-			_func(_arg1);
-		::Reforged.ScheduleSkills[caller].onScheduleComplete();
-	}
-
-	scheduleEvent(_timeUnit, _time, scheduledCallbackWrapper, _data);
+	scheduleEvent(_timeUnit, _time, getWrapper(caller, _func, 1), _data);
 }
 
 local teleport = ::TacticalNavigator.teleport;
@@ -110,16 +166,7 @@ local teleport = ::TacticalNavigator.teleport;
 		return;
 	}
 
-	::Reforged.ScheduleSkills[caller].Count++;
-
-	local function scheduledCallbackWrapper( _arg1, _arg2 )
-	{
-		if (_func != null)
-			_func(_arg1, _arg2);
-		::Reforged.ScheduleSkills[caller].onScheduleComplete();
-	}
-
-	teleport(_user, _targetTile, scheduledCallbackWrapper, _data, _bool, _float);
+	teleport(_user, _targetTile, getWrapper(caller, _func, 2), _data, _bool, _float);
 }
 
 local switchEntities = ::TacticalNavigator.switchEntities;
@@ -133,16 +180,7 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 	}
 
 	// Increase count by 2 because the callback is called for both entities
-	::Reforged.ScheduleSkills[caller].Count += 2;
-
-	local function scheduledCallbackWrapper( _arg1, _arg2 )
-	{
-		if (_func != null)
-			_func(_arg1, _arg2);
-		::Reforged.ScheduleSkills[caller].onScheduleComplete();
-	}
-
-	switchEntities(_user, _targetEntity, scheduledCallbackWrapper, _data, _float);
+	switchEntities(_user, _targetEntity, getWrapper(caller, _func, 2, 2), _data, _float);
 }
 
 ::Reforged.HooksMod.hook("scripts/skills/skill_container", function(q) {
@@ -200,13 +238,52 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 });
 
 ::Reforged.HooksMod.hook("scripts/ai/tactical/agent", function(q) {
+	q.m.RF_ForceReevaluate <- false;
 	// Prevent the AI from executing a skill while the previously executed skill has not fully finished executing
 	// including all its delayed effects
 	q.think = @(__original) function( _evaluateOnly = false )
 	{
 		if (::Reforged.ScheduleSkills.len() != 0)
+		{
+			__original(true);
 			return;
+		}
+
+		if (this.m.RF_ForceReevaluate)
+		{
+			this.m.RF_ForceReevaluate = false;
+
+			// This resets the `agent.think` function to start its logic from the beginning
+			this.m.NextBehaviorToEvaluate = -3;
+
+			// Throw away all existing generator functions of threaded behaviors
+			// forcing them to start a fresh evaluation
+			foreach (b in this.m.Behaviors)
+			{
+				b.m.Thread = null;
+			}
+		}
 
 		__original(_evaluateOnly);
+	}
+});
+
+::Reforged.HooksMod.hook("scripts/entity/tactical/actor", function(q) {
+	q.onDeath = @(__original) function( _killer, _skill, _tile, _fatalityType )
+	{
+		foreach (s in ::Reforged.ScheduleSkills)
+		{
+			s.ForceReevaluate = true;
+		}
+		__original(_killer, _skill, _tile, _fatalityType);
+	}
+
+	q.onMovementFinish = @(__original) function( _tile )
+	{
+		foreach (s in ::Reforged.ScheduleSkills)
+		{
+			s.ForceReevaluate = true;
+		}
+		__original(_tile);
 	}
 });

--- a/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
+++ b/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
@@ -346,6 +346,17 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 			this.m.RF_ForceReevaluate = false;
 			this.m.RF_AgentState.save();
 		}
+		// This should fix the crash during evaluation when entities die/move due to delayed effects
+		// because such functions e.g. ai_engage_melee are generators so they yield and continue evaluation
+		// but if we catch it and force a complete reset of evaluation that should avoid the crash easily.
+		// Note: RF_ForceReevaluate is set to true when any entity dies or moves.
+		else if (this.m.RF_ForceReevaluate)
+		{
+			this.RF_reset();
+			// Have to return here otherwise the __original will bump this.m.NextBehaviorToEvalute to 2
+			// causing us to never save the new state again (which is done few lines above in this function).
+			return;
+		}
 		__original(_entity);
 	}
 

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -32,6 +32,12 @@
 	miscTooltipPage.addEnumSetting("CraftingBlueprintVisibility", "One Ingredient Available", ["Always", "One Ingredient Available", "All Ingredients Available", "Vanilla"], "Blueprints Visible When", "Crafting Recipes in the Taxidermist will be displayed when this condition is met.\nNote that individual Blueprints (like Snake Oil) may still have custom rules preventing them from being shown.\n\n\'Vanilla\' means that the visibility behavior is unchanged from how it works in the base game.");
 }
 
+{
+	// Debug
+	local debugPage = ::Reforged.Mod.ModSettings.addPage("Debug");
+	debugPage.addBooleanSetting("Debug_onAnySkillExecutedFully", false, "onAnySkillExecutedFully", "Enable for debug logging of onAnySkillExecutedFully module").addBeforeChangeCallback(@( _newValue ) ::Reforged.Mod.Debug.setFlag("onAnySkillExecutedFully", _newValue));
+}
+
 ::Reforged.Mod.Keybinds.addSQKeybind("Tactical_WaitRound", "h", ::MSU.Key.State.Tactical, function()
 {
 	if (this.m.MenuStack.hasBacksteps() || this.isInputLocked() || this.isInCharacterScreen())

--- a/scripts/!mods_preload/mod_reforged.nut
+++ b/scripts/!mods_preload/mod_reforged.nut
@@ -68,6 +68,7 @@ foreach (requirement in requiredMods)
 	delete ::Reforged.checkConflictWithFilename;
 
 	::Reforged.Mod.Debug.setFlag("ai", false);
+	::Reforged.Mod.Debug.setFlag("onAnySkillExecutedFully", false);
 
 	::include("mod_reforged/hooks/misc.nut");
 	::include("mod_reforged/ui/load.nut");


### PR DESCRIPTION
This should improve AI performance because we allow the AI to evaluate (but not execute) its behaviors while delayed events are scheduled from a used skill. However, if anything important changed in the state during the delayed events e.g. anyone died, or moved, or morale state changed, or Action Points changed, then we force the AI to reevaluate using this new state. This is because any important state change could make the already evaluated behaviors to be no longer valid for execution.