### PR TITLE
feat: move damage of vanilla skills to onAnySkillUsed

### DIFF
--- a/mod_reforged/hooks/skills/actives/ghastly_touch.nut
+++ b/mod_reforged/hooks/skills/actives/ghastly_touch.nut
@@ -11,4 +11,6 @@
 	{
 		return this.skill.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/ghoul_claws.nut
+++ b/mod_reforged/hooks/skills/actives/ghoul_claws.nut
@@ -4,4 +4,6 @@
 	{
 		return this.skill.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/gore_skill.nut
+++ b/mod_reforged/hooks/skills/actives/gore_skill.nut
@@ -18,4 +18,6 @@
 		});
 		return ret;
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/greater_flesh_golem_attack_skill.nut
+++ b/mod_reforged/hooks/skills/actives/greater_flesh_golem_attack_skill.nut
@@ -11,4 +11,6 @@
 	{
 		return this.skill.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/hand_to_hand.nut
+++ b/mod_reforged/hooks/skills/actives/hand_to_hand.nut
@@ -26,4 +26,6 @@
 			_properties.MeleeSkill = old_MeleeSkill; // This reverts the vanilla -10 Modifier
 		}
 	}}.onAnySkillUsed;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/hand_to_hand_orc.nut
+++ b/mod_reforged/hooks/skills/actives/hand_to_hand_orc.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/hand_to_hand_orc", function(q) {
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
+});

--- a/mod_reforged/hooks/skills/actives/hyena_bite_skill.nut
+++ b/mod_reforged/hooks/skills/actives/hyena_bite_skill.nut
@@ -18,4 +18,6 @@
 		});
 		return ret;
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/kraken_bite_skill.nut
+++ b/mod_reforged/hooks/skills/actives/kraken_bite_skill.nut
@@ -18,4 +18,6 @@
 		});
 		return ret;
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/lesser_flesh_golem_attack_skill.nut
+++ b/mod_reforged/hooks/skills/actives/lesser_flesh_golem_attack_skill.nut
@@ -11,4 +11,6 @@
 	{
 		return this.skill.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/nightmare_skill.nut
+++ b/mod_reforged/hooks/skills/actives/nightmare_skill.nut
@@ -24,4 +24,6 @@
 		});
 		return ret;
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/serpent_bite_skill.nut
+++ b/mod_reforged/hooks/skills/actives/serpent_bite_skill.nut
@@ -11,4 +11,6 @@
 	{
 		return this.skill.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/spider_bite_skill.nut
+++ b/mod_reforged/hooks/skills/actives/spider_bite_skill.nut
@@ -11,4 +11,6 @@
 	{
 		return this.skill.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/sweep_skill.nut
+++ b/mod_reforged/hooks/skills/actives/sweep_skill.nut
@@ -30,4 +30,6 @@
 		});
 		return ret;
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/uproot_skill.nut
+++ b/mod_reforged/hooks/skills/actives/uproot_skill.nut
@@ -32,4 +32,6 @@
 		]);
 		return ret;
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/uproot_small_skill.nut
+++ b/mod_reforged/hooks/skills/actives/uproot_small_skill.nut
@@ -26,4 +26,6 @@
 		]);
 		return ret;
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/wardog_bite.nut
+++ b/mod_reforged/hooks/skills/actives/wardog_bite.nut
@@ -11,4 +11,6 @@
 	{
 		return this.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/werewolf_bite.nut
+++ b/mod_reforged/hooks/skills/actives/werewolf_bite.nut
@@ -11,4 +11,6 @@
 	{
 		return this.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/wolf_bite.nut
+++ b/mod_reforged/hooks/skills/actives/wolf_bite.nut
@@ -12,32 +12,6 @@
 		return this.getDefaultTooltip();
 	}}.getTooltip;
 
-	// VanillaFix: Overwrite vanilla function to prevent passive damage modification
-	q.onUpdate = @() { function onUpdate( _properties )
-	{
-	}}.onUpdate;
-
-	// VanillaFix: Overwrite vanilla function to apply the damage modification to this skill
-	q.onAnySkillUsed = @() { function onAnySkillUsed( _skill, _targetEntity, _properties )
-	{
-		if (_skill == this)
-		{
-			// Remove the effect on damage from equipped weapon (relevant for goblin wolfriders)
-			// We basically revert the changes that the weapon applies inside weapon.onUpdateProperties.
-			local weapon = this.getContainer().getActor().getMainhandItem();
-			if (weapon != null)
-			{
-				_properties.DamageRegularMin -= weapon.m.RegularDamage;
-				_properties.DamageRegularMax -= weapon.m.RegularDamageMax;
-				_properties.DamageArmorMult /= weapon.m.ArmorDamageMult;
-				_properties.DamageDirectAdd -= weapon.m.DirectDamageAdd;
-				_properties.HitChance[::Const.BodyPart.Head] -= weapon.m.ChanceToHitHead;
-			}
-
-			// Then add the damage of this skill. This is copied from what vanilla does in onUpdate of this skill
-			_properties.DamageRegularMin += 20;
-			_properties.DamageRegularMax += 40;
-			_properties.DamageArmorMult *= 0.4;
-		}
-	}}.onAnySkillUsed;
+	// VanillaFix: Prevent passive damage modification from this skill for goblin wolfriders
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/zombie_bite.nut
+++ b/mod_reforged/hooks/skills/actives/zombie_bite.nut
@@ -11,4 +11,6 @@
 	{
 		return this.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });


### PR DESCRIPTION
For certain skills vanilla adjusts the damage related fields in _properties during onUpdate instead of during onAnySkillUsed. This is problematic when a skill wants to display or communicate its damage output. This is relevant for example in nested tooltips. We move such damage modifications to onAnySkillUsed which is also a vanilla style of doing it which vanilla uses in certain skills and is a superior method.

One issue with this method is that the ZOC skills of certain beasts will not have any damage as vanilla doesn't inherit those skills from the real attack (for example the `sweep_zoc` skill of the Unhold). Therefore, the question is whether we should just hook the few relevant skills e.g. `ghoul_claws` etc. and leave the others alone?