### PR TITLE
fix: error in event hooks due to member being null when score is not 0

### DIFF
--- a/mod_reforged/hooks/events/events/bastard_assassin_event.nut
+++ b/mod_reforged/hooks/events/events/bastard_assassin_event.nut
@@ -2,8 +2,18 @@
 	q.onUpdateScore = @(__original) { function onUpdateScore()
 	{
 		__original();
-		// Prevent avatar from being chosen in this event.
-		if (this.m.Score != 0 && this.m.Bastard.getFlags().has("IsPlayerCharacter"))
+		/* Prevent avatar from being chosen in this event.
+		We need null check instead of `m.Score != 0`. The member variable is set
+		during onUpdateScore() of this event and is only set in a situation where
+		the Score is also set to a non-zero value. However, we can arrive at this
+		point in this hook with a non-zero Score but null member. This is because
+		during event_manager.selectEvent vanilla calls event.update() but that only
+		does onClear() and onUpdateScore(). The onClear() does not set the Score to 0
+		but does clear the member variables. This works fine in vanilla because vanilla
+		calls .clear() on an event after it has been selected as the ActiveEvent, and
+		that resets the score to 0 and then calls onUpdateScore() and only fires the
+		event if it at that point reports a non-zero score. */
+		if (!::MSU.isNull(this.m.Bastard) && this.m.Bastard.getFlags().has("IsPlayerCharacter"))
 		{
 			this.clear();
 			return;

--- a/mod_reforged/hooks/events/events/dlc4/wild_dog_sounds_event.nut
+++ b/mod_reforged/hooks/events/events/dlc4/wild_dog_sounds_event.nut
@@ -2,7 +2,6 @@
 	q.onUpdateScore = @(__original) { function onUpdateScore()
 	{
 		__original();
-		// Prevent avatar from being chosen in this event.
 		/* Prevent avatar from being chosen in this event.
 		We need null check instead of `m.Score != 0`. The member variable is set
 		during onUpdateScore() of this event and is only set in a situation where

--- a/mod_reforged/hooks/events/events/dlc4/wild_dog_sounds_event.nut
+++ b/mod_reforged/hooks/events/events/dlc4/wild_dog_sounds_event.nut
@@ -3,7 +3,18 @@
 	{
 		__original();
 		// Prevent avatar from being chosen in this event.
-		if (this.m.Score != 0 && this.m.Expendable.getFlags().has("IsPlayerCharacter"))
+		/* Prevent avatar from being chosen in this event.
+		We need null check instead of `m.Score != 0`. The member variable is set
+		during onUpdateScore() of this event and is only set in a situation where
+		the Score is also set to a non-zero value. However, we can arrive at this
+		point in this hook with a non-zero Score but null member. This is because
+		during event_manager.selectEvent vanilla calls event.update() but that only
+		does onClear() and onUpdateScore(). The onClear() does not set the Score to 0
+		but does clear the member variables. This works fine in vanilla because vanilla
+		calls .clear() on an event after it has been selected as the ActiveEvent, and
+		that resets the score to 0 and then calls onUpdateScore() and only fires the
+		event if it at that point reports a non-zero score. */
+		if (!::MSU.isNull(this.m.Expendable) && this.m.Expendable.getFlags().has("IsPlayerCharacter"))
 		{
 			this.clear();
 			return;

--- a/mod_reforged/hooks/events/events/dlc8/disowned_noble_welcomed_back_event.nut
+++ b/mod_reforged/hooks/events/events/dlc8/disowned_noble_welcomed_back_event.nut
@@ -3,7 +3,18 @@
 	{
 		__original();
 		// Prevent avatar from being chosen in this event.
-		if (this.m.Score != 0 && this.m.Disowned.getFlags().has("IsPlayerCharacter"))
+		/* Prevent avatar from being chosen in this event.
+		We need null check instead of `m.Score != 0`. The member variable is set
+		during onUpdateScore() of this event and is only set in a situation where
+		the Score is also set to a non-zero value. However, we can arrive at this
+		point in this hook with a non-zero Score but null member. This is because
+		during event_manager.selectEvent vanilla calls event.update() but that only
+		does onClear() and onUpdateScore(). The onClear() does not set the Score to 0
+		but does clear the member variables. This works fine in vanilla because vanilla
+		calls .clear() on an event after it has been selected as the ActiveEvent, and
+		that resets the score to 0 and then calls onUpdateScore() and only fires the
+		event if it at that point reports a non-zero score. */
+		if (!::MSU.isNull(this.m.Disowned) && this.m.Disowned.getFlags().has("IsPlayerCharacter"))
 		{
 			this.clear();
 			return;

--- a/mod_reforged/hooks/events/events/dlc8/disowned_noble_welcomed_back_event.nut
+++ b/mod_reforged/hooks/events/events/dlc8/disowned_noble_welcomed_back_event.nut
@@ -2,7 +2,6 @@
 	q.onUpdateScore = @(__original) { function onUpdateScore()
 	{
 		__original();
-		// Prevent avatar from being chosen in this event.
 		/* Prevent avatar from being chosen in this event.
 		We need null check instead of `m.Score != 0`. The member variable is set
 		during onUpdateScore() of this event and is only set in a situation where

--- a/mod_reforged/hooks/events/events/killer_vs_others_event.nut
+++ b/mod_reforged/hooks/events/events/killer_vs_others_event.nut
@@ -2,7 +2,6 @@
 	q.onUpdateScore = @(__original) { function onUpdateScore()
 	{
 		__original();
-		// Prevent avatar from being chosen in this event.
 		/* Prevent avatar from being chosen in this event.
 		We need null check instead of `m.Score != 0`. The member variable is set
 		during onUpdateScore() of this event and is only set in a situation where

--- a/mod_reforged/hooks/events/events/killer_vs_others_event.nut
+++ b/mod_reforged/hooks/events/events/killer_vs_others_event.nut
@@ -3,7 +3,18 @@
 	{
 		__original();
 		// Prevent avatar from being chosen in this event.
-		if (this.m.Score != 0 && this.m.Killer.getFlags().has("IsPlayerCharacter"))
+		/* Prevent avatar from being chosen in this event.
+		We need null check instead of `m.Score != 0`. The member variable is set
+		during onUpdateScore() of this event and is only set in a situation where
+		the Score is also set to a non-zero value. However, we can arrive at this
+		point in this hook with a non-zero Score but null member. This is because
+		during event_manager.selectEvent vanilla calls event.update() but that only
+		does onClear() and onUpdateScore(). The onClear() does not set the Score to 0
+		but does clear the member variables. This works fine in vanilla because vanilla
+		calls .clear() on an event after it has been selected as the ActiveEvent, and
+		that resets the score to 0 and then calls onUpdateScore() and only fires the
+		event if it at that point reports a non-zero score. */
+		if (!::MSU.isNull(this.m.Killer) && this.m.Killer.getFlags().has("IsPlayerCharacter"))
 		{
 			this.clear();
 			return;

--- a/mod_reforged/hooks/events/events/lawmen_after_criminal_event.nut
+++ b/mod_reforged/hooks/events/events/lawmen_after_criminal_event.nut
@@ -2,7 +2,6 @@
 	q.onUpdateScore = @(__original) { function onUpdateScore()
 	{
 		__original();
-		// Prevent avatar from being chosen in this event.
 		/* Prevent avatar from being chosen in this event.
 		We need null check instead of `m.Score != 0`. The member variable is set
 		during onUpdateScore() of this event and is only set in a situation where

--- a/mod_reforged/hooks/events/events/lawmen_after_criminal_event.nut
+++ b/mod_reforged/hooks/events/events/lawmen_after_criminal_event.nut
@@ -3,7 +3,18 @@
 	{
 		__original();
 		// Prevent avatar from being chosen in this event.
-		if (this.m.Score != 0 && this.m.Criminal.getFlags().has("IsPlayerCharacter"))
+		/* Prevent avatar from being chosen in this event.
+		We need null check instead of `m.Score != 0`. The member variable is set
+		during onUpdateScore() of this event and is only set in a situation where
+		the Score is also set to a non-zero value. However, we can arrive at this
+		point in this hook with a non-zero Score but null member. This is because
+		during event_manager.selectEvent vanilla calls event.update() but that only
+		does onClear() and onUpdateScore(). The onClear() does not set the Score to 0
+		but does clear the member variables. This works fine in vanilla because vanilla
+		calls .clear() on an event after it has been selected as the ActiveEvent, and
+		that resets the score to 0 and then calls onUpdateScore() and only fires the
+		event if it at that point reports a non-zero score. */
+		if (!::MSU.isNull(this.m.Criminal) && this.m.Criminal.getFlags().has("IsPlayerCharacter"))
 		{
 			this.clear();
 			return;

--- a/mod_reforged/hooks/events/events/sellsword_gets_better_deal_event.nut
+++ b/mod_reforged/hooks/events/events/sellsword_gets_better_deal_event.nut
@@ -3,7 +3,18 @@
 	{
 		__original();
 		// Prevent avatar from being chosen in this event.
-		if (this.m.Score != 0 && this.m.Sellsword.getFlags().has("IsPlayerCharacter"))
+		/* Prevent avatar from being chosen in this event.
+		We need null check instead of `m.Score != 0`. The member variable is set
+		during onUpdateScore() of this event and is only set in a situation where
+		the Score is also set to a non-zero value. However, we can arrive at this
+		point in this hook with a non-zero Score but null member. This is because
+		during event_manager.selectEvent vanilla calls event.update() but that only
+		does onClear() and onUpdateScore(). The onClear() does not set the Score to 0
+		but does clear the member variables. This works fine in vanilla because vanilla
+		calls .clear() on an event after it has been selected as the ActiveEvent, and
+		that resets the score to 0 and then calls onUpdateScore() and only fires the
+		event if it at that point reports a non-zero score. */
+		if (!::MSU.isNull(this.m.Sellsword) && this.m.Sellsword.getFlags().has("IsPlayerCharacter"))
 		{
 			this.clear();
 			return;

--- a/mod_reforged/hooks/events/events/sellsword_gets_better_deal_event.nut
+++ b/mod_reforged/hooks/events/events/sellsword_gets_better_deal_event.nut
@@ -2,7 +2,6 @@
 	q.onUpdateScore = @(__original) { function onUpdateScore()
 	{
 		__original();
-		// Prevent avatar from being chosen in this event.
 		/* Prevent avatar from being chosen in this event.
 		We need null check instead of `m.Score != 0`. The member variable is set
 		during onUpdateScore() of this event and is only set in a situation where


### PR DESCRIPTION
We need null check instead of `m.Score != 0`. The member variable is set during onUpdateScore() of this event and is only set in a situation where the Score is also set to a non-zero value. However, we can arrive at this point in this hook with a non-zero Score but null member. This is because during event_manager.selectEvent vanilla calls event.update() but that only does onClear() and UpdateScore(). The onClear() does not set the Score to 0 but does clear the member variables. This works fine in vanilla because vanilla calls .clear() on an event after it has been selected as the ActiveEvent, and that resets the score to 0 and then calls onUpdateScore() and only fires the event if it at that point reports a non-zero score.

I may have gone overboard with the comments in the code but it seems like an important thing to document as it is rather obscure and not easy to understand/infer from vanilla code.