### PR TITLE
fix: pummel scheduling a teleport upon killing goblin wolfrider

### DIFF
--- a/scripts/skills/actives/rf_pummel_skill.nut
+++ b/scripts/skills/actives/rf_pummel_skill.nut
@@ -109,7 +109,6 @@ this.rf_pummel_skill <- ::inherit("scripts/skills/actives/line_breaker", {
 			local tag = {
 				User = _user,
 				TargetTile = _targetTile
-				TargetEntity = targetEntity
 			}
 			// Doing this.line_breaker.onUse here directly doesn't work properly:
 			// The targetEntity gets knocked back by Linebreaker, but the attacker does not move to the target tile.
@@ -122,7 +121,7 @@ this.rf_pummel_skill <- ::inherit("scripts/skills/actives/line_breaker", {
 
 	function onPushThrough( _tag )
 	{
-		if (_tag.TargetEntity.isAlive())
+		if (_tag.TargetTile.IsOccupiedByActor && _tag.TargetTile.getEntity().isAlive())
 			this.line_breaker.onUse(_tag.User, _tag.TargetTile);
 		else
 			::Tactical.getNavigator().teleport(_tag.User, _tag.TargetTile, null, null, false);


### PR DESCRIPTION
Goblin Wolfriders spawn a goblin or wolf entity on their tile upon being killed. So, we need to actually check if the tile is now occupied by a living entity instead of checking if our original target entity is still alive.

What is better from a design POV? Executing Line Breaker on the newly spawned entity or instead just not doing anything if the original entity died and there is now a new entity on the tile?