### PR TITLE
Feat weapon master improvements

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -2162,7 +2162,8 @@ local vanillaDescriptions = [
 			Type = ::UPD.EffectType.Passive,
 			Description = [
 				"Upon equipping a weapon, temporarily gain the first and second [perk|Concept.Perk] of all of its [perk|Concept.Perk] groups if you have the corresponding [perk|Concept.Perk] in any weapon [perk|Concept.Perk] group regardless of tier.",
-				"For [non-hybrid|Concept.HybridWeapon] weapons, this extends to the third [perk|Concept.Perk] as well."
+				"For [non-hybrid|Concept.HybridWeapon] weapons, this extends to the third [perk|Concept.Perk] as well.",
+				"The perks gained during a battle last until the end of the battle instead of expiring immediately upon unequipping the weapon."
 			]
 		}]
 	}),

--- a/scripts/skills/perks/perk_rf_weapon_master.nut
+++ b/scripts/skills/perks/perk_rf_weapon_master.nut
@@ -1,6 +1,5 @@
 this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 	m = {
-		OldPerks = [], // Contains perks stored temporarily during battle while swapping a weapon
 		PerksAdded = []
 	},
 	function create()
@@ -27,13 +26,6 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 			this.getContainer().getActor().getItems().unequip(equippedItem);
 			this.getContainer().getActor().getItems().equip(equippedItem);
 		}
-	}
-
-	// onUnequip and onEquip run before paying for item action cost
-	// so we remove old perks after that entire thing is complete
-	function onPayForItemAction( _skill, _items )
-	{
-		this.removeOldPerks();
 	}
 
 	function onEquip( _item )
@@ -82,6 +74,9 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 				if (row.len() != 0)
 				{
 					local perkID = row[0];
+					// Don't add a perk which we already added (relevant when not removing perks during battle)
+					if (this.m.PerksAdded.find(id) != null)
+						continue;
 					this.m.PerksAdded.push(perkID);
 					this.getContainer().add(::Reforged.new(::Const.Perks.findById(perkID).Script, function(o) {
 						o.m.IsSerialized = false;
@@ -162,11 +157,8 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 		if (!_item.isItemType(::Const.Items.ItemType.Weapon))
 			return;
 
-		if (::Tactical.isActive())
-		{
-			this.m.OldPerks = clone this.m.PerksAdded;
-		}
-		else
+		// Don't remove perks during battle. This prevents perks from losing state e.g. cooldown, or other effects.
+		if (!::Tactical.isActive())
 		{
 			this.removePerks();
 		}
@@ -175,7 +167,7 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 	function onCombatFinished()
 	{
 		this.skill.onCombatFinished();
-		this.removeOldPerks();
+		this.removePerks();
 	}
 
 	function removePerks()
@@ -186,17 +178,5 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 		}
 
 		this.m.PerksAdded.clear();
-
-		this.removeOldPerks();
-	}
-
-	function removeOldPerks()
-	{
-		foreach (perkID in this.m.OldPerks)
-		{
-			this.getContainer().removeByStackByID(perkID, false);
-		}
-
-		this.m.OldPerks.clear();
 	}
 });

--- a/scripts/skills/perks/perk_rf_weapon_master.nut
+++ b/scripts/skills/perks/perk_rf_weapon_master.nut
@@ -8,8 +8,41 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 		this.m.Name = ::Const.Strings.PerkName.RF_WeaponMaster;
 		this.m.Description = "This character is skilled in the use of various weapons."
 		this.m.Icon = "ui/perks/perk_rf_weapon_master.png";
-		this.m.Type = ::Const.SkillType.Perk;
+		this.m.Type = ::Const.SkillType.Perk | ::Const.SkillType.StatusEffect;
 		this.m.Order = ::Const.SkillOrder.Any;
+	}
+
+	function __getTrueAddedPerks()
+	{
+		// exclude perks that were already present (i.e. not granted by Weapon Master)
+		return this.m.PerksAdded.filter(@(_, _perk) !_perk.isSerialized());
+	}
+
+	function isHidden()
+	{
+		return this.__getTrueAddedPerks().len() == 0;
+	}
+
+	function getTooltip()
+	{
+		local ret = this.skill.getTooltip();
+
+		local perks = this.__getTrueAddedPerks();
+		if  (perks.len() != 0)
+		{
+			local container = this.getContainer();
+			local extraData = "entityId:" + container.getActor().getID();
+			local perkIcons = perks
+								.map(@(_perk) ::Reforged.NestedTooltips.getNestedPerkImage(_perk, extraData))
+								.reduce(@(_a, _b) _a + _b);
+
+			ret.push({
+				id = 10,	type = "text",	icon = "ui/icons/special.png",
+				text = ::Reforged.Mod.Tooltips.parseString("[Perks|Concept.Perk] gained:\n" + perkIcons)
+			});
+		}
+
+		return ret;
 	}
 
 	function onAdded()
@@ -75,13 +108,20 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 				{
 					local perkID = row[0];
 					// Don't add a perk which we already added (relevant when not removing perks during battle)
-					if (this.m.PerksAdded.find(id) != null)
-						continue;
-					this.m.PerksAdded.push(perkID);
-					this.getContainer().add(::Reforged.new(::Const.Perks.findById(perkID).Script, function(o) {
+					foreach (p in this.m.PerksAdded)
+					{
+						if (p.getID() == perkID)
+							continue;
+					}
+					local perk = ::Reforged.new(::Const.Perks.findById(perkID).Script, function(o) {
 						o.m.IsSerialized = false;
 						o.m.IsRefundable = false;
-					}));
+					});
+					this.getContainer().add(perk);
+					// Need to do it like this because of Stack Based Skills which will throw away the perk above
+					// if a perk with the same ID already exists on the bro.
+					local existingPerk = this.getContainer().getSkillByID(perkID);
+					this.m.PerksAdded.push(::MSU.asWeakTableRef(existingPerk == null ? perk : existingPerk));
 					break;
 				}
 			}
@@ -172,9 +212,9 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 
 	function removePerks()
 	{
-		foreach (perkID in this.m.PerksAdded)
+		foreach (perk in this.m.PerksAdded)
 		{
-			this.getContainer().removeByStackByID(perkID, false);
+			this.getContainer().removeByStackByID(perk.getID(), false);
 		}
 
 		this.m.PerksAdded.clear();

--- a/scripts/skills/perks/perk_rf_weapon_master.nut
+++ b/scripts/skills/perks/perk_rf_weapon_master.nut
@@ -1,6 +1,7 @@
 this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 	m = {
-		PerksAdded = []
+		PerksAdded = [],
+		RestrictToGroupsInPerkTree = false
 	},
 	function create()
 	{
@@ -182,7 +183,11 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 
 		// Restrict us only to the perk groups that exist in this character's perk tree and
 		// add perks from all such equippedWeaponPGs in the valid tierRanges
-		equippedweaponPGs = equippedweaponPGs.filter(@(_, _pg) perkTree.hasPerkGroup(_pg.getID()));
+		if (this.m.RestrictToGroupsInPerkTree)
+		{
+			equippedweaponPGs = equippedweaponPGs.filter(@(_, _pg) perkTree.hasPerkGroup(_pg.getID()));
+		}
+
 		foreach (range in tierRanges)
 		{
 			foreach (pg in equippedweaponPGs)

--- a/scripts/skills/perks/perk_rf_weapon_master.nut
+++ b/scripts/skills/perks/perk_rf_weapon_master.nut
@@ -128,7 +128,8 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 			}
 		}
 
-		local perkTree = this.getContainer().getActor().getPerkTree();
+		local actor = this.getContainer().getActor();
+		local perkTree = ::MSU.isKindOf(actor, "player") ? actor.getPerkTree() : null;
 		local allWeaponPGs = []; // Contains all weapon PGs that are present in this character's perk tree
 		local equippedweaponPGs = []; // Contains the PGs of this equipped weapon
 
@@ -141,7 +142,7 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 			if (pg == null)
 				continue;
 
-			if (perkTree.hasPerkGroup(pg.getID()))
+			if (perkTree == null || perkTree.hasPerkGroup(pg.getID()))
 			{
 				allWeaponPGs.push(pg);
 			}
@@ -183,7 +184,7 @@ this.perk_rf_weapon_master <- ::inherit("scripts/skills/skill", {
 
 		// Restrict us only to the perk groups that exist in this character's perk tree and
 		// add perks from all such equippedWeaponPGs in the valid tierRanges
-		if (this.m.RestrictToGroupsInPerkTree)
+		if (this.m.RestrictToGroupsInPerkTree && perkTree != null)
 		{
 			equippedweaponPGs = equippedweaponPGs.filter(@(_, _pg) perkTree.hasPerkGroup(_pg.getID()));
 		}


### PR DESCRIPTION
- Don't remove perks granted by Weapon Master during battle. This prevents perks from losing state e.g. cooldown, or other effects.
- Add a Status Effect to Weapon master to show which perks are being granted by it.
- Grant perks even from perk groups not present in the perk tree.
- Adjust code to allow the perk to work with NPCs.

Based on discussion around the perk in the Dev Discord server [here](https://discord.com/channels/996482927531671692/1433583860066680994) and [here](https://discord.com/channels/996482927531671692/1484318741218066632).