### PR TITLE
feat: move damage of some vanilla skills to onAnySkillUsed

### DIFF
--- a/mod_reforged/hooks/skills/actives/hand_to_hand.nut
+++ b/mod_reforged/hooks/skills/actives/hand_to_hand.nut
@@ -26,4 +26,6 @@
 			_properties.MeleeSkill = old_MeleeSkill; // This reverts the vanilla -10 Modifier
 		}
 	}}.onAnySkillUsed;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/hand_to_hand_orc.nut
+++ b/mod_reforged/hooks/skills/actives/hand_to_hand_orc.nut
@@ -1,0 +1,3 @@
+::Reforged.HooksMod.hook("scripts/skills/actives/hand_to_hand_orc", function(q) {
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
+});

--- a/mod_reforged/hooks/skills/actives/lesser_flesh_golem_attack_skill.nut
+++ b/mod_reforged/hooks/skills/actives/lesser_flesh_golem_attack_skill.nut
@@ -11,4 +11,6 @@
 	{
 		return this.skill.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/wolf_bite.nut
+++ b/mod_reforged/hooks/skills/actives/wolf_bite.nut
@@ -12,32 +12,6 @@
 		return this.getDefaultTooltip();
 	}}.getTooltip;
 
-	// VanillaFix: Overwrite vanilla function to prevent passive damage modification
-	q.onUpdate = @() { function onUpdate( _properties )
-	{
-	}}.onUpdate;
-
-	// VanillaFix: Overwrite vanilla function to apply the damage modification to this skill
-	q.onAnySkillUsed = @() { function onAnySkillUsed( _skill, _targetEntity, _properties )
-	{
-		if (_skill == this)
-		{
-			// Remove the effect on damage from equipped weapon (relevant for goblin wolfriders)
-			// We basically revert the changes that the weapon applies inside weapon.onUpdateProperties.
-			local weapon = this.getContainer().getActor().getMainhandItem();
-			if (weapon != null)
-			{
-				_properties.DamageRegularMin -= weapon.m.RegularDamage;
-				_properties.DamageRegularMax -= weapon.m.RegularDamageMax;
-				_properties.DamageArmorMult /= weapon.m.ArmorDamageMult;
-				_properties.DamageDirectAdd -= weapon.m.DirectDamageAdd;
-				_properties.HitChance[::Const.BodyPart.Head] -= weapon.m.ChanceToHitHead;
-			}
-
-			// Then add the damage of this skill. This is copied from what vanilla does in onUpdate of this skill
-			_properties.DamageRegularMin += 20;
-			_properties.DamageRegularMax += 40;
-			_properties.DamageArmorMult *= 0.4;
-		}
-	}}.onAnySkillUsed;
+	// VanillaFix: Prevent passive damage modification from this skill for goblin wolfriders
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks/skills/actives/zombie_bite.nut
+++ b/mod_reforged/hooks/skills/actives/zombie_bite.nut
@@ -11,4 +11,6 @@
 	{
 		return this.getDefaultTooltip();
 	}}.getTooltip;
+
+	::Reforged.HooksHelper.moveDamageToOnAnySkillUsed(q);
 });

--- a/mod_reforged/hooks_helper.nut
+++ b/mod_reforged/hooks_helper.nut
@@ -87,4 +87,84 @@
 			_properties.DamageArmorMult += this.m.RF_Weapon.m.ArmorDamageMult - weapon.m.ArmorDamageMult;
 		}}.onAnySkillUsed;
 	}
+
+	// For certain skills vanilla adjusts the damage related fields in _properties during onUpdate
+	// instead of during onAnySkillUsed. This is problematic when a skill wants to display or communicate
+	// its damage output. This is relevant for example in nested tooltips. We move such damage
+	// modifications to onAnySkillUsed which is also a vanilla style of doing it which vanilla uses
+	// in certain skills and is a superior method.
+	// Note: This is only important to do for skills which are present on enemies who can have multiple
+	// sources of damage modification in `onUpdate` active at the same time e.g. enemies who carry weapons.
+	// For unarmed enemies e.g. Unholds, Beasts etc. it is not necessary to do this. A consideration with them
+	// is also that they sometimes have a `_zoc` version of their main skill that depends on the damage
+	// from the main skill to be added to onUpdate. This *could* be changed by changing the inheritance of those
+	// skills to inherit from the main skill, but seems unnecessary to do.
+	function moveDamageToOnAnySkillUsed( q )
+	{
+		q.m.__RF_DamageRegularMinAdd <- 0;
+		q.m.__RF_DamageRegularMaxAdd <- 0;
+		q.m.__RF_DamageArmorMult <- 1.0;
+		q.m.__RF_IsArmorMultAdditive <- false;
+
+		q.onUpdate = @(__original) { function onUpdate( _properties )
+		{
+			local old_DamageRegularMin = _properties.DamageRegularMin;
+			local old_DamageRegularMax = _properties.DamageRegularMax;
+			local old_DamageArmorMult = _properties.DamageArmorMult;
+
+			// Set DamageArmorMult to a large value so that we can detect whether __original changes it
+			// additively or not. Note: Multiplicative changes by __original or "setting" to a value are treated identically.
+			_properties.DamageArmorMult = 10000.0;
+
+			__original(_properties);
+
+			this.m.__RF_IsArmorMultAdditive = _properties.DamageArmorMult > 9999 && _properties.DamageArmorMult <= 10001;
+			if (this.m.__RF_IsArmorMultAdditive)
+			{
+				this.m.__RF_DamageArmorMult = (_properties.DamageArmorMult - 10000.0) - old_DamageArmorMult;
+			}
+			else
+			{
+				this.m.__RF_DamageArmorMult = (_properties.DamageArmorMult / 10000.0) / old_DamageArmorMult;
+			}
+
+			this.m.__RF_DamageRegularMinAdd = _properties.DamageRegularMin - old_DamageRegularMin;
+			this.m.__RF_DamageRegularMaxAdd = _properties.DamageRegularMax - old_DamageRegularMax;
+
+			_properties.DamageRegularMin = old_DamageRegularMin;
+			_properties.DamageRegularMax = old_DamageRegularMax;
+			_properties.DamageArmorMult = old_DamageArmorMult;
+		}}.onUpdate;
+
+		q.onAnySkillUsed = @(__original) { function onAnySkillUsed( _skill, _targetEntity, _properties )
+		{
+			__original(_skill, _targetEntity, _properties);
+			if (_skill == this)
+			{
+				// Remove the effect on damage from equipped weapon (relevant for e.g. goblin wolfriders or
+				// hand to hand skills used by entities that can also carry weapons)
+				// We basically revert the changes that the weapon applies inside weapon.onUpdateProperties.
+				local weapon = this.getContainer().getActor().getMainhandItem();
+				if (weapon != null && !this.getContainer().getActor().isDisarmed())
+				{
+					_properties.DamageRegularMin -= weapon.m.RegularDamage;
+					_properties.DamageRegularMax -= weapon.m.RegularDamageMax;
+					_properties.DamageArmorMult /= weapon.m.ArmorDamageMult;
+					_properties.DamageDirectAdd -= weapon.m.DirectDamageAdd;
+					_properties.HitChance[::Const.BodyPart.Head] -= weapon.m.ChanceToHitHead;
+				}
+
+				_properties.DamageRegularMin += this.m.__RF_DamageRegularMinAdd;
+				_properties.DamageRegularMax += this.m.__RF_DamageRegularMaxAdd;
+				if (this.m.__RF_IsArmorMultAdditive)
+				{
+					_properties.DamageArmorMult += this.m.__RF_DamageArmorMult;
+				}
+				else
+				{
+					_properties.DamageArmorMult *= this.m.__RF_DamageArmorMult;
+				}
+			}
+		}}.onAnySkillUsed;
+	}
 }


### PR DESCRIPTION
This is a lite version of #909 

This is only important to do for skills which are present on enemies who can have multiple sources of damage modification in `onUpdate` active at the same time e.g. enemies who carry weapons. For unarmed enemies e.g. Unholds, Beasts etc. it is not necessary to do this. A consideration with them is also that they sometimes have a `_zoc` version of their main skill that depends on the damage from the main skill to be added to onUpdate. This *could* be changed by changing the inheritance of those skills to inherit from the main skill, but seems unnecessary to do.

