### PR TITLE
fix: vanilla sergeant perk not showing any perk description

### DIFF
--- a/mod_reforged/config/perk_defs.nut
+++ b/mod_reforged/config/perk_defs.nut
@@ -9,6 +9,14 @@
 		IconDisabled = "skills/passive_03.png"
 	},
 	{
+		ID = "perk.captain",
+		Script = "scripts/skills/perks/perk_captain",
+		Name = ::Const.Strings.PerkName.Captain,
+		Tooltip = ::Const.Strings.PerkDescription.Captain,
+		Icon = "ui/perks/perk_12.png",	// TODO
+		IconDisabled = "ui/perks/perk_12.png"	// TODO
+	},
+	{
 		ID = "perk.devastating_strikes",
 		Script = "scripts/skills/perks/perk_devastating_strikes",
 		Name = ::Const.Strings.PerkName.DevastatingStrikes,

--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -219,6 +219,20 @@ local vanillaDescriptions = [
 		})
 	},
 	{
+		ID = "perk.captain",
+		Key = "Captain",
+		Description = ::UPD.getDescription({
+			Fluff = "Use a sergeant on the battlefield as an extension of your leadership and to keep everyone in line.",
+			Effects = [{
+				Type = ::UPD.EffectType.Passive,
+				Description = [
+					"Allies from your faction within " + ::MSU.Text.colorPositive("5") + " tiles gain [Resolve|Concept.Bravery] equals to " + ::MSU.Text.colorPositive("15%") + " of your [Resolve.|Concept.Bravery]",
+					"This effect does not stack. Only the Sergeant with the highest [Resolve|Concept.Bravery] will apply the bonus."
+				]
+			}]
+		})
+	},
+	{
 		ID = "perk.rotation",
 		Key = "Rotation",
 		Description = ::UPD.getDescription({


### PR DESCRIPTION
This fix does not work and I don't have an idea why.

This is the error:
<img width="1814" height="761" alt="image" src="https://github.com/user-attachments/assets/ee119584-d9e2-4e9b-b3f6-396d3daf71f8" />

When I write 
`ID = "perk.rotation"`
instead of
`ID = "perk.captain",`
then I get no errors, but most likely this then does not work correctly.