### PR TITLE
fix: equipment slot and perk assignment logic for enemies

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_leader.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_leader.nut
@@ -47,7 +47,7 @@
 	q.assignRandomEquipment = @() { function assignRandomEquipment()
 	{
 		// Get shield if 1h named weapon otherwise roll chance for it
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand) && (!this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand) || ::Math.rand(1, 100) <= 50))
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand) && ::Math.rand(1, 100) <= 50)
 		{
 			local shield = ::MSU.Class.WeightedContainer([
 				[1.0, "scripts/items/shields/heater_shield"],
@@ -59,6 +59,7 @@
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
+			// If no shield then forced to be 2-handed weapon
 			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 			{
 				local weapon = ::MSU.Class.WeightedContainer([
@@ -87,6 +88,7 @@
 			}
 		}
 
+		// Improved non-named armor and helmet for champions
 		if (this.m.IsMiniboss)
 		{
 			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_raider.nut
@@ -28,7 +28,7 @@
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer([
+			local weapons = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/arming_sword"],
 				[1, "scripts/items/weapons/boar_spear"],
 				[1, "scripts/items/weapons/falchion"],
@@ -37,13 +37,18 @@
 				[1, "scripts/items/weapons/military_pick"],
 				[1, "scripts/items/weapons/morning_star"],
 				[1, "scripts/items/weapons/scramasax"],
+			]);
 
-				[1, "scripts/items/weapons/longaxe"],
-				[1, "scripts/items/weapons/polehammer"],
-				[1, "scripts/items/weapons/rf_two_handed_falchion"],
-				[1, "scripts/items/weapons/warbrand"]
-			]).roll();
-			this.m.Items.equip(::new(weapon));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/longaxe"],
+					[1, "scripts/items/weapons/polehammer"],
+					[1, "scripts/items/weapons/rf_two_handed_falchion"],
+					[1, "scripts/items/weapons/warbrand"]
+				]);
+			}
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))

--- a/mod_reforged/hooks/entity/tactical/enemies/bandit_thug.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/bandit_thug.nut
@@ -47,7 +47,7 @@
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer([
+			local weapons = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/bludgeon"],
 				[1, "scripts/items/weapons/butchers_cleaver"],
 				[1, "scripts/items/weapons/dagger"],
@@ -57,13 +57,18 @@
 				[1, "scripts/items/weapons/reinforced_wooden_flail"],
 				[1, "scripts/items/weapons/shortsword"],
 				[1, "scripts/items/weapons/wooden_flail"],
-				[1, "scripts/items/weapons/wooden_stick"],
+				[1, "scripts/items/weapons/wooden_stick"]
+			]);
 
-				[1, "scripts/items/weapons/pitchfork"],
-				[1, "scripts/items/weapons/woodcutters_axe"]
-			]).roll();
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/pitchfork"],
+					[1, "scripts/items/weapons/woodcutters_axe"]
+				]);
+			}
 
-			this.m.Items.equip(::new(weapon));
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))

--- a/mod_reforged/hooks/entity/tactical/enemies/goblin_fighter.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/goblin_fighter.nut
@@ -43,7 +43,7 @@
 		}));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 
@@ -69,7 +69,7 @@
 				break;
 			}
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 
 	q.makeMiniboss = @(__original) { function makeMiniboss()
 	{

--- a/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/goblin_wolfrider.nut
@@ -61,10 +61,10 @@
 		// until they use that skill. We have "fixed" that in Reforged. The fix is in the hook on wolf_bite.
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/orc_warrior.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/orc_warrior.nut
@@ -63,11 +63,11 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_menacing"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 3);
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 
 	q.makeMiniboss = @(__original) { function makeMiniboss()
 	{

--- a/mod_reforged/hooks/entity/tactical/enemies/orc_young.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/orc_young.nut
@@ -64,107 +64,66 @@
 
 	q.assignRandomEquipment = @() { function assignRandomEquipment()
 	{
-		local r;
-		local weapon;
-
-		if (::Math.rand(1, 100) <= 25)
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag) && ::Math.rand(1, 100) <= 25)
 		{
 			this.m.Items.addToBag(::new("scripts/items/weapons/greenskins/orc_javelin"));
 		}
 
-		if (::Math.rand(1, 100) <= 75)
-		{
-			if (::Math.rand(1, 100) <= 50)
-			{
-				local r = ::Math.rand(1, 2);
-
-				if (r == 1)
-				{
-					weapon = ::new("scripts/items/weapons/greenskins/orc_axe");
-				}
-				else if (r == 2)
-				{
-					weapon = ::new("scripts/items/weapons/greenskins/orc_cleaver");
-				}
-			}
-			else
-			{
-				local r = ::Math.rand(1, 2);
-
-				if (r == 1)
-				{
-					weapon = ::new("scripts/items/weapons/greenskins/orc_wooden_club");
-				}
-				else if (r == 2)
-				{
-					weapon = ::new("scripts/items/weapons/greenskins/orc_metal_club");
-				}
-			}
-		}
-		else
-		{
-			r = ::Math.rand(1, 2);
-
-			// if (r == 1)
-			// {
-			// 	weapon = ::new("scripts/items/weapons/greenskins/goblin_falchion");
-			// }
-			if (r == 1)
-			{
-				weapon = ::new("scripts/items/weapons/hatchet");
-			}
-			else
-			{
-				weapon = ::new("scripts/items/weapons/morning_star");
-			}
-		}
+		local weapon = ::MSU.Class.WeightedContainer([
+			[1, "scripts/items/weapons/greenskins/orc_axe"],
+			[1, "scripts/items/weapons/greenskins/orc_cleaver"],
+			[1, "scripts/items/weapons/greenskins/orc_wooden_club"],
+			[1, "scripts/items/weapons/greenskins/orc_metal_club"],
+			// The sum of the weight of the following weapons should be 1/4 of the total weight.
+			// Because in vanilla Orc Young have a 75% chance to spawn with one of the above weapons.
+			// [0.33, "scripts/items/weapons/greenskins/goblin_falchion"], // Disabled in Reforged on Orc Young
+			[0.67, "scripts/items/weapons/hatchet"],
+			[0.67, "scripts/items/weapons/morning_star"]
+		]).roll();
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			this.m.Items.equip(weapon);
+			this.m.Items.equip(::new(weapon));
 		}
 		else
 		{
-			this.m.Items.addToBag(weapon);
+			this.m.Items.addToBag(::new(weapon));
 		}
 
-		if (::Math.rand(1, 100) <= 50)
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand) && ::Math.rand(1, 100) <= 50)
 		{
 			this.m.Items.equip(::new("scripts/items/shields/greenskins/orc_light_shield"));
 		}
 
-		r = ::Math.rand(1, 5);
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+		{
+			local armor = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/armor/greenskins/orc_young_very_light_armor"],
+				[1, "scripts/items/armor/greenskins/orc_young_light_armor"],
+				[1, "scripts/items/armor/greenskins/orc_young_medium_armor"],
+				[1, "scripts/items/armor/greenskins/orc_young_heavy_armor"],
+				[1, "NoArmor"]
+			]).roll();
 
-		if (r == 1)
-		{
-			this.m.Items.equip(::new("scripts/items/armor/greenskins/orc_young_very_light_armor"));
-		}
-		else if (r == 2)
-		{
-			this.m.Items.equip(::new("scripts/items/armor/greenskins/orc_young_light_armor"));
-		}
-		else if (r == 3)
-		{
-			this.m.Items.equip(::new("scripts/items/armor/greenskins/orc_young_medium_armor"));
-		}
-		else if (r == 4)
-		{
-			this.m.Items.equip(::new("scripts/items/armor/greenskins/orc_young_heavy_armor"));
+			if (armor != "NoArmor")
+			{
+				this.m.Items.equip(::new(armor));
+			}
 		}
 
-		r = ::Math.rand(1, 4);
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
+		{
+			local helmet = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/helmets/greenskins/orc_young_light_helmet"],
+				[1, "scripts/items/helmets/greenskins/orc_young_medium_helmet"],
+				[1, "scripts/items/helmets/greenskins/orc_young_heavy_helmet"],
+				[1, "NoHelmet"]
+			]).roll();
 
-		if (r == 1)
-		{
-			this.m.Items.equip(::new("scripts/items/helmets/greenskins/orc_young_light_helmet"));
-		}
-		else if (r == 2)
-		{
-			this.m.Items.equip(::new("scripts/items/helmets/greenskins/orc_young_medium_helmet"));
-		}
-		else if (r == 3)
-		{
-			this.m.Items.equip(::new("scripts/items/helmets/greenskins/orc_young_heavy_helmet"));
+			if (helmet != "NoHelmet")
+			{
+				this.m.Items.equip(::new(helmet));
+			}
 		}
 	}}.assignRandomEquipment;
 

--- a/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy.nut
@@ -33,15 +33,22 @@
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/ancient/khopesh"],
-				[1, "scripts/items/weapons/ancient/crypt_cleaver"],
-				[1, "scripts/items/weapons/ancient/rhomphaia"]
-			]).roll();
-			this.m.Items.equip(::new(weapon));
+			local weapons = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/ancient/khopesh"]
+			]);
+
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/ancient/crypt_cleaver"],
+					[1, "scripts/items/weapons/ancient/rhomphaia"]
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
-		if (this.getMainhandItem().isItemType(::Const.Items.ItemType.OneHanded) && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			this.m.Items.equip(::new("scripts/items/shields/ancient/tower_shield"));
 		}

--- a/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy_bodyguard.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy_bodyguard.nut
@@ -30,13 +30,19 @@
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/ancient/khopesh"],
-				[1, "scripts/items/weapons/ancient/crypt_cleaver"],
-				[1, "scripts/items/weapons/ancient/rhomphaia"]
-			]).roll();
+			local weapons = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/ancient/khopesh"]
+			]);
 
-			this.m.Items.equip(::new(weapon));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/ancient/crypt_cleaver"],
+					[1, "scripts/items/weapons/ancient/rhomphaia"]
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))

--- a/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy_polearm.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/skeleton_heavy_polearm.nut
@@ -27,7 +27,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_man_of_steel"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 
@@ -52,5 +52,5 @@
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_coup_de_grace"));
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/skeleton_medium.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/skeleton_medium.nut
@@ -35,7 +35,7 @@
 			this.m.Items.equip(::new(weapon));
 		}
 
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			this.m.Items.equip(::new("scripts/items/shields/ancient/coffin_shield"));
 		}

--- a/mod_reforged/hooks/entity/tactical/enemies/trickster_god.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/trickster_god.nut
@@ -46,11 +46,4 @@
 			o.onTurnStart = function() {}; // don't remove on turn start i.e. make it permanent
 		}));
 	}}.onInit;
-
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
-	{
-		__original();
-
-		// any skills that should be added based on equipment
-	}}.assignRandomEquipment;
 });

--- a/mod_reforged/hooks/entity/tactical/enemies/zombie_knight.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/zombie_knight.nut
@@ -46,7 +46,7 @@
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			if (::Math.rand(1, 100) > 85)
+			if (::Math.rand(1, 100) > 85 && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 			{
 				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
 					[1, "scripts/items/weapons/longaxe"],
@@ -56,19 +56,26 @@
 			}
 			else
 			{
-				this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+				local weapons = ::MSU.Class.WeightedContainer([
 					[1, "scripts/items/weapons/arming_sword"],
 					[1, "scripts/items/weapons/flail"],
 					[1, "scripts/items/weapons/hand_axe"],
 					[1, "scripts/items/weapons/military_pick"],
-					[1, "scripts/items/weapons/morning_star"],
+					[1, "scripts/items/weapons/morning_star"]
+				]);
 
-					[1, "scripts/items/weapons/rf_battle_axe"],
-					[1, "scripts/items/weapons/rf_greatsword"],
-					[1, "scripts/items/weapons/rf_two_handed_falchion"],
-					[1, "scripts/items/weapons/two_handed_mace"],
-					[1, "scripts/items/weapons/warbrand"]
-				]).roll()));
+				if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+				{
+					weapons.addArray([
+						[1, "scripts/items/weapons/rf_battle_axe"],
+						[1, "scripts/items/weapons/rf_greatsword"],
+						[1, "scripts/items/weapons/rf_two_handed_falchion"],
+						[1, "scripts/items/weapons/two_handed_mace"],
+						[1, "scripts/items/weapons/warbrand"]
+					]);
+				}
+
+				this.m.Items.equip(::new(weapons.roll()));
 			}
 		}
 

--- a/mod_reforged/hooks/entity/tactical/humans/barbarian_chosen.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/barbarian_chosen.nut
@@ -66,9 +66,9 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_vigorous_assault"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/barbarian_drummer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/barbarian_drummer.nut
@@ -51,7 +51,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_survival_instinct"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 
@@ -59,5 +59,5 @@
 		{
 			::Reforged.Skills.addMasteryOfEquippedWeapon(this)
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/barbarian_marauder.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/barbarian_marauder.nut
@@ -62,7 +62,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_vigorous_assault"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 
@@ -77,5 +77,5 @@
 				break;
 			}
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/barbarian_thrall.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/barbarian_thrall.nut
@@ -46,9 +46,9 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_survival_instinct"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 3);
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/bounty_hunter.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/bounty_hunter.nut
@@ -38,7 +38,6 @@
 	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
 	{
 		__original();
-		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
 
 		if (this.getBodyItem() != null && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
 		{
@@ -60,4 +59,10 @@
 			}
 		}
 	}}.assignRandomEquipment;
+
+	q.onSpawned = @(__original) { function onSpawned()
+	{
+		__original();
+		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/bounty_hunter_ranged.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/bounty_hunter_ranged.nut
@@ -28,7 +28,6 @@
 	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
 	{
 		__original();
-		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
 
 		if (this.getBodyItem() != null)
 		{
@@ -48,4 +47,10 @@
 			}
 		}
 	}}.assignRandomEquipment;
+
+	q.onSpawned = @(__original) { function onSpawned()
+	{
+		__original();
+		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/conscript.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/conscript.nut
@@ -28,18 +28,14 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_dodge"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_nimble"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rotation"));
-	}}.onInit;
-
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
-	{
-		__original();
-		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
-	}}.assignRandomEquipment;
-
-	q.onSpawned = @() { function onSpawned()
-	{
 		this.m.Skills.add(::new("scripts/skills/perks/perk_backstabber"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_quick_hands"));
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_phalanx"));
+	}}.onInit;
+
+	q.onSpawned = @(__original) { function onSpawned()
+	{
+		__original();
+		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
 	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/desert_devil.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/desert_devil.nut
@@ -46,13 +46,19 @@
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer([
+			local weapons = ::MSU.Class.WeightedContainer([
 				[2, "scripts/items/weapons/shamshir"],
+			]);
 
-				[1, "scripts/items/weapons/oriental/swordlance"],
-				[1, "scripts/items/weapons/rf_voulge"]
-			]).roll();
-			this.m.Items.equip(::new(weapon));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/oriental/swordlance"],
+					[1, "scripts/items/weapons/rf_voulge"]
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))

--- a/mod_reforged/hooks/entity/tactical/humans/desert_stalker.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/desert_stalker.nut
@@ -35,11 +35,11 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_small_target"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 
 	q.makeMiniboss = @(__original) { function makeMiniboss()
 	{

--- a/mod_reforged/hooks/entity/tactical/humans/executioner.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/executioner.nut
@@ -43,7 +43,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_survival_instinct"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
@@ -69,7 +69,7 @@
 				this.m.Skills.add(::new("scripts/skills/perks/perk_rf_small_target"));
 			}
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 
 	q.makeMiniboss = @(__original) { function makeMiniboss()
 	{

--- a/mod_reforged/hooks/entity/tactical/humans/gladiator.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/gladiator.nut
@@ -37,7 +37,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_the_rush_of_battle"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 
@@ -57,7 +57,7 @@
 
 			if (weapon.getRangeMax() == 2) this.m.Skills.add(::new("scripts/skills/perks/perk_mastery_polearm"));
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 
 	q.makeMiniboss = @(__original) { function makeMiniboss()
 	{

--- a/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/hedge_knight.nut
@@ -31,7 +31,7 @@
 
 	q.assignRandomEquipment = @() { function assignRandomEquipment()
 	{
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand) && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			local weapon = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/bardiche"],

--- a/mod_reforged/hooks/entity/tactical/humans/mercenary.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/mercenary.nut
@@ -34,67 +34,48 @@
 
 	q.assignRandomEquipment = @() { function assignRandomEquipment()
 	{
-		local r;
-
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapons = [
-				"weapons/billhook",
-				"weapons/pike",
-				"weapons/warbrand",
-				"weapons/longsword",
-				"weapons/hand_axe",
-				"weapons/fighting_spear",
-				"weapons/morning_star",
-				"weapons/falchion",
-				"weapons/arming_sword",
-				"weapons/flail",
-				"weapons/military_pick"
-			];
-
-			if (::Const.DLC.Unhold)
-			{
-				weapons.extend([
-					"weapons/polehammer",
-					"weapons/three_headed_flail"
-				]);
-			}
-
-			if (::Const.DLC.Wildmen)
-			{
-				weapons.extend([
-					"weapons/bardiche",
-					"weapons/scimitar"
-				]);
-			}
-
-			// Reforged
-			weapons.extend([
-				"weapons/rf_kriegsmesser",
-				"weapons/rf_greatsword"
+			local weapons = ::MSU.Class.WeightedContainer([
+				[1, "weapons/hand_axe"],
+				[1, "weapons/fighting_spear"],
+				[1, "weapons/morning_star"],
+				[1, "weapons/falchion"],
+				[1, "weapons/arming_sword"],
+				[1, "weapons/flail"],
+				[1, "weapons/military_pick"],
+				[1, "weapons/three_headed_flail"],
+				[1, "weapons/scimitar"]
 			]);
 
-			this.m.Items.equip(::new("scripts/items/" + weapons[::Math.rand(0, weapons.len() - 1)]));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "weapons/billhook"],
+					[1, "weapons/pike"],
+					[1, "weapons/warbrand"],
+					[1, "weapons/longsword"],
+					[1, "weapons/polehammer"],
+					[1, "weapons/bardiche"],
+					[1, "weapons/rf_kriegsmesser"],
+					[1, "weapons/rf_greatsword"]
+				]);
+			}
+
+			this.m.Items.equip(::new("scripts/items/" + weapons.roll()));
 		}
 
-		if (this.m.Items.getItemAtSlot(::Const.ItemSlot.Offhand) == null)
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 		{
 			if (::Math.rand(1, 100) <= 75)
 			{
-				r = ::Math.rand(0, 2);
+				local shields = ::MSU.Class.WeightedContainer([
+					[1, "shields/wooden_shield"],
+					[1, "shields/heater_shield"],
+					[1, "shields/kite_shield"]
+				]);
 
-				if (r == 0)
-				{
-					this.m.Items.equip(::new("scripts/items/shields/wooden_shield"));
-				}
-				else if (r == 1)
-				{
-					this.m.Items.equip(::new("scripts/items/shields/heater_shield"));
-				}
-				else if (r == 2)
-				{
-					this.m.Items.equip(::new("scripts/items/shields/kite_shield"));
-				}
+				this.m.Items.equip(::new("scripts/items/" + shields.roll()));
 			}
 			else
 			{
@@ -102,121 +83,32 @@
 			}
 		}
 
-		if (this.getIdealRange() == 1 && ::Math.rand(1, 100) <= 60)
+		if (this.getIdealRange() == 1 && this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag) && ::Math.rand(1, 100) <= 60)
 		{
-			if (::Const.DLC.Unhold)
-			{
-				r = ::Math.rand(1, 3);
-
-				if (r == 1)
-				{
-					this.m.Items.addToBag(::new("scripts/items/weapons/throwing_axe"));
-				}
-				else if (r == 2)
-				{
-					this.m.Items.addToBag(::new("scripts/items/weapons/javelin"));
-				}
-				else if (r == 3)
-				{
-					this.m.Items.addToBag(::new("scripts/items/weapons/throwing_spear"));
-				}
-			}
-			else
-			{
-				r = ::Math.rand(1, 2);
-
-				if (r == 1)
-				{
-					this.m.Items.addToBag(::new("scripts/items/weapons/throwing_axe"));
-				}
-				else if (r == 2)
-				{
-					this.m.Items.addToBag(::new("scripts/items/weapons/javelin"));
-				}
-			}
+			local bag = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/throwing_axe"],
+				[1, "scripts/items/weapons/javelin"],
+				[1, "scripts/items/weapons/throwing_spear"]
+			]);
+			this.m.Items.equip(::new(bag.roll()));
 		}
 
-		if (::Const.DLC.Unhold)
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
 		{
-			r = ::Math.rand(1, 11);
-
-			if (r == 1)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/sellsword_armor"));
-			}
-			else if (r == 2)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/padded_leather"));
-			}
-			else if (r == 3)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/patched_mail_shirt"));
-			}
-			else if (r == 4)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/basic_mail_shirt"));
-			}
-			else if (r == 5)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/mail_shirt"));
-			}
-			else if (r == 6)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/reinforced_mail_hauberk"));
-			}
-			else if (r == 7)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/mail_hauberk"));
-			}
-			else if (r == 8)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/lamellar_harness"));
-			}
-			else if (r == 9)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/footman_armor"));
-			}
-			else if (r == 10)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/light_scale_armor"));
-			}
-			else if (r == 11)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/leather_scale_armor"));
-			}
-		}
-		else
-		{
-			r = ::Math.rand(2, 8);
-
-			if (r == 2)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/padded_leather"));
-			}
-			else if (r == 3)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/patched_mail_shirt"));
-			}
-			else if (r == 4)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/basic_mail_shirt"));
-			}
-			else if (r == 5)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/mail_shirt"));
-			}
-			else if (r == 6)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/reinforced_mail_hauberk"));
-			}
-			else if (r == 7)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/mail_hauberk"));
-			}
-			else if (r == 8)
-			{
-				this.m.Items.equip(::new("scripts/items/armor/lamellar_harness"));
-			}
+			local armor = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/armor/sellsword_armor"],
+				[1, "scripts/items/armor/padded_leather"],
+				[1, "scripts/items/armor/patched_mail_shirt"],
+				[1, "scripts/items/armor/basic_mail_shirt"],
+				[1, "scripts/items/armor/mail_shirt"],
+				[1, "scripts/items/armor/reinforced_mail_hauberk"],
+				[1, "scripts/items/armor/mail_hauberk"],
+				[1, "scripts/items/armor/lamellar_harness"],
+				[1, "scripts/items/armor/footman_armor"],
+				[1, "scripts/items/armor/light_scale_armor"],
+				[1, "scripts/items/armor/leather_scale_armor"],
+			]);
+			this.m.Items.equip(::new(armor.roll()));
 		}
 
 		if (this.getBodyItem() != null && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier4)
@@ -245,34 +137,31 @@
 			}
 		}
 
-		if (::Math.rand(1, 100) <= 95)
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head) && ::Math.rand(1, 100) <= 95)
 		{
-			local helmets = [
-				"scripts/items/helmets/nasal_helmet",
-				"scripts/items/helmets/nasal_helmet_with_mail",
-				"scripts/items/helmets/mail_coif",
-				"scripts/items/helmets/reinforced_mail_coif",
-				"scripts/items/helmets/headscarf",
-				"scripts/items/helmets/kettle_hat",
-				"scripts/items/helmets/kettle_hat_with_mail",
-				"scripts/items/helmets/flat_top_helmet",
-				"scripts/items/helmets/flat_top_with_mail",
-				"scripts/items/helmets/closed_flat_top_helmet",
-				"scripts/items/helmets/closed_mail_coif",
-				"scripts/items/helmets/bascinet_with_mail"
-			];
+			local helmets = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/helmets/nasal_helmet"],
+				[1, "scripts/items/helmets/nasal_helmet_with_mail"],
+				[1, "scripts/items/helmets/mail_coif"],
+				[1, "scripts/items/helmets/reinforced_mail_coif"],
+				[1, "scripts/items/helmets/headscarf"],
+				[1, "scripts/items/helmets/kettle_hat"],
+				[1, "scripts/items/helmets/kettle_hat_with_mail"],
+				[1, "scripts/items/helmets/flat_top_helmet"],
+				[1, "scripts/items/helmets/flat_top_with_mail"],
+				[1, "scripts/items/helmets/closed_flat_top_helmet"],
+				[1, "scripts/items/helmets/closed_mail_coif"],
+				[1, "scripts/items/helmets/bascinet_with_mail"],
+				[1, "scripts/items/helmets/nordic_helmet"],
+				[1, "scripts/items/helmets/steppe_helmet_with_mail"]
+			]);
 
-			if (::Const.DLC.Wildmen)
-			{
-				helmets.extend([
-					"scripts/items/helmets/nordic_helmet",
-					"scripts/items/helmets/steppe_helmet_with_mail"
-				]);
-			}
-
-			this.m.Items.equip(::new(helmets[::Math.rand(1, helmets.len() - 1)]));
+			this.m.Items.equip(::new(helmets.roll()));
 		}
+	}}.assignRandomEquipment;
 
+	q.onSpawned = @() { function onSpawned()
+	{
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
 		if (this.isArmedWithShield())
 		{
@@ -300,5 +189,5 @@
 				break;
 			}
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/mercenary_low.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/mercenary_low.nut
@@ -30,7 +30,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rotation"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
@@ -39,5 +39,5 @@
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_shield_expert"));
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/mercenary_ranged.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/mercenary_ranged.nut
@@ -36,8 +36,6 @@
 	{
 		__original();
 
-		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
-
 		if (this.getBodyItem() != null && ::Math.rand(1, 100) <= ::Reforged.Config.ArmorAttachmentChance.Tier3)
 		{
 			local armor = this.getBodyItem();
@@ -57,4 +55,10 @@
 			}
 		}
 	}}.assignRandomEquipment;
+
+	q.onSpawned = @(__original) { function onSpawned()
+	{
+		__original();
+		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/militia_captain.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/militia_captain.nut
@@ -40,7 +40,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_strength_in_numbers"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
@@ -50,5 +50,5 @@
 			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_phalanx"));
 			this.m.Skills.add(::new("scripts/skills/perks/perk_shield_expert"));
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/militia_guest.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/militia_guest.nut
@@ -22,7 +22,7 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_strength_in_numbers"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 3);
@@ -31,5 +31,5 @@
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_phalanx"));
 		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/militia_guest_ranged.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/militia_guest_ranged.nut
@@ -22,10 +22,10 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_strength_in_numbers"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 4);
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/militia_ranged.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/militia_ranged.nut
@@ -17,10 +17,10 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_rf_strength_in_numbers"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 3);
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/noble_sergeant.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/noble_sergeant.nut
@@ -50,15 +50,23 @@
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+			local weapons = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/fighting_axe"],
 				[1, "scripts/items/weapons/military_cleaver"],
 				[1, "scripts/items/weapons/warhammer"],
 				[1, "scripts/items/weapons/winged_mace"],
-				[1, "scripts/items/weapons/arming_sword"],
-				[1, "scripts/items/weapons/rf_battle_axe"],
-				[1, "scripts/items/weapons/rf_kriegsmesser"]
-			]).roll()));
+				[1, "scripts/items/weapons/arming_sword"]
+			]);
+
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/rf_battle_axe"],
+					[1, "scripts/items/weapons/rf_kriegsmesser"]
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))

--- a/mod_reforged/hooks/entity/tactical/humans/nomad_cutthroat.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/nomad_cutthroat.nut
@@ -42,9 +42,9 @@
 		this.m.Skills.add(::new("scripts/skills/perks/perk_dodge"));
 	}}.onInit;
 
-	q.assignRandomEquipment = @(__original) { function assignRandomEquipment()
+	q.onSpawned = @(__original) { function onSpawned()
 	{
 		__original();
 		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this, 3);
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 });

--- a/mod_reforged/hooks/entity/tactical/humans/oathbringer.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/oathbringer.nut
@@ -39,94 +39,83 @@
 
 	q.assignRandomEquipment = @() { function assignRandomEquipment()
 	{
-			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapons = [
+			local weapons = ::MSU.Class.WeightedContainer().addMany(1, [
 				"weapons/fighting_axe",
 				"weapons/noble_sword",
 				"weapons/winged_mace",
 				"weapons/warhammer"
-			];
+			]);
 
 			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
 			{
-				weapons.extend([
+				weapons.addMany(1, [
 					"weapons/greatsword",
 					"weapons/greataxe",
-					"weapons/two_handed_hammer"
-				]);
-			}
-
-			if (::Const.DLC.Unhold && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
-			{
-				weapons.extend([
+					"weapons/two_handed_hammer",
 					"weapons/two_handed_flanged_mace",
-					"weapons/two_handed_flail"
-				]);
-			}
-
-			if (::Const.DLC.Wildmen && this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
-			{
-				weapons.extend([
+					"weapons/two_handed_flail",
 					"weapons/bardiche"
 				]);
 			}
 
-			this.m.Items.equip(::new("scripts/items/" + weapons[::Math.rand(0, weapons.len() - 1)]));
+			this.m.Items.equip(::new("scripts/items/" + weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand) && ::Math.rand(1, 100) <= 60)
 		{
-			local shields = [
+			local shield = ::MSU.Class.WeightedContainer().addMany(1, [
 				"shields/heater_shield"
-			];
-			this.m.Items.equip(::new("scripts/items/" + shields[::Math.rand(0, shields.len() - 1)]));
+			]).roll();
+			this.m.Items.equip(::new("scripts/items/" + shield));
 		}
-		// else
-		// {
-		// 	this.m.Skills.add(::new("scripts/skills/perks/perk_duelist"));
-		// }
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Body))
 		{
-			local armor = [
+			local armor = ::MSU.Class.WeightedContainer().addMany(1, [
 				"armor/adorned_heavy_mail_hauberk"
-			];
-			this.m.Items.equip(::new("scripts/items/" + armor[::Math.rand(0, armor.len() - 1)]));
+			]).roll();
+			this.m.Items.equip(::new("scripts/items/" + armor));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Head))
 		{
-			local helmet = [
+			local helmet = ::MSU.Class.WeightedContainer().addMany(1, [
 				"helmets/adorned_closed_flat_top_with_mail",
 				"helmets/adorned_closed_flat_top_with_mail",
 				"helmets/adorned_full_helm",
 				"helmets/adorned_full_helm",
 				"helmets/full_helm"
-			];
-			this.m.Items.equip(::new("scripts/items/" + helmet[::Math.rand(0, helmet.len() - 1)]));
+			]).roll();
+			this.m.Items.equip(::new("scripts/items/" + helmet));
 		}
+	}}.assignRandomEquipment;
 
-		// Reforged
+	q.onSpawned = @(__original) { function onSpawned()
+	{
+		__original();
+
 		if (this.isArmedWithShield())
 		{
 			this.m.Skills.add(::new("scripts/skills/perks/perk_shield_expert"));
 		}
 
 		local weapon = this.getMainhandItem();
-		if (weapon == null) return;
-
-		::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
-
-		if (::Reforged.Items.isDuelistValid(weapon))
+		if (weapon != null)
 		{
-			this.m.Skills.add(::new("scripts/skills/perks/perk_duelist"));
+			::Reforged.Skills.addPerkGroupOfEquippedWeapon(this);
+
+			if (::Reforged.Items.isDuelistValid(weapon))
+			{
+				this.m.Skills.add(::new("scripts/skills/perks/perk_duelist"));
+			}
+			else
+			{
+				this.m.Skills.add(::new("scripts/skills/perks/perk_rf_man_of_steel"));
+			}
 		}
-		else
-		{
-			this.m.Skills.add(::new("scripts/skills/perks/perk_rf_man_of_steel"));
-		}
-	}}.assignRandomEquipment;
+	}}.onSpawned;
 
 	q.makeMiniboss = @(__original) { function makeMiniboss()
 	{

--- a/mod_reforged/hooks/entity/tactical/humans/swordmaster.nut
+++ b/mod_reforged/hooks/entity/tactical/humans/swordmaster.nut
@@ -109,48 +109,58 @@
 					[1, "scripts/items/helmets/nasal_helmet_with_mail"]
 				]).roll();
 			}
-		this.m.Items.equip(::new(helmet));
+			this.m.Items.equip(::new(helmet));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon;
+			local weapons;
 			switch(this.m.MyVariant)
 			{
 				case this.m.SwordmasterVariants.BladeDancer:
-					weapon = ::MSU.Class.WeightedContainer([
-						[1, "scripts/items/weapons/longsword"],
-						[1, "scripts/items/weapons/rf_greatsword"],
-						[1, "scripts/items/weapons/noble_sword"],
-						[1, "scripts/items/weapons/warbrand"]
-					]).roll();
+					weapons = ::MSU.Class.WeightedContainer([
+						[1, "scripts/items/weapons/noble_sword"]
+					]);
+					if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+					{
+						weapons.addArray([
+							[1, "scripts/items/weapons/longsword"],
+							[1, "scripts/items/weapons/rf_greatsword"],
+							[1, "scripts/items/weapons/warbrand"]
+						]);
+					}
 					break;
 
 				case this.m.SwordmasterVariants.Versatile:
-					weapon = "scripts/items/weapons/greatsword";
+					weapons = ::MSU.Class.WeightedContainer([
+						[1, "scripts/items/weapons/greatsword"]
+					]);
 					break;
 
 				case this.m.SwordmasterVariants.Metzger:
-						weapon = "scripts/items/weapons/shamshir";
-						this.m.Items.equip(::new("scripts/items/shields/oriental/southern_light_shield"));
+					weapons = ::MSU.Class.WeightedContainer([
+						[1, "scripts/items/weapons/shamshir"]
+					]);
+					this.m.Items.equip(::new("scripts/items/shields/oriental/southern_light_shield"));
 					break;
 
 				case this.m.SwordmasterVariants.Precise:
-					weapon = ::MSU.Class.WeightedContainer([
+					weapons = ::MSU.Class.WeightedContainer([
 						[1, "scripts/items/weapons/fencing_sword"],
 						[1, "scripts/items/weapons/rf_estoc"]
-					]).roll();
+					]);
 					break;
 
 				case this.m.SwordmasterVariants.Reaper:
-					weapon = ::MSU.Class.WeightedContainer([
+					weapons = ::MSU.Class.WeightedContainer([
 						[1, "scripts/items/weapons/rf_greatsword"],
 						[1, "scripts/items/weapons/warbrand"],
 						[1, "scripts/items/weapons/greatsword"]
-					]).roll();
+					]);
 					break;
 			}
-				this.m.Items.equip(::new(weapon));
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 	}}.assignRandomEquipment;
 

--- a/scripts/entity/tactical/enemies/rf_bandit_baron.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_baron.nut
@@ -82,7 +82,7 @@ this.rf_bandit_baron <- ::inherit("scripts/entity/tactical/human", {
 	function assignRandomEquipment()
 	{
 		// Get shield if 1h named weapon otherwise roll chance for it
-		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand) && (!this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand) || ::Math.rand(1, 100) <= 50))
+		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand) && ::Math.rand(1, 100) <= 50)
 		{
 			local shield = ::MSU.Class.WeightedContainer([
 				[1.0, "scripts/items/shields/heater_shield"],

--- a/scripts/entity/tactical/enemies/rf_bandit_marauder.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_marauder.nut
@@ -48,20 +48,26 @@ this.rf_bandit_marauder <- ::inherit("scripts/entity/tactical/human", {
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer([
+			local weapons = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/arming_sword"],
 				[1, "scripts/items/weapons/boar_spear"],
 				[1, "scripts/items/weapons/flail"],
 				[1, "scripts/items/weapons/hand_axe"],
 				[1, "scripts/items/weapons/military_pick"],
 				[1, "scripts/items/weapons/morning_star"],
-				[1, "scripts/items/weapons/scramasax"],
+				[1, "scripts/items/weapons/scramasax"]
+			]);
 
-				[1, "scripts/items/weapons/longaxe"],
-				[1, "scripts/items/weapons/polehammer"],
-				[1, "scripts/items/weapons/rf_two_handed_falchion"]
-			]).roll();
-			this.m.Items.equip(::new(weapon));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/longaxe"],
+					[1, "scripts/items/weapons/polehammer"],
+					[1, "scripts/items/weapons/rf_two_handed_falchion"]
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))

--- a/scripts/entity/tactical/enemies/rf_bandit_pillager.nut
+++ b/scripts/entity/tactical/enemies/rf_bandit_pillager.nut
@@ -48,7 +48,7 @@ this.rf_bandit_pillager <- ::inherit("scripts/entity/tactical/human", {
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer([
+			local weapons = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/boar_spear"],
 				[1, "scripts/items/weapons/falchion"],
 				[1, "scripts/items/weapons/flail"],
@@ -56,12 +56,18 @@ this.rf_bandit_pillager <- ::inherit("scripts/entity/tactical/human", {
 				[1, "scripts/items/weapons/military_pick"],
 				[1, "scripts/items/weapons/morning_star"],
 				[1, "scripts/items/weapons/scramasax"],
-				[1, "scripts/items/weapons/shortsword"],
+				[1, "scripts/items/weapons/shortsword"]
+			]);
 
-				[1, "scripts/items/weapons/rf_two_handed_falchion"],
-				[1, "scripts/items/weapons/warbrand"]
-			]).roll();
-			this.m.Items.equip(::new(weapon));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/rf_two_handed_falchion"],
+					[1, "scripts/items/weapons/warbrand"]
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Bag))

--- a/scripts/entity/tactical/enemies/rf_draugr_huskarl.nut
+++ b/scripts/entity/tactical/enemies/rf_draugr_huskarl.nut
@@ -50,13 +50,18 @@ this.rf_draugr_huskarl <- ::inherit("scripts/entity/tactical/enemies/rf_draugr",
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer().addMany(1, [
-				"rf_draugr_sword",
-				"rf_draugr_battle_axe",
-				"rf_draugr_greataxe"
-			]).roll();
+			local weapons = ::MSU.Class.WeightedContainer().addMany(1, [
+				"rf_draugr_sword"
+			]);
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addMany(1, [
+					"rf_draugr_battle_axe",
+					"rf_draugr_greataxe"
+				]);
+			}
 
-			this.m.Items.equip(::new("scripts/items/weapons/rf_draugr/" + weapon));
+			this.m.Items.equip(::new("scripts/items/weapons/rf_draugr/" + weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))

--- a/scripts/entity/tactical/enemies/rf_draugr_warrior.nut
+++ b/scripts/entity/tactical/enemies/rf_draugr_warrior.nut
@@ -54,14 +54,20 @@ this.rf_draugr_warrior <- ::inherit("scripts/entity/tactical/enemies/rf_draugr",
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer().addMany(1, [
+			local weapons = ::MSU.Class.WeightedContainer().addMany(1, [
 				"rf_draugr_axe",
-				"rf_draugr_cleaver",
-				"rf_draugr_voulge",
-				"rf_draugr_battle_axe"
-			]).roll();
+				"rf_draugr_cleaver"
+			]);
 
-			this.m.Items.equip(::new("scripts/items/weapons/rf_draugr/" + weapon));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addMany(1, [
+					"rf_draugr_voulge",
+					"rf_draugr_battle_axe"
+				]);
+			}
+
+			this.m.Items.equip(::new("scripts/items/weapons/rf_draugr/" + weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand) && ::Math.rand(1, 100) <= 70)

--- a/scripts/entity/tactical/enemies/rf_skeleton_heavy_elite.nut
+++ b/scripts/entity/tactical/enemies/rf_skeleton_heavy_elite.nut
@@ -32,13 +32,19 @@ this.rf_skeleton_heavy_elite <- ::inherit("scripts/entity/tactical/skeleton", {
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			local weapon = ::MSU.Class.WeightedContainer([
-				[1, "scripts/items/weapons/ancient/khopesh"],
-				[1, "scripts/items/weapons/ancient/crypt_cleaver"],
-				[1, "scripts/items/weapons/ancient/rhomphaia"]
-			]).roll();
+			local weapons = ::MSU.Class.WeightedContainer([
+				[1, "scripts/items/weapons/ancient/khopesh"]
+			]);
 
-			this.m.Items.equip(::new(weapon));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/ancient/crypt_cleaver"],
+					[1, "scripts/items/weapons/ancient/rhomphaia"]
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))

--- a/scripts/entity/tactical/enemies/rf_zombie_hero.nut
+++ b/scripts/entity/tactical/enemies/rf_zombie_hero.nut
@@ -82,24 +82,31 @@ this.rf_zombie_hero <- ::inherit("scripts/entity/tactical/enemies/zombie", {
 	{
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Mainhand))
 		{
-			this.m.Items.equip(::new(::MSU.Class.WeightedContainer([
+			local weapons = ::MSU.Class.WeightedContainer([
 				[1, "scripts/items/weapons/arming_sword"],
 				[1, "scripts/items/weapons/fighting_axe"],
 				[1, "scripts/items/weapons/noble_sword"],
 				[1, "scripts/items/weapons/military_cleaver"],
 				[1, "scripts/items/weapons/warhammer"],
-				[1, "scripts/items/weapons/winged_mace"],
+				[1, "scripts/items/weapons/winged_mace"]
+			]);
 
-				[1, "scripts/items/weapons/bardiche"],
-				[1, "scripts/items/weapons/longsword"],
-				[1, "scripts/items/weapons/greataxe"],
-				[1, "scripts/items/weapons/rf_kriegsmesser"],
-				[1, "scripts/items/weapons/rf_poleaxe"],
-				[1, "scripts/items/weapons/two_handed_flail"],
-				[1, "scripts/items/weapons/two_handed_flanged_mace"],
-				[1, "scripts/items/weapons/two_handed_hammer"],
-				[1, "scripts/items/weapons/greatsword"]
-			]).roll()));
+			if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))
+			{
+				weapons.addArray([
+					[1, "scripts/items/weapons/bardiche"],
+					[1, "scripts/items/weapons/longsword"],
+					[1, "scripts/items/weapons/greataxe"],
+					[1, "scripts/items/weapons/rf_kriegsmesser"],
+					[1, "scripts/items/weapons/rf_poleaxe"],
+					[1, "scripts/items/weapons/two_handed_flail"],
+					[1, "scripts/items/weapons/two_handed_flanged_mace"],
+					[1, "scripts/items/weapons/two_handed_hammer"],
+					[1, "scripts/items/weapons/greatsword"]
+				]);
+			}
+
+			this.m.Items.equip(::new(weapons.roll()));
 		}
 
 		if (this.m.Items.hasEmptySlot(::Const.ItemSlot.Offhand))


### PR DESCRIPTION
- Move perks assignment based on equipment to onSpawned instead of assignRandomEquipment.
- For relevant enemies, add check for Offhand being free before trying to equip a two-handed weapon.
- Convert enemies using copied pasted vanilla assignRandomEquipment code to use MSU weighted containers.
- Remove redundant empty hooks on functions.

[Relevant issue on Discord](https://discord.com/channels/1006908336991645757/1006908337981509725/1489841449586524210) where some mod adds champions for enemies which spawn with named shield and then don't get a weapon because Reforged is trying to equip the champion with a two-handed weapon in `assignRandomEquipment`.