### PR TITLE
fix: bug preventing slinging of multiple pots of the same type

### DIFF
--- a/mod_reforged/inherit_helper.nut
+++ b/mod_reforged/inherit_helper.nut
@@ -17,6 +17,7 @@
 				this.m.MaxLevelDifference = 4;	// Flasks have 3
 				this.m.IsRanged = true;	// Causes you to be able to sling further when shooting downhill
 				this.m.IsHidden = true;
+				this.m.IsStacking = true;	// Multiple of the same skills are allowed be present in parallel. If this is false, then we run into a bug when trying to sling the same pot twice during the same fight
 				this.m.ProjectileTimeScale = 1.0	// Flasks have 1.5 which makes the projectile slower
 			}
 


### PR DESCRIPTION
Since IsStacking was set to false, this skill was only added once when multiple pots were present. And this one skill was connected to its item/ammo via the setItem instance, which can hold only one item After you used this skill once the getItem item is consumed and now null It does not automatically update the reference to point on the next item