### PR TITLE
feat: add info about free swap per turn to dagger weapons tooltip

### DIFF
--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -53,6 +53,16 @@
 			}
 		}
 
+		if (this.isWeaponType(::Const.Items.WeaponType.Dagger, true, true))
+		{
+			ret.push({
+				id = 30,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("The first swap every [turn|Concept.Turn] to/from this weapon costs no [Action Points|Concept.ActionPoints]")
+			});
+		}
+
 		return ret;
 	}}.getTooltip;
 


### PR DESCRIPTION
This will help clarify it for players as it is a rather hidden feature. See for example the player's confusion here: https://discord.com/channels/1006908336991645757/1006909211919274096/1423730587113361539