### PR TITLE
balance: reduce goblin pike reach from 7 to 6

### DIFF
--- a/mod_reforged/hooks/items/weapons/greenskins/goblin_pike.nut
+++ b/mod_reforged/hooks/items/weapons/greenskins/goblin_pike.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) { function create()
 	{
 		__original();
-		this.m.Reach = 7;
+		this.m.Reach = 6;
 	}}.create;
 
 	q.onEquip = @() { function onEquip()


### PR DESCRIPTION
This weapon has lower AP cost so this is gameplay-wise a better balance. It is also thematic for the goblin pike to be smaller than a human one.