### PR TITLE
feat: properly set-up oninit for zombie treasure hunter

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/zombie_treasure_hunter.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/zombie_treasure_hunter.nut
@@ -1,16 +1,17 @@
-// ::Reforged.HooksMod.hook("scripts/entity/tactical/enemies/zombie_treasure_hunter", function(q) {
-// 	q.onInit = @(__original) function()
-// 	{
-// 		// copy vanilla function contents completely
-// 		// and replace skills except equipment based skills
-// 		// NOTE: Remove the hook on onInit completely if unused
-// 	}
-
-//
-// 	q.assignRandomEquipment = @(__original) function()
-// 	{
-// 		__original();
-
-// 		// any skills that should be added based on equipment
-// 	}
-// });
+::Reforged.HooksMod.hook("scripts/entity/tactical/enemies/zombie_treasure_hunter", function(q) {
+	q.onInit = @(__original) function()
+	{
+		this.zombie_knight.onInit();
+		local b = this.m.BaseProperties;
+		b.setValues(::Const.Tactical.Actor.ZombieTreasureHunter);
+		// b.SurroundedBonus = 10;	// This is now controlled by them having 'Backstabber'
+		// b.IsAffectedByNight = false;	// Redundant. Set via rf_zombie_racial
+		// b.IsAffectedByInjuries = false;	// Redundant. Set via rf_zombie_racial
+		// b.IsImmuneToBleeding = true;	// Redundant. Set via rf_zombie_racial
+		// b.IsImmuneToPoison = true;	// Redundant. Set via rf_zombie_racial
+		// b.FatigueDealtPerHitMult = 2.0;	// Set via rf_zombie_racial
+		b.DamageTotalMult = 1.25;
+		b.DamageReceivedArmorMult = 0.75;
+		this.m.Skills.update();
+	}
+});


### PR DESCRIPTION
I'm not entirely sure this is necessary but I believe some of zombie treasure hunter's oninit changes were multiplying because we hadn't commented them out (surroundedbonus, fatiguedealtperhitmult)