### PR TITLE
fix(vanilla): remove redundant injury definitions from disarm skill

### DIFF
--- a/mod_reforged/hooks/skills/actives/disarm_skill.nut
+++ b/mod_reforged/hooks/skills/actives/disarm_skill.nut
@@ -1,0 +1,12 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/disarm_skill", function(q) {
+	q.create = @(__original) { function create()
+	{
+		__original();
+
+		// VanillaFix: We remove the injuries from this skill as it doesnt deal damage anyways
+		// This will prevent MSU from falsely displaying a damage type in the description
+		// This is in line with how other utility skills like Repel or Hook leave these members on their default value
+		this.m.InjuriesOnBody = null;
+		this.m.InjuriesOnHead = null;
+	}}.create;
+});


### PR DESCRIPTION
Possible patch note for Reforged:
- Remove misleading damage type line from disarm skill tooltip