### PR TITLE
fix: flail spinner and whirling death error if weapon breaks

### DIFF
--- a/scripts/skills/perks/perk_rf_flail_spinner.nut
+++ b/scripts/skills/perks/perk_rf_flail_spinner.nut
@@ -59,7 +59,7 @@ this.perk_rf_flail_spinner <- ::inherit("scripts/skills/skill", {
 
 	function trySpinFlail( _tag )
 	{
-		if (!_tag.User.isAlive() || !_tag.TargetEntity.isAlive())
+		if (!_tag.User.isAlive() || !_tag.TargetEntity.isAlive() || ::MSU.isNull(_tag.Skill.getContainer()))
 			return;
 
 		// If the skill is already executing, we wait for it to complete that first.

--- a/scripts/skills/perks/perk_rf_whirling_death.nut
+++ b/scripts/skills/perks/perk_rf_whirling_death.nut
@@ -155,7 +155,7 @@ this.perk_rf_whirling_death <- ::inherit("scripts/skills/skill", {
 
 	function tryWhirl( _tag )
 	{
-		if (!_tag.User.isAlive() || !_tag.TargetEntity.isAlive())
+		if (!_tag.User.isAlive() || !_tag.TargetEntity.isAlive() || ::MSU.isNull(_tag.Skill.getContainer()))
 			return;
 
 		// If the skill is already executing, we wait for it to complete that first.


### PR DESCRIPTION
Weapon skills are removed by vanilla with a delayed event upon breaking of a weapon. Therefore, any delayed attack using a weapon's skill must have an null check for its container.