### PR TITLE
fix: recover being disabled by displacement due to zombie resurrection

### DIFF
--- a/mod_reforged/hooks/skills/actives/recover_skill.nut
+++ b/mod_reforged/hooks/skills/actives/recover_skill.nut
@@ -59,7 +59,7 @@
 	q.onMovementStarted = @(__original) { function onMovementStarted( _tile, _numTiles )
 	{
 		__original(_tile, _numTiles);
-		if (::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()))
+		if (::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()) && this.getContainer().getActor().m.CurrentMovementType == ::Const.Tactical.MovementType.Default)
 		{
 			this.m.HasMovedOrUsedSkill = true;
 		}


### PR DESCRIPTION
I have not tested that it fixes the bug, but in theory it should. Let me know if you think this is not the correct approach.

Related bug report on Discord: https://discord.com/channels/1006908336991645757/1491960913144713277