### PR TITLE
fix: errors when trying to sling acid flasks or holy water

### DIFF
--- a/mod_reforged/hooks/skills/actives/throw_acid_flask.nut
+++ b/mod_reforged/hooks/skills/actives/throw_acid_flask.nut
@@ -1,0 +1,9 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/throw_acid_flask", function(q) {
+// New Functions
+	// Our slingItemSkill mechanic (see inherit_helper.nut) requires those thrown object skills to contain an onApply function
+	// That is true for many throw item skills, except throw_acid_flask, so we introduce that function here and redirect it to the onApplyAcid function
+	q.onApply <- function( _data )
+	{
+		return this.onApplyAcid(_data);
+	}
+});

--- a/mod_reforged/hooks/skills/actives/throw_holy_water.nut
+++ b/mod_reforged/hooks/skills/actives/throw_holy_water.nut
@@ -1,0 +1,9 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/throw_holy_water", function(q) {
+// New Functions
+	// Our slingItemSkill mechanic (see inherit_helper.nut) requires those thrown object skills to contain an onApply function
+	// That is true for many throw item skills, except throw_holy_water, so we introduce that function here and redirect it to the onApplyEffect function
+	q.onApply <- function( _data )
+	{
+		return this.onApplyEffect(_data);
+	}
+});


### PR DESCRIPTION
I tested this fix out for both items.
Before the fix the acid flask crashed my game instantly while the holy water only glitched out the UI