### PR TITLE
Refactor attractionmult on npcs

### DIFF
--- a/mod_reforged/hooks/entity/tactical/humans/desert_stalker.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/desert_stalker.nut
@@ -29,6 +29,7 @@
 		// this.m.Skills.add(::new("scripts/skills/actives/recover_skill"));	// Now granted to all humans by default
 
 		//Reforged
+		b.TargetAttractionMult = 1.1;
 		b.RangedDefense += 15;
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rotation"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_footwork"));

--- a/scripts/entity/tactical/humans/rf_arbalester_heavy.nut
+++ b/scripts/entity/tactical/humans/rf_arbalester_heavy.nut
@@ -21,6 +21,7 @@ this.rf_arbalester_heavy <- ::inherit("scripts/entity/tactical/human" {
 		this.human.onInit();
 		local b = this.m.BaseProperties;
 		b.setValues(::Const.Tactical.Actor.RF_ArbalesterHeavy);
+		b.TargetAttractionMult = 1.1;
 		this.m.ActionPoints = b.ActionPoints;
 		this.m.Hitpoints = b.Hitpoints;
 		this.m.CurrentProperties = clone b;


### PR DESCRIPTION
The Heavy Arbalester had it coming with this mult, as the vanilla Crossbowman version already had this.
And the desert stalker getting this is in line with the regular nomad archer having the attraction multiplier.

There is an argument for also giving the Master Archer such an attraction multiplier, but I havent done that here