### PR TITLE
refactor: add (x2) to blueprints, which grant two items upon crafting

### DIFF
--- a/mod_reforged/hooks/crafting/blueprints/acid_flask_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/acid_flask_blueprint.nut
@@ -1,4 +1,9 @@
 ::Reforged.HooksMod.hook("scripts/crafting/blueprints/acid_flask_blueprint", function(q) {
+	q.getName = @(__original) { function getName()
+	{
+		return __original() + " (x2)";	// We adjust the name of the recipe to communicate that you receive two of them
+	}}.getName;
+
 	q.onCraft = @(__original) { function onCraft( _stash )
 	{
 		__original(_stash);

--- a/mod_reforged/hooks/crafting/blueprints/daze_bomb_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/daze_bomb_blueprint.nut
@@ -1,4 +1,9 @@
 ::Reforged.HooksMod.hook("scripts/crafting/blueprints/daze_bomb_blueprint", function(q) {
+	q.getName = @(__original) { function getName()
+	{
+		return __original() + " (x2)";	// We adjust the name of the recipe to communicate that you receive two of them
+	}}.getName;
+
 	q.onCraft = @(__original) { function onCraft( _stash )
 	{
 		__original(_stash);

--- a/mod_reforged/hooks/crafting/blueprints/fire_bomb_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/fire_bomb_blueprint.nut
@@ -1,4 +1,9 @@
 ::Reforged.HooksMod.hook("scripts/crafting/blueprints/fire_bomb_blueprint", function(q) {
+	q.getName = @(__original) { function getName()
+	{
+		return __original() + " (x2)";	// We adjust the name of the recipe to communicate that you receive two of them
+	}}.getName;
+
 	q.onCraft = @(__original) { function onCraft( _stash )
 	{
 		__original(_stash);

--- a/mod_reforged/hooks/crafting/blueprints/smoke_bomb_blueprint.nut
+++ b/mod_reforged/hooks/crafting/blueprints/smoke_bomb_blueprint.nut
@@ -1,4 +1,9 @@
 ::Reforged.HooksMod.hook("scripts/crafting/blueprints/smoke_bomb_blueprint", function(q) {
+	q.getName = @(__original) { function getName()
+	{
+		return __original() + " (x2)";	// We adjust the name of the recipe to communicate that you receive two of them
+	}}.getName;
+
 	q.onCraft = @(__original) { function onCraft( _stash )
 	{
 		__original(_stash);


### PR DESCRIPTION
This is how it looks after this change:

<img width="1006" height="567" alt="image" src="https://github.com/user-attachments/assets/9c40c5dd-68ec-4f1c-ab36-b88b67a89c2e" />