### PR TITLE
feat: show distance in days as text instead of number in contracts

### DIFF
--- a/mod_reforged/config/text/text.nut
+++ b/mod_reforged/config/text/text.nut
@@ -1,4 +1,73 @@
 ::Reforged.Text <- {
+	// Converts a given integer into a text which represents that number
+	// e.g. 1: one, 51: fifty one, 1251: one thousand two hundred and fifty one
+	// Supports language up to "million". Does not convert higher numbers to "billion" etc.
+	// i.e. billion will be written as thousand million.
+	function getNumberAsText( _number )
+	{
+		if (_number == 0)
+			return "zero";
+
+		local ret = "";
+		local n = _number;
+		if (n < 0)
+		{
+			ret = "negative ";
+			n = -n;
+		}
+
+		local units = ["", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"];
+		local tens = ["", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"];
+
+		// Helper function to process groups of three digits (up to 999)
+		local getPart = function( _n )
+		{
+			local str = "";
+			if (_n >= 100)
+			{
+				str += units[_n / 100] + " hundred";
+				_n = _n % 100;
+				if (_n > 0)
+					str += " and ";
+			}
+
+			if (_n >= 20)
+			{
+				str += tens[_n / 10];
+				if (_n % 10 > 0)
+					str += " " + units[_n % 10];
+			}
+			else if (_n > 0)
+			{
+				str += units[_n];
+			}
+			return str;
+		};
+
+		if (n >= 1000000)
+		{
+			ret += getPart(n / 1000000) + " million";
+			n = n % 1000000;
+			if (n > 0)
+				ret += (n < 100 ? " and " : " ");
+		}
+
+		if (n >= 1000)
+		{
+			ret += getPart(n / 1000) + " thousand";
+			n = n % 1000;
+			if (n > 0)
+				ret += (n < 100 ? " and " : " ");
+		}
+
+		if (n > 0)
+		{
+			ret += getPart(n);
+		}
+
+		return ret;
+	}
+
 	function getDayHourString( _seconds )
 	{
 		local days = ::Math.floor(_seconds / ::World.getTime().SecondsPerDay);
@@ -22,7 +91,12 @@
 	{
 		local doubleDays = ::Math.round(2.0 * (_seconds / ::World.getTime().SecondsPerDay));
 		local daysAndHalf = (doubleDays / 2.0);
-		if (daysAndHalf <= 1.0) return "a day"
-		return "" + daysAndHalf + " days";
+		if (daysAndHalf <= 1.0)
+			return "a day"
+
+		if (daysAndHalf == daysAndHalf.tointeger())
+			return daysAndHalf + " days";
+
+		return this.getNumberAsText(daysAndHalf.tointeger()) + " and a half days";
 	}
 }

--- a/mod_reforged/hooks/contracts/contracts/deliver_item_contract.nut
+++ b/mod_reforged/hooks/contracts/contracts/deliver_item_contract.nut
@@ -6,7 +6,7 @@
 		{
 			if (var[0] != "days") continue;
 			local seconds = this.getSecondsRequiredToTravel(this.m.Flags.get("Distance"), ::Const.World.MovementSettings.Speed, true);
-			var[1] = ::Reforged.Text.getDaysAndHalf(seconds);
+			var[1] = "[color=#f6eedb]" + ::Reforged.Text.getDaysAndHalf(seconds) + "[/color]"; // Same color as vanilla OOC var but we can't use a var within a var
 			break;
 		}
 	}}.onPrepareVariables;

--- a/mod_reforged/hooks/contracts/contracts/escort_caravan_contract.nut
+++ b/mod_reforged/hooks/contracts/contracts/escort_caravan_contract.nut
@@ -6,7 +6,7 @@
 		{
 			if (var[0] != "days") continue;
 			local seconds = this.getSecondsRequiredToTravel(this.m.Flags.get("Distance"), ::Const.World.MovementSettings.Speed * 0.6, true);
-			var[1] = ::Reforged.Text.getDaysAndHalf(seconds);
+			var[1] = "[color=#f6eedb]" + ::Reforged.Text.getDaysAndHalf(seconds) + "[/color]"; // Same color as vanilla OOC var but we can't use a var within a var
 			break;
 		}
 	}}.onPrepareVariables;


### PR DESCRIPTION
There's also a second commit in this PR which improves the UX by highlighting the days text in delivery/caravan contracts.