### PR TITLE
feat: use nested names and icons during events for various classes

### DIFF
--- a/mod_reforged/hooks/contracts/contract.nut
+++ b/mod_reforged/hooks/contracts/contract.nut
@@ -344,4 +344,20 @@
 		::Const.World.Common.RF_addSpawnlistInfo(_entity, _partyList);
 		__original(_entity, _partyList, _resources);
 	}}.addUnitsToEntity;
+
+	q.setScreen = @(__original) { function setScreen( _screen, _restartIfAlreadyActive = true )
+	{
+		::Reforged.NestedTooltips.setApplyNestingForEvents(true);
+		__original(_screen, _restartIfAlreadyActive);
+		::Reforged.NestedTooltips.setApplyNestingForEvents(false);
+	}}.setScreen;
+});
+
+::Reforged.HooksMod.hookTree("scripts/contracts/contract", function(q) {
+	q.onPrepareVariables = @(__original) { function onPrepareVariables( _vars )
+	{
+		::Reforged.NestedTooltips.setApplyNestingForEvents(true);
+		__original(_vars);
+		::Reforged.NestedTooltips.setApplyNestingForEvents(false);
+	}}.onPrepareVariables;
 });

--- a/mod_reforged/hooks/events/event.nut
+++ b/mod_reforged/hooks/events/event.nut
@@ -37,4 +37,20 @@
 			}
 		}
 	}}.RF_getUICharacterTooltipID;
+
+	q.setScreen = @(__original) { function setScreen( _screen )
+	{
+		::Reforged.NestedTooltips.setApplyNestingForEvents(true);
+		__original(_screen);
+		::Reforged.NestedTooltips.setApplyNestingForEvents(false);
+	}}.setScreen;
+});
+
+::Reforged.HooksMod.hookTree("scripts/events/event", function(q) {
+	q.onPrepareVariables = @(__original) { function onPrepareVariables( _vars )
+	{
+		::Reforged.NestedTooltips.setApplyNestingForEvents(true);
+		__original(_vars);
+		::Reforged.NestedTooltips.setApplyNestingForEvents(false);
+	}}.onPrepareVariables;
 });

--- a/mod_reforged/msu_systems/nested_tooltips.nut
+++ b/mod_reforged/msu_systems/nested_tooltips.nut
@@ -7,7 +7,88 @@ local getThresholdForInjury = function( _script )
 	}
 }
 
+// Apply nesting in events
+{
+	::Reforged.HooksMod.hookTree("scripts/entity/tactical/actor", function(q) {
+		q.getName = @(__original) { function getName()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|EventActor+%i]", __original(), this.getID())) : __original();
+		}}.getName;
+
+		q.getNameOnly = @(__original) { function getNameOnly()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|EventActor+%i]", __original(), this.getID())) : __original();
+		}}.getNameOnly;
+	});
+
+	::Reforged.HooksMod.hookTree("scripts/items/item", function(q) {
+		q.getName = @(__original) { function getName()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Obj+%s,contentType:ui-item]", __original(), ::Reforged.Mod.Tooltips.parseObject(this))) : __original();
+		}}.getName;
+
+		q.getIcon = @(__original) { function getIcon()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/ui/items/%s|Obj+%s,contentType:ui-item]", __original(), ::Reforged.Mod.Tooltips.parseObject(this))) : __original();
+		}}.getIcon;
+	});
+
+	::Reforged.HooksMod.hookTree("scripts/skills/skill", function(q) {
+		q.getName = @(__original) { function getName()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+		}}.getName;
+
+		if (q.contains("getNameOnly"))
+		{
+			q.getNameOnly = @(__original) { function getNameOnly()
+			{
+				return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+			}}.getNameOnly;
+		}
+
+		q.getIcon = @(__original) { function getIcon()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+		}}.getIcon;
+
+		q.getIconColored = @(__original) { function getIconColored()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+		}}.getIconColored;
+
+		q.getIconDisabled = @(__original) { function getIconDisabled()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+		}}.getIconDisabled;
+	});
+
+	::Reforged.HooksMod.hookTree("scripts/factions/faction", function(q) {
+		q.getName = @(__original) { function getName()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Faction+%i]", __original(), this.getID())) : __original();
+		}}.getName;
+
+		if (q.contains("getNameOnly"))
+		{
+			q.getNameOnly = @(__original) { function getNameOnly()
+			{
+				return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Faction+%i]", __original(), this.getID())) : __original();
+			}}.getNameOnly;
+		}
+	});
+
+	::Reforged.HooksMod.hookTree("scripts/entity/world/world_entity", function(q) {
+		q.getName = @(__original) { function getName()
+		{
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|WorldEntity+%i]", __original(), this.getID())) : __original();
+		}}.getName;
+	});
+}
+
 ::Reforged.NestedTooltips <- {
+	__IsApplyingNestingForEvents = 0,
+
 	Tooltips = {
 		Concept = {}
 	},
@@ -38,6 +119,22 @@ local getThresholdForInjury = function( _script )
 		"assets.BusinessReputation",
 		"assets.MoralReputation"
 	],
+
+	function setApplyNestingForEvents( _apply )
+	{
+		// Have to do it as a "stack" because functions which set this on/off
+		// can be called from within themselves and we don't want to set it to
+		// false in the middle of such a call stack.
+		if (_apply)
+			this.__IsApplyingNestingForEvents += 1;
+		else if (this.__IsApplyingNestingForEvents > 0)
+			this.__IsApplyingNestingForEvents -= 1;
+	}
+
+	function isApplyingNestingForEvents()
+	{
+		return this.__IsApplyingNestingForEvents != 0;
+	}
 
 	function getNestedPerkName( _obj, _extraData = null )
 	{


### PR DESCRIPTION
Converts the following to nested tooltips in event and contract screens:
- Actor names
- Item names and icons
- Skill names and icons
- Faction names
- World entity names

<img width="1405" height="1261" alt="image" src="https://github.com/user-attachments/assets/4c476d71-cf21-43d0-88a2-bc3ebee57324" />

<img src="https://media.discordapp.net/attachments/996543320320921722/1494098408561049741/image.png?ex=69e207d3&is=69e0b653&hm=e56fa1c6e9b728e4cbdbe604e0d5fec6cd561efb8bb92e94edde70c50f94ca6f&=&format=webp&quality=lossless&width=1872&height=1980">
