### PR TITLE
onAnySkillExecutedFully improvements for stability and better debugging

### DIFF
--- a/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
+++ b/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
@@ -217,11 +217,16 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 });
 
 ::Reforged.HooksMod.hook("scripts/states/tactical_state", function(q) {
+	q.RF_canExecuteSkill <- { function RF_canExecuteSkill()
+	{
+		return !::Time.hasEventScheduled(::TimeUnit.Virtual) && !::Tactical.getNavigator().IsTravelling;
+	}}.RF_canExecuteSkill;
+
 	q.executeEntitySkill = @(__original) function( _activeEntity, _targetTile )
 	{
 		// Prevent executing a skill while the previously executed skill has not fully finished executing
 		// including all its delayed effects
-		if (::Time.hasEventScheduled(::TimeUnit.Virtual))
+		if (!this.RF_canExecuteSkill())
 		{
 			::Tactical.EventLog.log(::MSU.Text.colorNegative("Already executing a skill!"));
 			return;

--- a/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
+++ b/mod_reforged/hooks/experimental_modules/onAnySkillExecutedFully.nut
@@ -65,10 +65,6 @@ local function getSchedulerSkill()
 	local level = 3;
 	local infos = ::getstackinfos(level);
 
-	// frameUpdate is an MSU keybinds system function which calls ::Time.scheduleEvent on every frame
-	if (infos.func == "frameUpdate")
-		return null;
-
 	do
 	{
 		// We skip native functions, this includes calls from .call or .acall etc.
@@ -122,7 +118,7 @@ local function getWrapper( _caller, _func, _numArgs, _countBump = 1 )
 local scheduleEvent = ::Time.scheduleEvent;
 ::Time.scheduleEvent = function( _timeUnit, _time, _func, _data )
 {
-	if (_timeUnit == ::TimeUnit.Rounds)
+	if (_timeUnit != ::TimeUnit.Virtual)
 	{
 		scheduleEvent(_timeUnit, _time, _func, _data);
 		return;
@@ -225,7 +221,7 @@ local switchEntities = ::TacticalNavigator.switchEntities;
 	{
 		// Prevent executing a skill while the previously executed skill has not fully finished executing
 		// including all its delayed effects
-		if (::Reforged.ScheduleSkills.len() != 0)
+		if (::Time.hasEventScheduled(::TimeUnit.Virtual))
 		{
 			::Tactical.EventLog.log(::MSU.Text.colorNegative("Already executing a skill!"));
 			return;


### PR DESCRIPTION
- When preventing skill execution, instead of checking for `ScheduleSkills.len()` we simply check for any scheduled event with `VirtualTime` or if the `Navigator.IsTravelling`. The former is true for delayed skill effects and the latter is true for `teleport` and `switchEntities`.
- Extracted the logic of allowing skill execution into a separate function. 
- We only consider events scheduled with `TimeUnit.Virtual` as delayed skill effects because this is the only time unit that makes sense to be used for delayed skill effects. This is also in line with what vanilla checks in `turn_sequence_bar.initNextTurn`. It also cleans up the code a bit.
- Improved debugging logs by printing caller ClassName and function name, along with file source and line and callback function name.