### PR TITLE
refactor(style): sort hedgeknight perks similar to other enemy hooks

### DIFF
--- a/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
@@ -10,20 +10,26 @@
 		this.m.CurrentProperties = clone b;
 		this.setAppearance();
 		this.getSprite("socket").setBrush("bust_base_military");
-		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_battle_fervor"));
-		this.m.Skills.add(::new("scripts/skills/perks/perk_battle_forged"));
-		this.m.Skills.add(::new("scripts/skills/perks/perk_berserk"));
-		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_bully"));
+		// this.m.Skills.add(::new("scripts/skills/perks/perk_brawny"));
+		// this.m.Skills.add(::new("scripts/skills/perks/perk_fast_adaption"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_crippling_strikes"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_coup_de_grace"));
+		// this.m.Skills.add(::new("scripts/skills/perks/perk_devastating_strikes"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_battle_forged"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_battle_flow"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_fearsome"));
-		// this.m.Skills.add(::new("scripts/skills/perks/perk_rf_heartless"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_killing_frenzy"));
-		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_menacing"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_berserk"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_hold_out"));
+		// this.m.Skills.add(::new("scripts/skills/perks/perk_reach_advantage"));
+
+		// Reforged
+		this.m.Skills.add(::new("scripts/skills/perks/perk_underdog"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_battle_fervor"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_bully"));
+		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_menacing"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_savage_strength"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_survival_instinct"));
-		this.m.Skills.add(::new("scripts/skills/perks/perk_underdog"));
 	}}.onInit;
 
 	q.assignRandomEquipment = @() { function assignRandomEquipment()


### PR DESCRIPTION
Add Reforged category with reforged additions
Sort Vanilla perks to to be in line with vanillas order 
Add commented versions of perks that vanilla added to them 
Remove commented non-existing perk_rf_heartless from hedgeknight