### PR TITLE
refactor: remove hard-coded hard-to-mod unit costs

### DIFF
--- a/mod_reforged/hooks/config/spawnlist_master.nut
+++ b/mod_reforged/hooks/config/spawnlist_master.nut
@@ -22,11 +22,17 @@
 ::Const.World.Spawn.Troops.BanditLeader.Strength = 40; // vanilla 30
 ::Const.World.Spawn.Troops.BanditLeader.Cost = 40; // vanilla 25
 
+// Beasts
+::Const.World.Spawn.Troops.SandGolemMEDIUM.Cost = 42; // vanilla 35
+::Const.World.Spawn.Troops.SandGolemHIGH.Cost = 129; // vanilla 70
+
 //Civilian
+::Const.World.Spawn.Troops.CaravanDonkey.Cost = 10; // Vanilla 0
 ::Const.World.Spawn.Troops.HedgeKnight.Strength = 45; // vanilla 40
 ::Const.World.Spawn.Troops.HedgeKnight.Cost = 45; // vanilla 40
 ::Const.World.Spawn.Troops.MasterArcher.Strength = 45; // vanilla 40
 ::Const.World.Spawn.Troops.MasterArcher.Cost = 45; // vanilla 40
+::Const.World.Spawn.Troops.MilitiaVeteran.Cost = 15; // Vanilla 12
 ::Const.World.Spawn.Troops.Swordmaster.Strength = 45; // vanilla 40
 ::Const.World.Spawn.Troops.Swordmaster.Cost = 45; // vanilla 40
 
@@ -42,6 +48,10 @@
 ::Const.World.Spawn.Troops.Greatsword.NameList <- ::Const.Strings.CharacterNames;
 ::Const.World.Spawn.Troops.Greatsword.TitleList <- ::Const.Strings.RF_ZweihanderTitles;
 ::Const.World.Spawn.Troops.Knight.Strength = 45; // vanilla 40
+::Const.World.Spawn.Troops.MilitaryDonkey.Cost = 10; // Vanilla 0
+
+// Southern
+::Const.World.Spawn.Troops.SouthernDonkey.Cost = 10; // Vanilla 0
 
 // Cost is handled in bandit_units.nut
 ::MSU.Table.merge(::Const.World.Spawn.Troops, {

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/beast_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/beast_units.nut
@@ -91,13 +91,11 @@ local units = [
 		ID = "Unit.RF.SandGolemMEDIUM",
 		Troop = "SandGolemMEDIUM",
 		Figure = "figure_golem_01",
-		Cost = 42	// 35 in Vanilla, 3 Small Golems should cost slightly less than 1 Medium Golem because they always spend their first turn action morphing
 	},
 	{	// In Vanilla these never spawn naturally as part of the line-up
 		ID = "Unit.RF.SandGolemHIGH",
 		Troop = "SandGolemHIGH",
 		Figure = "figure_golem_02",	// I don't know if a 'figure_golem_03' exists
-		Cost = 129	// 70 in Vanilla, -!!-
 	}
 
 	// Possible Hexen
@@ -110,7 +108,6 @@ local units = [
 		ID = "Unit.RF.HexeOneSpider",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
-		Cost = 50,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SpiderBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false }
@@ -121,7 +118,6 @@ local units = [
 		ID = "Unit.RF.HexeTwoSpider",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
-		Cost = 50,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SpiderBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false }
@@ -132,7 +128,6 @@ local units = [
 		ID = "Unit.RF.HexeOneDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
-		Cost = 50,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "DirewolfBodyguards", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false }
@@ -143,7 +138,6 @@ local units = [
 		ID = "Unit.RF.HexeTwoDirewolf",
 		Troop = "Hexe",
 		Figure = "figure_hexe_01",
-		Cost = 50,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "DirewolfBodyguards", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false }

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/human_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/human_units.nut
@@ -36,7 +36,6 @@ local units = [
 	{
 		ID = "Unit.RF.CaravanDonkey",
 		Troop = "CaravanDonkey",
-		Cost = 10,	// 0 in Vanilla
 		Figure = "cart_02"
 	},
 
@@ -52,12 +51,10 @@ local units = [
 	{
 		ID = "Unit.RF.MilitiaVeteran",
 		Troop = "MilitiaVeteran",
-		Cost = 15	// Vanilla 12
 	},
 	{
 		ID = "Unit.RF.MilitiaCaptain",
 		Troop = "MilitiaCaptain",
-		Cost = 20,
 		StartingResourceMin = 144	// In Vanilla they appear in a group of 144 cost
 	},
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/noble_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/noble_units.nut
@@ -52,7 +52,6 @@ local units = [
 	{	// This already exists under human_units but noble caravans use a different figure
 		ID = "Unit.RF.NobleCaravanDonkey",
 		Troop = "CaravanDonkey",
-		Cost = 0,	// 0 in Vanilla
 		Figure = "cart_01"
 	},
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/southern_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/southern_units.nut
@@ -47,7 +47,6 @@ local units = [
 		ID = "Unit.RF.SouthernDonkey",
 		Troop = "SouthernDonkey",
 		Figure = "cart_03",
-		Cost = 10	// 0 in Vanilla
 	}
 ]
 

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/undead_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/undead_units.nut
@@ -109,7 +109,6 @@ local units = [
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 300,
-		Cost = 40,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyPrae", IsUsingTopPartyResources = false }
@@ -121,7 +120,6 @@ local units = [
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 325,
-		Cost = 40,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyPrae2", IsUsingTopPartyResources = false }
@@ -133,7 +131,6 @@ local units = [
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 350,
-		Cost = 40,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyPraeHonor", IsUsingTopPartyResources = false }
@@ -145,7 +142,6 @@ local units = [
 		Troop = "SkeletonPriest",
 		Figure = "figure_skeleton_04",
 		StartingResourceMin = 375,
-		Cost = 40,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyHonor2", IsUsingTopPartyResources = false }

--- a/mod_reforged_AfterHooks/dynamic_spawns/units/zombie_units.nut
+++ b/mod_reforged_AfterHooks/dynamic_spawns/units/zombie_units.nut
@@ -34,7 +34,6 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 100, // In Vanilla they appear in a group of 100 cost
-		Cost = 30,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyYeoman", IsUsingTopPartyResources = false }
@@ -46,7 +45,6 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 320, // In Vanilla they appear in a group of 320 cost
-		Cost = 30,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyKnight", IsUsingTopPartyResources = false }
@@ -58,7 +56,6 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 360, // In Vanilla they appear in a group of 415 cost
-		Cost = 30,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyYeomanKnight", IsUsingTopPartyResources = false }
@@ -70,7 +67,6 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 420, // In Vanilla they appear in a group of 415 cost
-		Cost = 30,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyKnightKnight", IsUsingTopPartyResources = false }
@@ -84,7 +80,6 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 110,
-		Cost = 30,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1, IsUsingTopPartyResources = false }
@@ -96,7 +91,6 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 130,
-		Cost = 30,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2, IsUsingTopPartyResources = false }
@@ -108,7 +102,6 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		StartingResourceMin = 170,
-		Cost = 30,
 		StaticDefs = {
 			Parties = [
 				{ BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3, IsUsingTopPartyResources = false }


### PR DESCRIPTION
All units we register automatically fetch a `Cost` value from the SpawnlistMaster entries, if no hard-coded one was defined for them.
This commit removes the hard-coded cost entries and it also moves those adjustments over into the `spawnlist_master`, where they differ from Vanilla. Hexen and Necromancer for example dont differ and therefor dont need entries there