### PR TITLE
fix: RF_HasOnSpawnBeenCalled not being reset for player characters

### DIFF
--- a/mod_reforged/hooks/experimental_modules/onSpawnEntity.nut
+++ b/mod_reforged/hooks/experimental_modules/onSpawnEntity.nut
@@ -123,6 +123,15 @@
 		}}.onAfterInit;
 	});
 
+	::Reforged.HooksMod.hookTree("scripts/entity/tactical/player", function(q) {
+		// Player characters partake in multiple battles but only ever trigger onAfterInit once per session, so we need to reset RF_HasOnSpawnBeenCalled here too
+		q.onCombatFinished = @(__original) { function onCombatFinished()
+		{
+			__original();
+			this.m.RF_HasOnSpawnBeenCalled = false;
+		}}.onCombatFinished;
+	});
+
 	// Alternative approach instead of hooking actor.onResurrected
 	// this will allow the actor to be safely killed inside onSpawn but
 	// requires the code to be a bit uglier AND has an edge case where we can't handle


### PR DESCRIPTION
As a result, if we implemented a new perk which implements an effect during `onSpawned`, then it would only work for the first battle after loading a save.
In every other battle the event is no longer triggered for player characters