### PR TITLE
feat: bind tooltips to character images shown on event screen

### DIFF
--- a/mod_reforged/actor_tooltip_functions.nut
+++ b/mod_reforged/actor_tooltip_functions.nut
@@ -137,6 +137,27 @@
 		return effectList;
 	}
 
+	// This is only used for players and isn't part of
+	// the standard actor tooltip generation.
+	function getTooltipTraits( _actor, _startID )
+	{
+		local extraData = "entityId:" + _actor.getID();
+		local entryText = "";
+		foreach (trait in _actor.getSkills().getAllSkillsOfType(::Const.SkillType.Trait))
+		{
+			if (::MSU.isKindOf(trait, "character_background") || ::MSU.isKindOf(trait, "character_trait"))
+				entryText += ::Reforged.NestedTooltips.getNestedSkillImage(trait, extraData);
+		}
+		local ret = [];
+		this.pushSectionName(ret, "Traits", _startID);
+		ret.push({
+			id = ++_startID,
+			type = "text",
+			text = ::Reforged.Mod.Tooltips.parseString(entryText)
+		});
+		return ret;
+	}
+
 	// Returns a list of all perks in tooltip-form
 	function getTooltipPerks( _actor, _startID )
 	{

--- a/mod_reforged/hooks/contracts/contract.nut
+++ b/mod_reforged/hooks/contracts/contract.nut
@@ -253,6 +253,66 @@
 		return _numTiles * 170.0 / _speed;
 	}}.getSecondsRequiredToTravel;
 
+	// Returns a TooltipID used to bind the tooltip of the character/banner/destination being displayed
+	// on the screen. Similar to the usage of the vanilla `getUICharacterImage` function.
+	q.RF_getUICharacterTooltipID <- { function RF_getUICharacterTooltipID( _index = 0 )
+	{
+		local image = this.getUICharacterImage(_index);
+		if (image == null)
+			return null;
+
+		local imagePath = image.Image;
+
+		// In Reforged we pass the destination's image sometimes, so we handle that here.
+		if ("Destination" in this.m && !::MSU.isNull(this.m.Destination) && this.m.Destination.getImagePath() == imagePath)
+		{
+			return "WorldEntity+" + this.m.Destination.getID();
+		}
+
+		if ("Characters" in this.m.ActiveScreen && this.m.ActiveScreen.Characters.len() > _index)
+		{
+			// Vanilla stores references to actors in the `m` table of the contract. So we have to iterate
+			// over that and use the imagePath to detect if this is the actor we are looking for.
+			foreach (k, v in this.m)
+			{
+				// We cannot compare getImagePath to the imagePath stored here because
+				// actor.getImagePath adds m.ContendID to it which can be different every time.
+				// We instead check if the actor's ID is present in the imagePath between two commas.
+				if (::MSU.isKindOf(v, "actor") && imagePath.find("," + v.getID() + ",") != null)
+				{
+					return "EventActor+" + v.getID();
+				}
+			}
+		}
+
+		if ("Banner" in this.m.ActiveScreen && imagePath == this.m.ActiveScreen.Banner)
+		{
+			foreach (f in ::World.FactionManager.getFactions())
+			{
+				if (f != null && (imagePath == f.getUIBanner() || imagePath == f.getUIBannerSmall()))
+				{
+					return "Faction+" + f.getID();
+				}
+			}
+		}
+
+		if (("ShowEmployer" in this.m.ActiveScreen) && this.m.ActiveScreen.ShowEmployer)
+		{
+			if (_index == 0)
+			{
+				return "EventActor+" + this.m.EmployerID;
+			}
+			else if (::World.FactionManager.getFaction(this.m.Faction).getType() == ::Const.FactionType.NobleHouse)
+			{
+				return "Faction+" + this.getFaction().getID();
+			}
+			else
+			{
+				return null;
+			}
+		}
+	}}.RF_getUICharacterTooltipID;
+
 	q.getUICharacterImage = @(__original) { function getUICharacterImage( _index = 0 )
 	{
 		if ((!("Characters" in this.m.ActiveScreen) || !this.m.ActiveScreen.Characters.len()) &&

--- a/mod_reforged/hooks/events/event.nut
+++ b/mod_reforged/hooks/events/event.nut
@@ -1,0 +1,40 @@
+::Reforged.HooksMod.hook("scripts/events/event", function(q) {
+	// Returns a TooltipID used to bind the tooltip of the character/banner being displayed
+	// on the screen. Similar to the usage of the vanilla `getUICharacterImage` function.
+	q.RF_getUICharacterTooltipID <- { function RF_getUICharacterTooltipID( _index = 0 )
+	{
+		local image = this.getUICharacterImage(_index);
+		if (image == null)
+			return null;
+
+		local imagePath = image.Image;
+
+		if ("Characters" in this.m.ActiveScreen && this.m.ActiveScreen.Characters.len() > _index)
+		{
+			// Vanilla stores references to actors in the `m` table of the event. So we have to iterate
+			// over that and use the imagePath to detect if this is the actor we are looking for.
+			foreach (k, v in this.m)
+			{
+				// We cannot compare getImagePath to the imagePath stored here because
+				// somehow that can have a different value (see actor.getImagePath where it adds
+				// m.ContentID to it which can be different). So, we instead check if the
+				// actor's ID is present in the imagePath between two commas.
+				if (::MSU.isKindOf(v, "actor") && imagePath.find("," + v.getID() + ",") != null)
+				{
+					return "EventActor+" + v.getID();
+				}
+			}
+		}
+
+		if ("Banner" in this.m.ActiveScreen && imagePath == this.m.ActiveScreen.Banner)
+		{
+			foreach (f in ::World.FactionManager.getFactions())
+			{
+				if (f != null && (imagePath == f.getUIBanner() || imagePath == f.getUIBannerSmall()))
+				{
+					return "Faction+" + f.getID();
+				}
+			}
+		}
+	}}.RF_getUICharacterTooltipID;
+});

--- a/mod_reforged/hooks/ui/screens/world/world_event_screen.nut
+++ b/mod_reforged/hooks/ui/screens/world/world_event_screen.nut
@@ -1,0 +1,10 @@
+::Reforged.HooksMod.hook("scripts/ui/screens/world/world_event_screen", function(q) {
+	q.convertEventToUIData = @(__original) { function convertEventToUIData( _event )
+	{
+		local ret = __original(_event);
+		// Add TooltipIDs for left and right characters shown on the screen.
+		ret.characterLeftTooltipID <- _event.RF_getUICharacterTooltipID(0);
+		ret.characterRightTooltipID <- _event.RF_getUICharacterTooltipID(1);
+		return ret;
+	}}.convertEventToUIData;
+});

--- a/mod_reforged/msu_systems/tooltips.nut
+++ b/mod_reforged/msu_systems/tooltips.nut
@@ -1,4 +1,25 @@
 ::Reforged.Mod.Tooltips.setTooltips({
+	EventActor = ::MSU.Class.CustomTooltip(function( _data ) {
+		local entity = ::Tactical.getEntityByID(_data.ExtraData.tointeger());
+		if (entity == null)
+			return null;
+
+		if (::MSU.isKindOf(entity, "player"))
+		{
+			local ret = entity.getRosterTooltip();
+			ret.push({id = 124, type = "text", text = "rf_divider"});
+			ret.extend([::Reforged.TacticalTooltip.getTooltipAttributesSmall(entity, 100)]);
+			ret.push({id = 124, type = "text", text = "rf_divider"});
+			ret.extend(::Reforged.TacticalTooltip.getTooltipTraits(entity, 200));
+			ret.extend(::Reforged.TacticalTooltip.getTooltipEffects(entity, 300));
+			ret.extend(::Reforged.TacticalTooltip.getTooltipPerks(entity, 400));
+			ret.extend(::Reforged.TacticalTooltip.getTooltipEquippedItems(entity, 500));
+			ret.extend(::Reforged.TacticalTooltip.getTooltipBagItems(entity, 600));
+			return ret;
+		}
+
+		return ::TooltipEvents.general_queryUIElementTooltipData(entity.getID(), "CharacterNameAndTitles", null);
+	}),
 	Faction = ::MSU.Class.CustomTooltip(function( _data ) {
 		local ret = [
 			{ contentType = "settlement-status-effect" }

--- a/ui/mods/mod_reforged/js_hooks/screens/world/world_event_screen.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/world/world_event_screen.js
@@ -14,7 +14,6 @@ WorldEventScreen.prototype.updateHeader = function (_data)
 
 	if (_data.characterRightTooltipID !== null)
 	{
-		console.error(_data.characterLeftTooltipID.indexOf("WorldEntity+"));
 		this.mCharacterOverlayRight.bindTooltip({ contentType: 'msu-generic', modId: _data.characterRightTooltipID.indexOf("WorldEntity+") != -1 ? Reforged.MSUID : Reforged.ID, elementId: _data.characterRightTooltipID });
 	}
 }

--- a/ui/mods/mod_reforged/js_hooks/screens/world/world_event_screen.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/world/world_event_screen.js
@@ -1,0 +1,20 @@
+Reforged.Hooks.WorldEventScreen_updateHeader = WorldEventScreen.prototype.updateHeader;
+WorldEventScreen.prototype.updateHeader = function (_data)
+{
+	Reforged.Hooks.WorldEventScreen_updateHeader.call(this, _data);
+
+	// Bind tooltips of the characters to their images in the event screen.
+	// Note: WorldEntity is a key in MSU Nested Tooltips so for that we want
+	// to return msu's id instead of reforged id.
+
+	if (_data.characterLeftTooltipID !== null)
+	{
+		this.mCharacterOverlayLeft.bindTooltip({ contentType: 'msu-generic', modId: _data.characterLeftTooltipID.indexOf("WorldEntity+") != -1 ? Reforged.MSUID : Reforged.ID, elementId: _data.characterLeftTooltipID });
+	}
+
+	if (_data.characterRightTooltipID !== null)
+	{
+		console.error(_data.characterLeftTooltipID.indexOf("WorldEntity+"));
+		this.mCharacterOverlayRight.bindTooltip({ contentType: 'msu-generic', modId: _data.characterRightTooltipID.indexOf("WorldEntity+") != -1 ? Reforged.MSUID : Reforged.ID, elementId: _data.characterRightTooltipID });
+	}
+}

--- a/ui/mods/mod_reforged/setup.js
+++ b/ui/mods/mod_reforged/setup.js
@@ -1,5 +1,6 @@
 var Reforged = {
 	ID : "mod_reforged",
+	MSUID : "mod_msu",
 	JSConnectionID : "ReforgedJSConnection",
 	Hooks : {}
 }


### PR DESCRIPTION
Requires the next version of Nested Tooltips Framework that contains support for the `WorldEntity` key.

<img width="753" height="623" alt="image" src="https://github.com/user-attachments/assets/3b89779e-22c7-4057-a141-d1296fa76aa7" />
