### PR TITLE
refactor: remove stun warning from line breaker skill

### DIFF
--- a/scripts/skills/actives/rf_cover_ally_skill.nut
+++ b/scripts/skills/actives/rf_cover_ally_skill.nut
@@ -46,13 +46,13 @@ this.rf_cover_ally_skill <- ::inherit("scripts/skills/skill", {
 			}
 		]);
 
-		if (this.getContainer().getActor().getCurrentProperties().IsRooted || this.getContainer().getActor().getCurrentProperties().IsStunned)
+		if (this.getContainer().getActor().getCurrentProperties().IsRooted)
 		{
 			ret.push({
 				id = 20,
 				type = "text",
 				icon = "ui/icons/warning.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorNegative("Cannot be used while Rooted or [Stunned|Skill+stunned_effect]"))
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorNegative("Cannot be used while [Rooted|Concept.Rooted]"))
 			});
 		}
 

--- a/scripts/skills/actives/rf_line_breaker_skill.nut
+++ b/scripts/skills/actives/rf_line_breaker_skill.nut
@@ -24,13 +24,13 @@ this.rf_line_breaker_skill <- ::inherit("scripts/skills/actives/line_breaker", {
 	{
 		local ret = this.skill.getDefaultUtilityTooltip();
 
-		if (this.getContainer().getActor().getCurrentProperties().IsRooted || this.getContainer().getActor().getCurrentProperties().IsStunned)
+		if (this.getContainer().getActor().getCurrentProperties().IsRooted)
 		{
 			ret.push({
 				id = 10,
 				type = "text",
 				icon = "ui/icons/warning.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorNegative("Cannot be used while Rooted or [Stunned|Skill+stunned_effect]"))
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorNegative("Cannot be used while [Rooted|Concept.Rooted]"))
 			});
 		}
 

--- a/scripts/skills/actives/rf_swordmaster_push_through_skill.nut
+++ b/scripts/skills/actives/rf_swordmaster_push_through_skill.nut
@@ -49,13 +49,13 @@ this.rf_swordmaster_push_through_skill <- ::inherit("scripts/skills/actives/line
 			text = ::Reforged.Mod.Tooltips.parseString("If the attack is successful, automatically use [Line Breaker|Skill+line_breaker] for free on the target")
 		});
 
-		if (actor.getCurrentProperties().IsRooted || actor.getCurrentProperties().IsStunned)
+		if (actor.getCurrentProperties().IsRooted)
 		{
 			ret.push({
 				id = 10,
 				type = "text",
 				icon = "ui/icons/warning.png",
-				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorNegative("Cannot be used while Rooted or [Stunned|Skill+stunned_effect]"))
+				text = ::Reforged.Mod.Tooltips.parseString(::MSU.Text.colorNegative("Cannot be used while [Rooted|Concept.Rooted]"))
 			});
 		}
 


### PR DESCRIPTION
It commonly understood that someone who is stunned has no turn at all 
So it is redundant to write a warning about that in every active skill