### PR TITLE
fix: first AI at start of round sometimes ignoring resurrected zombies

### DIFF
--- a/mod_reforged/hooks/experimental_modules/ai_agent_fixes.nut
+++ b/mod_reforged/hooks/experimental_modules/ai_agent_fixes.nut
@@ -263,6 +263,23 @@
 	// We use an array because one callback may trigger another and we to support a stack of those.
 	q.m.RF_switchEntitiesCallbacks <- [];
 
+	// Force the currently active entity to throw away his picked behavior and reevalute if anyone resurrected
+	// This will solve situations where they otherwise ignore freshly resurrected zombie and disrespect their zone of control
+	q.onResurrected = @(__original) { function onResurrected( _tile )
+	{
+		__original(_tile);
+
+		local activeEntity = ::Tactical.TurnSequenceBar.getActiveEntity();
+		if (activeEntity != null)
+		{
+			activeEntity.getAIAgent().m.RF_AgentState.invalidate(format("%s (%i).onResurrected", this.getName(), this.getID()));
+		}
+		else
+		{
+			::logError(format("onResurrected activeEntity null. %s (%i) ", this.getName(), this.getID()));
+		}
+	}}.onResurrected;
+
 	// Force the currently active entity to throw away his picked behavior and reevalute if anyone moved
 	q.onMovementFinish = @(__original) { function onMovementFinish( _tile )
 	{


### PR DESCRIPTION
Currently there is a bug in Reforged (and probably Vanilla too), where the first NPC in a round will think and evaluate his options, while zombies are still resurrecting, and he therefor won't consider those as options or danger.
Most notably dogs will "disrespect" resurrecting zombies and can die in the process.

I have not tested out this in practice.
Its mainly copied from how we handle onMovementEnd of an actor

The timing should be correct though, as the onResurrect calls happen in sequence with a small delay and the NPC only acts after all are resurrected.