### PR TITLE
feat: add ability to add dividers in tooltip text and hint entries

### DIFF
--- a/ui/mods/mod_reforged/js_hooks/screens/tooltip/modules/tooltip_module.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/tooltip/modules/tooltip_module.js
@@ -40,9 +40,29 @@ TooltipModule.prototype.addHeaderDescriptionDiv = function(_parentDIV, _data)
 Reforged.Hooks.TooltipModule_addContentTextDiv = TooltipModule.prototype.addContentTextDiv;
 TooltipModule.prototype.addContentTextDiv = function(_parentDIV, _data, _isChildRow, _isParentFullWidth)
 {
+	// Add ability to add dividers in text entries.
+	if (_data !== null && 'text' in _data && _data.text === 'rf_divider')
+	{
+		var container = $('<div class="row ui-control-tooltip-module-bottom-devider"/>');
+		_parentDIV.append(container);
+		return container;
+	}
 	var ret = Reforged.Hooks.TooltipModule_addContentTextDiv.call(this, _parentDIV, _data, _isChildRow, _isParentFullWidth);
 	if (ret === null || _data.rawHTMLInText !== true )
 		return ret;
 	this.rf_unescapeTagsOnElement(ret.find(".text:first"));
 	return ret;
+};
+
+Reforged.Hooks.TooltipModule_addHintDiv = TooltipModule.prototype.addHintDiv;
+TooltipModule.prototype.addHintDiv = function(_parentDIV, _data, _isChildRow, _isParentFullWidth)
+{
+	// Add ability to add dividers in hint entries.
+	if (_data !== null && 'text' in _data && _data.text === 'rf_divider')
+	{
+		var container = $('<div class="row ui-control-tooltip-module-bottom-devider"/>');
+		_parentDIV.append(container);
+		return container;
+	}
+	return Reforged.Hooks.TooltipModule_addHintDiv.call(this, _parentDIV, _data, _isChildRow, _isParentFullWidth);
 };

--- a/ui/mods/mod_reforged/js_hooks/screens/tooltip/modules/tooltip_module.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/tooltip/modules/tooltip_module.js
@@ -43,7 +43,8 @@ TooltipModule.prototype.addContentTextDiv = function(_parentDIV, _data, _isChild
 	// Add ability to add dividers in text entries.
 	if (_data !== null && 'text' in _data && _data.text === 'rf_divider')
 	{
-		var container = $('<div class="row ui-control-tooltip-module-bottom-devider"/>');
+		var cssClass = 'cssClass' in _data ? _data.cssClass : 'row ui-control-tooltip-module-bottom-devider';
+		var container = $('<div class="' + cssClass + '"/>');
 		_parentDIV.append(container);
 		return container;
 	}
@@ -60,7 +61,8 @@ TooltipModule.prototype.addHintDiv = function(_parentDIV, _data, _isChildRow, _i
 	// Add ability to add dividers in hint entries.
 	if (_data !== null && 'text' in _data && _data.text === 'rf_divider')
 	{
-		var container = $('<div class="row ui-control-tooltip-module-bottom-devider"/>');
+		var cssClass = 'cssClass' in _data ? _data.cssClass : 'row ui-control-tooltip-module-bottom-devider';
+		var container = $('<div class="' + cssClass + '"/>');
 		_parentDIV.append(container);
 		return container;
 	}


### PR DESCRIPTION
Usage:
Pass `rf_divider` as value for the `text` key of a "text" or "hint" type tooltip entry.

<img width="164" height="247" alt="image" src="https://github.com/user-attachments/assets/b3dbd7bf-119b-4afd-86aa-6a694b536d2a" />
