### PR TITLE
fix: schrat shield spawning sapling on blocking ranged attacks

### DIFF
--- a/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
+++ b/mod_reforged/hooks/items/shields/special/craftable_schrat_shield.nut
@@ -24,7 +24,7 @@
 
 	q.onShieldHit = @() { function onShieldHit( _attacker, _skill )
 	{
-		if (!::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()) && this.getCondition() >= this.m.SpawnSaplingConditionThreshold && this.getCondition() > this.m.SpawnSaplingConditionLoss)
+		if (!_skill.isRanged() && !::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()) && this.getCondition() >= this.m.SpawnSaplingConditionThreshold && this.getCondition() > this.m.SpawnSaplingConditionLoss)
 		{
 			this.spawnSapling();
 		}


### PR DESCRIPTION
It makes no sense for them to spawn it on blocking ranged attacks and this wasn't intended as far as I know.