### PR TITLE
fix: barrow chant and frostbound not adding their effects on self spawn

### DIFF
--- a/scripts/skills/effects/rf_barrow_chant_effect.nut
+++ b/scripts/skills/effects/rf_barrow_chant_effect.nut
@@ -63,6 +63,16 @@ this.rf_barrow_chant_effect <- ::inherit("scripts/skills/skill", {
 
 	function onActorSpawned( _actor )
 	{
-		_actor.getSkills().add(::new("scripts/skills/effects/rf_barrow_chant_debuff_effect"));
+		if (::MSU.isEqual(_actor, this.getContainer().getActor()))
+		{
+			foreach (a in ::Tactical.Entities.getAllInstancesAsArray())
+			{
+				a.getSkills().add(::new("scripts/skills/effects/rf_barrow_chant_debuff_effect"));
+			}
+		}
+		else
+		{
+			_actor.getSkills().add(::new("scripts/skills/effects/rf_barrow_chant_debuff_effect"));
+		}
 	}
 });

--- a/scripts/skills/effects/rf_frostbound_effect.nut
+++ b/scripts/skills/effects/rf_frostbound_effect.nut
@@ -50,7 +50,17 @@ this.rf_frostbound_effect <- ::inherit("scripts/skills/skill", {
 
 	function onActorSpawned( _actor )
 	{
-		if (!::MSU.isKindOf(_actor, "rf_draugr") && !_actor.getSkills().hasSkill("special.rf_frostbound_manager"))
+		if (::MSU.isEqual(_actor, this.getContainer().getActor()))
+		{
+			foreach (a in ::Tactical.Entities.getAllInstancesAsArray())
+			{
+				if (!::MSU.isKindOf(_actor, "rf_draugr") && !_actor.getSkills().hasSkill("special.rf_frostbound_manager"))
+				{
+					a.getSkills().add(::new("scripts/skills/special/rf_frostbound_manager"));
+				}
+			}
+		}
+		else if (!::MSU.isKindOf(_actor, "rf_draugr") && !_actor.getSkills().hasSkill("special.rf_frostbound_manager"))
 		{
 			_actor.getSkills().add(::new("scripts/skills/special/rf_frostbound_manager"));
 		}


### PR DESCRIPTION
The original implementation only adds the manager/debuff effect to actors that spawn while the original actor has already spawned. But it does not add the manager/debuff effects if the actor with these effects is spawned mid-combat. The new implementation fixes it (albeit this doesn't seem very efficient).