### PR TITLE
feat: add chance to reduce condition of shields at spawn on some enemies

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
@@ -60,7 +60,16 @@
 				[1.0, "scripts/items/shields/wooden_shield"],
 				[1.0, "scripts/items/shields/kite_shield"]
 			]).roll();
-			this.m.Items.equip(::new(shield));
+
+			if (shield != null)
+			{
+				shield = ::new(shield);
+				this.m.Items.equip(shield);
+				if (::Math.rand(1, 100) <= 25)
+				{
+					shield.setCondition(::Math.floor(shield.getCondition() * ::MSU.Math.randf(0.6, 0.8)));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))

--- a/mod_reforged/hooks/entity/tactical/humans/nomad_outlaw.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/nomad_outlaw.nut
@@ -68,6 +68,12 @@
 	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
 	{
 		__original();
+
+		local offhandItem = this.getOffhandItem();
+		if (offhandItem != null && offhandItem.isItemType(::Const.Items.ItemType.Shield))
+		{
+			// missing
+		}
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
 	}}.assignRandomEquipment;
 });

--- a/scripts/entity/tactical/enemies/rf_bandit_scoundrel.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_scoundrel.nut
@@ -93,7 +93,15 @@ this.rf_bandit_scoundrel <- ::inherit("scripts/entity/tactical/human", {
 				[1, "scripts/items/shields/wooden_shield"]
 			]).rollChance(33);
 
-			if (shield != null) this.m.Items.equip(::new(shield));
+			if (shield != null)
+			{
+				shield = ::new(shield);
+				this.m.Items.equip(shield);
+				if (::Math.rand(1, 100) <= 75)
+				{
+					shield.setCondition(::Math.floor(shield.getCondition() * ::MSU.Math.randf(0.2, 0.4)));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))

--- a/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_vandal.nut
@@ -80,7 +80,15 @@ this.rf_bandit_vandal <- ::inherit("scripts/entity/tactical/human", {
 				[1, "scripts/items/shields/kite_shield"]
 			]).roll();
 
-			this.m.Items.equip(::new(shield));
+			if (shield != null)
+			{
+				shield = ::new(shield);
+				this.m.Items.equip(shield);
+				if (::Math.rand(1, 100) <= 50)
+				{
+					shield.setCondition(::Math.floor(shield.getCondition() * ::MSU.Math.randf(0.4, 0.6)));
+				}
+			}
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))


### PR DESCRIPTION
Discussed in VC. This brings back some capability to destroy shields, fits the Bandit/Nomad factions having some degree of shoddy/worn gear and adds a player cost (repairing the shield) to having the benefit of 'unbreakable' shields.