### PR TITLE
feat: rework deep impact

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1145,7 +1145,7 @@ local vanillaDescriptions = [
 		Effects = [{
 			Type = ::UPD.EffectType.Active,
 			Description = [
-				"Unlocks the [$ $|Skill+rf_deep_impact_skill] skill which allows you to debilitate a target, reducing its damage output."
+				"Unlocks the [$ $|Skill+rf_deep_impact_skill] skill which allows you to debilitate a target."
 			]
 		}]
 	}),

--- a/scripts/skills/actives/rf_deep_impact_skill.nut
+++ b/scripts/skills/actives/rf_deep_impact_skill.nut
@@ -1,8 +1,9 @@
+// This skill is never meant to be added directly to a character. Instead you add another skill to the character
+// and call this skill's convertToDeepImpactSkill function to convert that skill to a deep impact skill.
+// This is because this skill is meant to be a proxy for the AOO of a weapon, but there is no clean way to achieve that.
 this.rf_deep_impact_skill <- ::inherit("scripts/skills/skill", {
 	m = {
-		RequiredWeaponType = null,
-		RequiredDamageType = null,
-		IsAttacking = false // Used to check that this skill was used to trigger the AOO and if yes then apply debuff
+		TwoHandedAPCostAdd = 2
 	},
 	function create()
 	{
@@ -12,138 +13,92 @@ this.rf_deep_impact_skill <- ::inherit("scripts/skills/skill", {
 		this.m.Icon = "skills/rf_deep_impact_skill.png";
 		this.m.IconDisabled = "skills/rf_deep_impact_skill_sw.png";
 		this.m.Overlay = "rf_deep_impact_skill";
-		this.m.Type = ::Const.SkillType.Active;
-		this.m.Order = ::Const.SkillOrder.OffensiveTargeted;
-		this.m.IsSerialized = false;
-		this.m.IsActive = true;
-		this.m.IsTargeted = true;
-		this.m.IsAttack = true;
-		this.m.IsWeaponSkill = true;
 		this.m.IsIgnoredAsAOO = true;
 		this.m.ActionPointCost = 4;
-		this.m.FatigueCost = 30;
-		this.m.MinRange = 1;
-		this.m.MaxRange = 1;
+		this.m.FatigueCost = 25;
 		this.m.AIBehaviorID = ::Const.AI.Behavior.ID.KnockOut;
-	}
-
-	function getCostString()
-	{
-		local aoo = this.getContainer().getAttackOfOpportunity();
-		if (aoo != null && this.isSkillValid(aoo))
-			return this.skill.getCostString();
-
-		return ::Reforged.Mod.Tooltips.parseString("Costs as if your primary attack had a base [Fatigue|Concept.Fatigue] cost of " + ::MSU.Text.colorNegative(this.m.FatigueCost));
 	}
 
 	function getTooltip()
 	{
-		local ret = this.skill.getDefaultUtilityTooltip();
-		if (this.getContainer().getActor().getID() == ::MSU.getDummyPlayer().getID())
-		{
-			ret.push({
-				id = 10,
-				type = "text",
-				icon = "ui/icons/special.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Perform your primary attack on the target and if successful, apply the [$ $|Skill+rf_deep_impact_effect] effect")
-			});
-			return ret;
-		}
+		local ret = this.skill.getDefaultTooltip();
+		ret.extend(this.getDeepImpactTooltip());
 
-		local aoo = this.getContainer().getAttackOfOpportunity();
-		if (aoo == null || !this.isSkillValid(aoo))
+		if (this.m.TwoHandedAPCostAdd != 0 && ::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
 		{
 			ret.push({
 				id = 20,
 				type = "text",
-				icon = "ui/icons/warning.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorNegative("Requires a valid attack"))
-			});
-		}
-		else
-		{
-			ret.push({
-				id = 10,
-				type = "text",
-				icon = "ui/icons/special.png",
-				text = ::Reforged.Mod.Tooltips.parseString(format("Perform a %s on the target and if successful, apply the [$ $|Skill+rf_deep_impact_effect] effect", ::Reforged.NestedTooltips.getNestedSkillName(aoo)))
+				icon = "ui/icons/action_points.png",
+				text = ::Reforged.Mod.Tooltips.parseString("Costs " + ::MSU.Text.colorizeValue(this.m.TwoHandedAPCostAdd, {AddSign = true, InvertColor = true}) + " [Action Points|Concept.ActionPoints] with two-handed hammers")
 			});
 		}
 
 		return ret;
+	}
+
+	function getDeepImpactTooltip()
+	{
+		return [{
+			id = 11,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Upon dealing damage to [Hitpoints|Concept.Hitpoints] inflicts the target with the [Deep Impact|Skill+rf_deep_impact_effect] effect")
+		}];
+	}
+
+	function onItemSet()
+	{
+		if (this.getItem().isItemType(::Const.Items.ItemType.TwoHanded))
+		{
+			this.m.ActionPointCost += this.m.TwoHandedAPCostAdd;
+		}
 	}
 
 	function onAfterUpdate( _properties )
 	{
-		local aoo = this.getContainer().getAttackOfOpportunity();
-		if (aoo != null && this.isSkillValid(aoo))
-		{
-			this.m.ActionPointCost = aoo.m.ActionPointCost;
-			this.m.FatigueCostMult = aoo.m.FatigueCostMult;
-			this.m.MinRange = aoo.m.MinRange;
-			this.m.MaxRange = aoo.m.MaxRange;
-		}
-	}
-
-	// MSU function
-	// overwrite to return AOO damage type instead of our own
-	function getDamageType()
-	{
-		local aoo = this.getContainer().getAttackOfOpportunity();
-		return aoo != null && this.isSkillValid(aoo) ? aoo.getDamageType() : this.skill.getDamageType();
-	}
-
-	function isUsable()
-	{
-		local aoo = this.getContainer().getAttackOfOpportunity();
-		return aoo != null && aoo.isUsable() && this.isSkillValid(aoo);
-	}
-
-	function onVerifyTarget( _originTile, _targetTile )
-	{
-		local aoo = this.getContainer().getAttackOfOpportunity();
-		return aoo != null && aoo.onVerifyTarget(_originTile, _targetTile);
-	}
-
-	// This skill really just serves as a proxy for the AOO. It's job is to trigger the AOO on the target tile
-	function onUse( _user, _targetTile )
-	{
-		local aoo = this.getContainer().getAttackOfOpportunity();
-
-		local overlay = aoo.m.Overlay;
-		aoo.m.Overlay = "";
-
-		this.m.IsAttacking = true;
-		local ret = aoo.useForFree(_targetTile);
-		this.m.IsAttacking = false;
-
-		aoo.m.Overlay = overlay;
-
-		return ret;
+		this.m.FatigueCostMult = _properties.IsSpecializedInHammers ? ::Const.Combat.WeaponSpecFatigueMult : 1.0;
 	}
 
 	function onTargetHit( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
 	{
-		if (!this.m.IsAttacking || !_targetEntity.isAlive() || _damageInflictedHitpoints == 0 || !this.isSkillValid(_skill))
+		if (_skill != this || !_targetEntity.isAlive() || _damageInflictedHitpoints == 0)
 			return;
 
 		local effect = _targetEntity.getSkills().getSkillByID("effects.rf_deep_impact");
 		if (effect == null)
 			effect = ::new("scripts/skills/effects/rf_deep_impact_effect");
 
-		effect.setDamageTotalMult(effect.m.DamageTotalMult - _damageInflictedHitpoints.tofloat() / _targetEntity.getHitpoints());
+		local mult = _damageInflictedHitpoints.tofloat() / _targetEntity.getHitpoints();
+		effect.setDamageTotalMult(effect.m.DamageTotalMult - mult);
+		effect.setSkillMult(effect.m.SkillMult - mult);
 		_targetEntity.getSkills().add(effect);
 	}
 
-	function isSkillValid( _skill )
+	// Converts the given skill to a "deep impact" version of it by modifying some `m` fields and some functions.
+	// Also changes the ID of that skill to deep impact's id.
+	function convertSkill( _skill )
 	{
-		if (!_skill.isAttack() || (this.m.RequiredDamageType != null && !_skill.getDamageType().contains(this.m.RequiredDamageType)))
-			return;
+		foreach (field in ["ID", "Name", "Description", "Icon", "IconDisabled", "Overlay", "IsIgnoredAsAOO", "FatigueCost", "AIBehaviorID"])
+		{
+			_skill.m[field] = this.m[field];
+		}
 
-		if (this.m.RequiredWeaponType == null)
-			return true;
+		_skill.m.__RF_DeepImpactSkill <- this;
 
-		local weapon = _skill.getItem();
-		return !::MSU.isNull(weapon) && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(this.m.RequiredWeaponType);
+		local getTooltip = _skill.getTooltip;
+		_skill.getTooltip = function()
+		{
+			local ret = getTooltip();
+			ret.extend(this.m.__RF_DeepImpactSkill.getDeepImpactTooltip.call(this));
+			return ret;
+		}
+
+		local onTargetHit = _skill.onTargetHit;
+		_skill.onTargetHit = function( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor )
+		{
+			onTargetHit( _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor );
+			this.m.__RF_DeepImpactSkill.onTargetHit.call(this, _skill, _targetEntity, _bodyPart, _damageInflictedHitpoints, _damageInflictedArmor);
+		}
 	}
 });

--- a/scripts/skills/effects/rf_deep_impact_effect.nut
+++ b/scripts/skills/effects/rf_deep_impact_effect.nut
@@ -1,13 +1,16 @@
 this.rf_deep_impact_effect <- ::inherit("scripts/skills/skill", {
 	m = {
-		DamageTotalMult = 1.0, // Needs to be set externally when the effect is added
-		DamageTotalMultMin = 0.5
+		// Both of these need to be set externally when the effect is added
+		SkillMult = 1.0
+		DamageTotalMult = 1.0,
+
+		MultMin = 0.5
 	},
 	function create()
 	{
 		this.m.ID = "effects.rf_deep_impact";
 		this.m.Name = "Deep Impact";
-		this.m.Description = "This character has received a very heavy blow, significantly reducing their combat effectiveness.";
+		this.m.Description = "This character has received a very heavy blow, significantly reducing combat effectiveness.";
 		this.m.Icon = "ui/perks/perk_rf_deep_impact.png";
 		this.m.Overlay = "rf_deep_impact_effect";
 		this.m.IconMini = "rf_deep_impact_effect_mini";
@@ -17,7 +20,12 @@ this.rf_deep_impact_effect <- ::inherit("scripts/skills/skill", {
 
 	function setDamageTotalMult( _d )
 	{
-		this.m.DamageTotalMult = ::Math.maxf(this.m.DamageTotalMultMin, _d);
+		this.m.DamageTotalMult = ::Math.minf(this.m.DamageTotalMult, ::Math.maxf(this.m.MultMin, _d));
+	}
+
+	function setSkillMult( _m )
+	{
+		this.m.SkillMult = ::Math.minf(this.m.SkillMult, ::Math.maxf(this.m.MultMin, _m));
 	}
 
 	function getTooltip()
@@ -30,17 +38,48 @@ this.rf_deep_impact_effect <- ::inherit("scripts/skills/skill", {
 				id = 10,
 				type = "text",
 				icon = "ui/icons/regular_damage.png",
-				text = ::Reforged.Mod.Tooltips.parseString("Damage dealt is reduced by a percentage equal to the ratio of the [Hitpoints|Concept.Hitpoints] damage received to current [Hitpoints|Concept.Hitpoints], up to a maximum of " + ::MSU.Text.colorizeMult(this.m.DamageTotalMultMin))
+				text = ::Reforged.Mod.Tooltips.parseString("Damage dealt, [Melee Skill|Concept.MeleeSkill], [Melee Defense|Concept.MeleeDefense], [Ranged Skill|Concept.RangeSkill] and [Ranged Defense|Concept.RangeDefense] are reduced by a percentage equal to the ratio of the [Hitpoints|Concept.Hitpoints] damage received to current [Hitpoints,|Concept.Hitpoints] up to a maximum of " + ::MSU.Text.colorizeMult(this.m.MultMin))
 			});
 		}
 		else
 		{
-			ret.push({
-				id = 10,
-				type = "text",
-				icon = "ui/icons/regular_damage.png",
-				text = ::MSU.Text.colorizeMult(::Math.round(this.m.DamageTotalMult * 100) / 100.0) + " less damage dealt "
-			});
+			if (this.m.DamageTotalMult != 1.0)
+			{
+				ret.push({
+					id = 10,
+					type = "text",
+					icon = "ui/icons/regular_damage.png",
+					text = ::MSU.Text.colorizeMultWithText(this.m.DamageTotalMult) + " damage dealt"
+				});
+			}
+
+			if (this.m.SkillMult != 1.0)
+			{
+				ret.push({
+					id = 11,
+					type = "text",
+					icon = "ui/icons/melee_skill.png",
+					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMultWithText(this.m.SkillMult) + " [Melee Skill|Concept.MeleeSkill]")
+				});
+				ret.push({
+					id = 12,
+					type = "text",
+					icon = "ui/icons/melee_defense.png",
+					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMultWithText(this.m.SkillMult) + " [Melee Defense|Concept.MeleeDefense]")
+				});
+				ret.push({
+					id = 13,
+					type = "text",
+					icon = "ui/icons/ranged_skill.png",
+					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMultWithText(this.m.SkillMult) + " [Ranged Skill|Concept.RangeSkill]")
+				});
+				ret.push({
+					id = 14,
+					type = "text",
+					icon = "ui/icons/ranged_defense.png",
+					text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorizeMultWithText(this.m.SkillMult) + " [Ranged Defense|Concept.RangeDefense]")
+				});
+			}
 		}
 
 		return ret;
@@ -49,6 +88,10 @@ this.rf_deep_impact_effect <- ::inherit("scripts/skills/skill", {
 	function onUpdate( _properties )
 	{
 		_properties.DamageTotalMult *= this.m.DamageTotalMult;
+		_properties.MeleeSkillMult *= this.m.SkillMult;
+		_properties.MeleeDefenseMult *= this.m.SkillMult;
+		_properties.RangedSkillMult *= this.m.SkillMult;
+		_properties.RangedDefenseMult *= this.m.SkillMult;
 	}
 
 	function onTurnEnd()

--- a/scripts/skills/perks/perk_rf_deep_impact.nut
+++ b/scripts/skills/perks/perk_rf_deep_impact.nut
@@ -1,8 +1,5 @@
 this.perk_rf_deep_impact <- ::inherit("scripts/skills/skill", {
-	m = {
-		RequiredWeaponType = ::Const.Items.WeaponType.Hammer,
-		RequiredDamageType = ::Const.Damage.DamageType.Blunt
-	},
+	m = {},
 	function create()
 	{
 		this.m.ID = "perk.rf_deep_impact";
@@ -15,37 +12,38 @@ this.perk_rf_deep_impact <- ::inherit("scripts/skills/skill", {
 
 	function onEquip( _item )
 	{
-		if (this.m.RequiredWeaponType == null || !_item.isItemType(::Const.Items.ItemType.Weapon) || !_item.isWeaponType(this.m.RequiredWeaponType))
-			return;
-
-		local self = this;
-		_item.addSkill(::Reforged.new("scripts/skills/actives/rf_deep_impact_skill", function(o) {
-			o.m.RequiredWeaponType = self.m.RequiredWeaponType;
-			o.m.RequiredDamageType = self.m.RequiredDamageType;
-		}));
+		if (_item.isItemType(::Const.Items.ItemType.Weapon) && _item.isWeaponType(::Const.Items.WeaponType.Hammer))
+		{
+			local aoo = this.getContainer().getAttackOfOpportunity();
+			if (aoo != null)
+			{
+				local s = ::new(::IO.scriptFilenameByHash(aoo.ClassNameHash));
+				::new("scripts/skills/actives/rf_deep_impact_skill").convertSkill(s);
+				_item.addSkill(s);
+			}
+		}
 	}
 
 	function onAdded()
 	{
-		if (this.m.RequiredWeaponType == null)
-		{
-			local self = this;
-			this.getContainer().add(::Reforged.new("scripts/skills/actives/rf_deep_impact_skill", function(o) {
-				o.m.RequiredWeaponType = self.m.RequiredWeaponType;
-				o.m.RequiredDamageType = self.m.RequiredDamageType;
-			}));
-		}
-		else
-		{
-			local weapon = this.getContainer().getActor().getMainhandItem();
-			if (weapon != null)
-				this.onEquip(weapon);
-		}
+		local weapon = this.getContainer().getActor().getMainhandItem();
+		if (weapon != null)
+			this.onEquip(weapon);
 	}
 
 	function onRemoved()
 	{
-		if (this.m.RequiredWeaponType == null)
-			this.getContainer().removeByID("actives.rf_deep_impact");
+		local weapon = this.getContainer().getActor().getMainhandItem();
+		if (weapon != null && weapon.isItemType(::Const.Items.ItemType.Weapon) && weapon.isWeaponType(::Const.Items.WeaponType.Hammer))
+		{
+			foreach (s in weapon.m.SkillPtrs)
+			{
+				if (s.getID() == "actives.rf_deep_impact")
+				{
+					weapon.removeSkill(s);
+					break;
+				}
+			}
+		}
 	}
 });


### PR DESCRIPTION
- No longer a proxy skill, instead is a new skill of its own.
- Streamline code to be a hammer only skill.
- Reduce Fatigue Cost from 30 to 25.
- Costs 4 AP with one-handed but 6 AP with two-handed hammers.
- Buff Deep Impact effect to also reduce melee skill, ranged skill, melee defense and ranged defense in addition to damage.