### PR TITLE
feat: show predicted hitchances in tile tooltip during movement preview

### DIFF
--- a/mod_reforged/hooks/native/TacticalTile.nut
+++ b/mod_reforged/hooks/native/TacticalTile.nut
@@ -1,0 +1,47 @@
+// Hook to return as if the previewing entity has ZoC on this tile. Relevant for hit-chance prediction during movement preview.
+local hasZoneOfControlOtherThan = ::TacticalTile.hasZoneOfControlOtherThan;
+::TacticalTile.hasZoneOfControlOtherThan <- { function hasZoneOfControlOtherThan( _factions )
+{
+	return hasZoneOfControlOtherThan(_factions) || (this.Properties.has("RF_PreviewZOCFaction") && _factions.find(this.Properties.get("RF_PreviewZOCFaction")) == null)
+}}.hasZoneOfControlOtherThan;
+
+// Hook to return as if the previewing entity has ZoC on this tile. Relevant for hit-chance prediction during movement preview.
+local getZoneOfControlCount = ::TacticalTile.getZoneOfControlCount;
+::TacticalTile.getZoneOfControlCount <- { function getZoneOfControlCount( _factions )
+{
+	if (!this.Properties.has("RF_PreviewZOCFaction") || _factions.find(this.Properties.get("RF_PreviewZOCFaction")) == null)
+		return getZoneOfControlCount(_factions);
+
+	return getZoneOfControlCount(_factions) + 1;
+}}.getZoneOfControlCount;
+
+// Hook to return as if the previewing entity has ZoC on this tile. Relevant for hit-chance prediction during movement preview.
+local getZoneOfControlCountOtherThan = ::TacticalTile.getZoneOfControlCountOtherThan;
+::TacticalTile.getZoneOfControlCountOtherThan <- { function getZoneOfControlCountOtherThan( _factions )
+{
+	if (!this.Properties.has("RF_PreviewZOCFaction") || _factions.find(this.Properties.get("RF_PreviewZOCFaction")) != null)
+		return getZoneOfControlCountOtherThan(_factions);
+
+	return getZoneOfControlCountOtherThan(_factions) + 1;
+}}.getZoneOfControlCountOtherThan;
+
+// Hook to return as if the previewing entity is present in this tile. Relevant for hit-chance prediction during movement preview.
+local getEntity = ::TacticalTile.getEntity;
+::TacticalTile.getEntity <- { function getEntity()
+{
+	return this.Properties.has("RF_PreviewEntity") ? this.Properties.get("RF_PreviewEntity") : getEntity();
+}}.getEntity;
+
+// Hook to return as if the previewing entity is present in this tile. Relevant for hit-chance prediction during movement preview.
+local IsOccupiedByActor = ::TacticalTile.__getTable.IsOccupiedByActor;
+::TacticalTile.__getTable.IsOccupiedByActor <- { function IsOccupiedByActor()
+{
+	return IsOccupiedByActor() || this.Properties.has("RF_PreviewEntity");
+}}.IsOccupiedByActor;
+
+// Hook to return as if the previewing entity is present in this tile. Relevant for hit-chance prediction during movement preview.
+local IsEmpty = ::TacticalTile.__getTable.IsEmpty;
+::TacticalTile.__getTable.IsEmpty <- { function IsEmpty()
+{
+	return IsEmpty() && !this.Properties.has("RF_PreviewEntity");
+}}.IsEmpty;

--- a/mod_reforged/hooks/native/TacticalTile.nut
+++ b/mod_reforged/hooks/native/TacticalTile.nut
@@ -7,12 +7,12 @@ local hasZoneOfControlOtherThan = ::TacticalTile.hasZoneOfControlOtherThan;
 
 // Hook to return as if the previewing entity has ZoC on this tile. Relevant for hit-chance prediction during movement preview.
 local getZoneOfControlCount = ::TacticalTile.getZoneOfControlCount;
-::TacticalTile.getZoneOfControlCount <- { function getZoneOfControlCount( _factions )
+::TacticalTile.getZoneOfControlCount <- { function getZoneOfControlCount( _faction )
 {
-	if (!this.Properties.has("RF_PreviewZOCFaction") || _factions.find(this.Properties.get("RF_PreviewZOCFaction")) == null)
-		return getZoneOfControlCount(_factions);
+	if (!this.Properties.has("RF_PreviewZOCFaction") || this.Properties.get("RF_PreviewZOCFaction") != _faction)
+		return getZoneOfControlCount(_faction);
 
-	return getZoneOfControlCount(_factions) + 1;
+	return getZoneOfControlCount(_faction) + 1;
 }}.getZoneOfControlCount;
 
 // Hook to return as if the previewing entity has ZoC on this tile. Relevant for hit-chance prediction during movement preview.

--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -270,12 +270,13 @@
 									.filter(@(_, _a) !_a.isAlliedWith(entity) && _a.onMovementInZoneOfControl(entity, true))
 									.map(function(_a) {
 										local aoo = _a.getSkills().getAttackOfOpportunity();
+										_a.getSkills().update();
+										_tag.ActorsToUpdate.push(_a);
 										return {
 											id = 100,	type = "text",	icon = ::Reforged.Mod.Tooltips.parseString(::Reforged.NestedTooltips.getNestedEntityImage(_a)),
 											text = ::MSU.Text.colorNegative(aoo.getHitchance(entity) + "%") + " chance to hit with " + ::Reforged.Mod.Tooltips.parseString(::Reforged.NestedTooltips.getNestedSkillName(aoo, "entityId:" + _a.getID()))
 										}
 									});
-
 
 			if (spearwallAttacks.len() != 0)
 			{
@@ -322,8 +323,11 @@
 					// with the previewing entity being considered at the destTile. During cleanup
 					// we will have to do another update on these enemies to set them back to the
 					// correct properties.
-					enemy.getSkills().update();
-					_tag.ActorsToUpdate.push(enemy);
+					if (_tag.ActorsToUpdate.find(enemy) == null)
+					{
+						enemy.getSkills().update();
+						_tag.ActorsToUpdate.push(enemy);
+					}
 
 					local hitChance = enemyAttack.getHitchance(entity);
 					if (text == "" && hitChance <= collapseThreshold)

--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -292,84 +292,110 @@
 
 		// Below we add tooltip about chances to hit valid targets and to be hit from opponents assuming we are at the destination tile.
 
-		local myAttacks = entity.getSkills().getAllSkillsOfType(::Const.SkillType.Active).filter(@(_, _a) _a.isAttack());
-		local myVision = entity.getCurrentProperties().getVision();
-		local extraData = "entityId: " + entity.getID();
-
-		local attacks = [];
-		local collapseThreshold = ::Reforged.Mod.ModSettings.getSetting("TacticalTooltip_ThreatHitchanceThreshold").getValue();
-		local attacksBelowThreshold = "";
-
-		foreach (enemy in ::Tactical.Entities.getAllInstancesAsArray().filter(@(_, _a) !_a.isAlliedWith(entity) && !_a.isHiddenToPlayer()))
+		local showPlayer = true;
+		local showEnemy = true;
+		switch (::Reforged.Mod.ModSettings.getSetting("TacticalTooltip_MovementPreviewHitchances").getValue())
 		{
-			local text = "";
-			local score = 0;
-			foreach (a in myAttacks)
-			{
-				if (a.isUsable() && a.isInRange(enemy.getTile()) && (!a.isVisibleTileNeeded() || destTile.hasLineOfSightTo(enemy.getTile(), myVision)))
-				{
-					local hitChance = a.getHitchance(entity);
-					score = 999 + hitChance;
-					text = format("%s with %s", ::MSU.Text.colorPositive(a.getHitchance(enemy) + "%"), ::Reforged.NestedTooltips.getNestedSkillName(a, extraData));
-					break;
-				}
-			}
+			case "None":
+				showplayer = false;
+				showEnemy = false;
+				break;
 
-			foreach (enemyAttack in enemy.getSkills().getAllSkillsOfType(::Const.SkillType.Active).filter(@(_, _a) _a.isAttack()))
-			{
-				if (enemyAttack.isUsable() && enemyAttack.isInRange(destTile) && (!enemyAttack.isVisibleTileNeeded() || enemy.getTile().hasLineOfSightTo(destTile, enemy.getCurrentProperties().getVision())))
-				{
-					// We update the skills of the enemy so that it sets the correct properties
-					// with the previewing entity being considered at the destTile. During cleanup
-					// we will have to do another update on these enemies to set them back to the
-					// correct properties.
-					if (_tag.ActorsToUpdate.find(enemy) == null)
-					{
-						enemy.getSkills().update();
-						_tag.ActorsToUpdate.push(enemy);
-					}
-
-					local hitChance = enemyAttack.getHitchance(entity);
-					if (text == "" && hitChance <= collapseThreshold)
-					{
-						attacksBelowThreshold += ::Reforged.NestedTooltips.getNestedEntityImage(enemy);
-					}
-					else
-					{
-						score += hitChance;
-						text += text == "" ? "" : ", ";
-						text += format("%s with %s", ::MSU.Text.colorNegative(hitChance + "%"), ::Reforged.NestedTooltips.getNestedSkillName(enemyAttack, "entityId: " + enemy.getID()));
-					}
-					break;
-				}
-			}
-
-			if (text == "")
-				continue;
-
-			attacks.push([score, {
-				id = 100, type = "text", icon = ::Reforged.Mod.Tooltips.parseString(::Reforged.NestedTooltips.getNestedEntityImage(enemy)),
-				text = ::Reforged.Mod.Tooltips.parseString(text)
-			}]);
+			case "Player Only":
+				showEnemy = false;
+				break;
+			case "AI Only":
+				showPlayer = false;
+				break;
 		}
 
-		if (attacks.len() != 0)
+		if (showPlayer || showEnemy)
 		{
-			ret.push({
-				id = 100, type = "text", icon = "ui/icons/icon_contract_swords.png",
-				text = format("Chances %s and %s:", ::MSU.Text.colorPositive("to hit"), ::MSU.Text.colorNegative("to be hit"))
-			})
-			attacks.sort(@(_a, _b) -1 * (_a[0] <=> _b[0]));
-			ret.extend(attacks.map(@(_a) _a[1]));
-		}
+			local myAttacks = entity.getSkills().getAllSkillsOfType(::Const.SkillType.Active).filter(@(_, _a) _a.isAttack());
+			local myVision = entity.getCurrentProperties().getVision();
+			local extraData = "entityId: " + entity.getID();
 
-		if (attacksBelowThreshold != "")
-		{
-			ret.push({
-				id = 100, type = "text", icon = "ui/icons/icon_contract_swords.png",
-				text = "Opponents with hitchance below " + ::MSU.Text.colorNegative(collapseThreshold + "%")
-				children = [{ id = 100, type = "text", text = ::Reforged.Mod.Tooltips.parseString(attacksBelowThreshold) }]
-			});
+			local attacks = [];
+			local collapseThreshold = ::Reforged.Mod.ModSettings.getSetting("TacticalTooltip_CollapseHitchanceThreshold").getValue();
+			local attacksBelowThreshold = "";
+
+			foreach (enemy in ::Tactical.Entities.getAllInstancesAsArray().filter(@(_, _a) !_a.isAlliedWith(entity) && !_a.isHiddenToPlayer()))
+			{
+				local text = "";
+				local score = 0;
+				if (showPlayer)
+				{
+					foreach (a in myAttacks)
+					{
+						if (a.isUsable() && a.isInRange(enemy.getTile()) && (!a.isVisibleTileNeeded() || destTile.hasLineOfSightTo(enemy.getTile(), myVision)))
+						{
+							local hitChance = a.getHitchance(entity);
+							score = 999 + hitChance;
+							text = format("%s with %s", ::MSU.Text.colorPositive(a.getHitchance(enemy) + "%"), ::Reforged.NestedTooltips.getNestedSkillName(a, extraData));
+							break;
+						}
+					}
+				}
+
+				if (showEnemy)
+				{
+					foreach (enemyAttack in enemy.getSkills().getAllSkillsOfType(::Const.SkillType.Active).filter(@(_, _a) _a.isAttack()))
+					{
+						if (enemyAttack.isUsable() && enemyAttack.isInRange(destTile) && (!enemyAttack.isVisibleTileNeeded() || enemy.getTile().hasLineOfSightTo(destTile, enemy.getCurrentProperties().getVision())))
+						{
+							// We update the skills of the enemy so that it sets the correct properties
+							// with the previewing entity being considered at the destTile. During cleanup
+							// we will have to do another update on these enemies to set them back to the
+							// correct properties.
+							if (_tag.ActorsToUpdate.find(enemy) == null)
+							{
+								enemy.getSkills().update();
+								_tag.ActorsToUpdate.push(enemy);
+							}
+
+							local hitChance = enemyAttack.getHitchance(entity);
+							if (score == 0 && hitChance <= collapseThreshold)
+							{
+								attacksBelowThreshold += ::Reforged.NestedTooltips.getNestedEntityImage(enemy);
+							}
+							else
+							{
+								score += hitChance;
+								text += text == "" ? "" : ", ";
+								text += format("%s with %s", ::MSU.Text.colorNegative(hitChance + "%"), ::Reforged.NestedTooltips.getNestedSkillName(enemyAttack, "entityId: " + enemy.getID()));
+							}
+							break;
+						}
+					}
+				}
+
+				if (text == "")
+					continue;
+
+				attacks.push([score, {
+					id = 100, type = "text", icon = ::Reforged.Mod.Tooltips.parseString(::Reforged.NestedTooltips.getNestedEntityImage(enemy)),
+					text = ::Reforged.Mod.Tooltips.parseString(text)
+				}]);
+			}
+
+			if (attacks.len() != 0)
+			{
+				ret.push({
+					id = 100, type = "text", icon = "ui/icons/icon_contract_swords.png",
+					text = format("Chances %s and %s:", ::MSU.Text.colorPositive("to hit"), ::MSU.Text.colorNegative("to be hit"))
+				})
+				attacks.sort(@(_a, _b) -1 * (_a[0] <=> _b[0]));
+				ret.extend(attacks.map(@(_a) _a[1]));
+			}
+
+			if (attacksBelowThreshold != "")
+			{
+				ret.push({
+					id = 100, type = "text", icon = "ui/icons/icon_contract_swords.png",
+					text = "Opponents with hitchance below " + ::MSU.Text.colorNegative(collapseThreshold + "%")
+					children = [{ id = 100, type = "text", text = ::Reforged.Mod.Tooltips.parseString(attacksBelowThreshold) }]
+				});
+			}
 		}
 
 		_cleanupFunc(_tag);

--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -3,9 +3,9 @@
 	q.tactical_queryTileTooltipData = @(__original) { function tactical_queryTileTooltipData()
 	{
 		local ret = __original();
-		if (ret != null)
+		if (ret != null && ::Tactical.State.getLastTileHovered().IsEmpty && ::Tactical.State.getCurrentActionState() == ::Const.Tactical.ActionState.ComputePath)
 		{
-			ret.extend(this.RF_getZOCAttackTooltip(::Tactical.TurnSequenceBar.getActiveEntity()));
+			ret.extend(this.RF_getHitchancesForMovementPreview(::Tactical.TurnSequenceBar.getActiveEntity()));
 		}
 		return ret;
 	}}.tactical_queryTileTooltipData;
@@ -87,15 +87,15 @@
 
 // New Functions
 	// Adds entries to the tile tooltip about zone of control attacks at the starting and ending tiles of the previewed movement
-	q.RF_getZOCAttackTooltip <- { function RF_getZOCAttackTooltip( _entity )
+	q.RF_getHitchancesForMovementPreview <- { function RF_getHitchancesForMovementPreview( _entity )
 	{
-		if (_entity == null || !_entity.isPlacedOnMap() || ::Tactical.State.getCurrentActionState() != ::Const.Tactical.ActionState.ComputePath || _entity.getCurrentProperties().IsImmuneToZoneOfControl)
+		if (_entity == null || !_entity.isPlacedOnMap())
 			return [];
 
 		local ret = [];
 
 		// Add tooltip about zone of control attacks at the starting tile
-		if (_entity.getTile().Properties.Effect == null || _entity.getTile().Properties.Effect.Type != "smoke")
+		if (!_entity.getCurrentProperties().IsImmuneToZoneOfControl && (_entity.getTile().Properties.Effect == null || _entity.getTile().Properties.Effect.Type != "smoke"))
 		{
 			local attacks = ::Tactical.Entities.getAdjacentActors(_entity.getTile()).filter(@(_, _a) !_a.isAlliedWith(_entity) && _a.onMovementInZoneOfControl(_entity, false))
 							.map(function(_a) {
@@ -129,35 +129,153 @@
 			}
 		}
 
-		// Add tooltip about zone of control attacks at the ending tile (e.g. spearwall attacks from opponents)
 		// _entity.getPreviewMovement is null when movement cannot be afforded at all
-		if (_entity.getPreviewMovement() != null && (_entity.getPreviewMovement().End.Properties.Effect == null || _entity.getPreviewMovement().End.Properties.Effect.Type != "smoke"))
+		if (_entity.getPreviewMovement() != null)
 		{
-			// Switcheroo the entity's getTile function to return the end tile of movement
-			// so that hitchances of enemies are calculated with that, in any case any skill
-			// on the enemies wants to check distance to the target in its onAnySkillUsed function.
-			local original_getTile = _entity.getTile;
-			_entity.getTile = @() _entity.getPreviewMovement().End;
+			ret.extend(_entity.getSkills().MV_runBetweenPreviewUpdates(this.RF_getHitchancesAtDestination, this, this.RF_applyMovementPreview(_entity), this.RF_cleanupMovementPreview));
+		}
 
-			local spearwallAttacks;
-			// try/catch block so that the switcheroo on getTile above is safely
-			// reverted even if some error happened in between.
-			try
+		return ret;
+	}}.RF_getHitchancesForMovementPreview;
+
+	// Change and switcheroo various things so that the hit-chance calculations
+	// are done as if the previewing entity is already on the previewed tile.
+	q.RF_applyMovementPreview <- { function RF_applyMovementPreview( _entity )
+	{
+		local currTile = _entity.getTile();
+		local destTile = ::Tactical.State.getLastTileHovered();
+
+		// Switcheroo the entity's getTile function to return the currently hovered tile
+		// so that hitchances of enemies are calculated with that. E.g. in case any skill
+		// on the enemies wants to check distance to the target in its onAnySkillUsed function.
+		// Similarly, height advantage etc. is properly accounted for.
+		local original_getTile = _entity.getTile;
+		_entity.getTile = @() destTile;
+
+		// Goal:
+		// - Consider the destination tile as occupied by the previewing entity.
+		// - Consider destination tile and its neighbors part of ZoC of the previewing entity.
+		// This is achieved by hooking the relevant functions of TacticalTile class and checking
+		// for these specific data in the tile's Properties.
+		// This is important so that any skill.isUsable checks or hit-chances or skill effects
+		// behave more accurately when predicting during the preview.
+		destTile.Properties.set("RF_PreviewEntity", _entity);
+		if (_entity.hasZoneOfControl())
+		{
+			local f = _entity.getFaction();
+			destTile.Properties.set("RF_PreviewZOCFaction", f);
+			foreach (t in ::MSU.Tile.getNeighbors(destTile))
 			{
-				spearwallAttacks = ::Tactical.Entities.getAdjacentActors(_entity.getPreviewMovement().End).filter(@(_, _a) !_a.isAlliedWith(_entity) && _a.onMovementInZoneOfControl(_entity, true))
+				t.Properties.set("RF_PreviewZOCFaction", f);
+			}
+		}
+
+		// Remove the current terrain effect from the previewing entity and add the
+		// terrain effect of the destination tile. This ensures that hit-chances are
+		// properly calculated based on the effects of the terrain.
+		// We make this addition directly into the `m.Skills` of the skills container
+		// instead of doing `container.add` because we don't want to *actually* add or remove
+		// the terrain effects and don't want to trigger their `onAdded` or `onRemoved`.
+		local currTerrainEffect, currTerrainEffectIdx;
+		if (::Const.Tactical.TerrainEffect[currTile.Type].len() > 0)
+		{
+			local id = ::Const.Tactical.TerrainEffectID[currTile.Type];
+			foreach (i, s in _entity.getSkills().m.Skills)
+			{
+				if (s.getID() == id)
+				{
+					currTerrainEffectIdx = i;
+					currTerrainEffect = _entity.getSkills().m.Skills.remove(i);
+					break;
+				}
+			}
+		}
+
+		local destTerrainEffect;
+		if (::Const.Tactical.TerrainEffect[destTile.Type].len() > 0 && !_entity.getSkills().hasSkill(::Const.Tactical.TerrainEffectID[destTile.Type]))
+		{
+			destTerrainEffect = ::new(::Const.Tactical.TerrainEffect[destTile.Type]);
+			destTerrainEffect.saveBaseValues();
+			_entity.getSkills().m.Skills.push(destTerrainEffect);
+		}
+
+		return {
+			Entity = _entity,
+			original_getTile = original_getTile,
+			DestTile = destTile,
+			DestTerrainEffect = destTerrainEffect,
+			CurrTerrainEffect = currTerrainEffect,
+			CurrTerrainEffectIdx = currTerrainEffectIdx,
+			// Will contain a list of actors whose skill_container.update() was called
+			// during fetching the hit-chances during preview with the changes above.
+			// We will need to update them again during cleanup.
+			ActorsToUpdate = []
+		};
+	}}.RF_applyMovementPreview;
+
+	// Between the two preview updates we must clean up all the switcheroos and other
+	// data injections we made for the previewing entity. This function reverses all the
+	// changes made in the RF_applyMovementPreview function.
+	q.RF_cleanupMovementPreview <- { function RF_cleanupMovementPreview( _tag )
+	{
+		local entity = _tag.Entity;
+		entity.getTile = _tag.original_getTile;
+
+		local destTile = _tag.DestTile;
+		destTile.Properties.remove("RF_PreviewEntity");
+		destTile.Properties.remove("RF_PreviewZOCFaction");
+		foreach (t in ::MSU.Tile.getNeighbors(destTile))
+		{
+			t.Properties.remove("RF_PreviewZOCFaction");
+		}
+
+		local destTerrainEffect = _tag.DestTerrainEffect;
+		if (destTerrainEffect != null)
+		{
+			local skills = entity.getSkills().m.Skills;
+			for (local i = skills.len() - 1; i >= 0; i--)
+			{
+				if (skills[i] == destTerrainEffect)
+				{
+					skills.remove(i);
+					break;
+				}
+			}
+		}
+
+		if (_tag.CurrTerrainEffect != null)
+		{
+			entity.getSkills().m.Skills.insert(_tag.CurrTerrainEffectIdx, _tag.CurrTerrainEffect);
+		}
+
+		foreach (a in _tag.ActorsToUpdate)
+		{
+			a.getSkills().update();
+		}
+	}}.RF_cleanupMovementPreview;
+
+	// Returns tooltip entries for predicted chances to hit and
+	// to be hit at the previewed destination tile.
+	q.RF_getHitchancesAtDestination <- { function RF_getHitchancesAtDestination( _tag, _cleanupFunc )
+	{
+		local ret = [];
+
+		local entity = _tag.Entity;
+		local destTile = _tag.DestTile;
+
+		// Add tooltip about zone of control attacks at the ending tile (e.g. spearwall attacks from opponents)
+		if (!entity.getCurrentProperties().IsImmuneToZoneOfControl && (destTile.Properties.Effect == null || destTile.Properties.Effect.Type != "smoke"))
+		{
+			local spearwallAttacks = ::Tactical.Entities.getAdjacentActors(entity.getPreviewMovement().End)
+									.filter(@(_, _a) !_a.isAlliedWith(entity) && _a.onMovementInZoneOfControl(entity, true))
 									.map(function(_a) {
 										local aoo = _a.getSkills().getAttackOfOpportunity();
 										return {
 											id = 100,	type = "text",	icon = ::Reforged.Mod.Tooltips.parseString(::Reforged.NestedTooltips.getNestedEntityImage(_a)),
-											text = ::MSU.Text.colorNegative(aoo.getHitchance(_entity) + "%") + " chance to hit with " + ::Reforged.Mod.Tooltips.parseString(::Reforged.NestedTooltips.getNestedSkillName(aoo, "entityId:" + _a.getID()))
+											text = ::MSU.Text.colorNegative(aoo.getHitchance(entity) + "%") + " chance to hit with " + ::Reforged.Mod.Tooltips.parseString(::Reforged.NestedTooltips.getNestedSkillName(aoo, "entityId:" + _a.getID()))
 										}
 									});
-			}
-			catch (error)
-			{
-			}
 
-			_entity.getTile = original_getTile;
 
 			if (spearwallAttacks.len() != 0)
 			{
@@ -165,14 +283,94 @@
 					id = 101,
 					type = "text",
 					icon = "ui/icons/warning.png",
-					text = ::MSU.Text.colorNegative("Will be attacked on arrival by: "),
+					text = ::MSU.Text.colorNegative("Will be attacked on arrival by:"),
 					children = spearwallAttacks
 				});
 			}
 		}
 
+		// Below we add tooltip about chances to hit valid targets and to be hit from opponents assuming we are at the destination tile.
+
+		local myAttacks = entity.getSkills().getAllSkillsOfType(::Const.SkillType.Active).filter(@(_, _a) _a.isAttack());
+		local myVision = entity.getCurrentProperties().getVision();
+		local extraData = "entityId: " + entity.getID();
+
+		local attacks = [];
+		local collapseThreshold = ::Reforged.Mod.ModSettings.getSetting("TacticalTooltip_ThreatHitchanceThreshold").getValue();
+		local attacksBelowThreshold = "";
+
+		foreach (enemy in ::Tactical.Entities.getAllInstancesAsArray().filter(@(_, _a) !_a.isAlliedWith(entity) && !_a.isHiddenToPlayer()))
+		{
+			local text = "";
+			local score = 0;
+			foreach (a in myAttacks)
+			{
+				if (a.isUsable() && a.isInRange(enemy.getTile()) && (!a.isVisibleTileNeeded() || destTile.hasLineOfSightTo(enemy.getTile(), myVision)))
+				{
+					local hitChance = a.getHitchance(entity);
+					score = 999 + hitChance;
+					text = format("%s with %s", ::MSU.Text.colorPositive(a.getHitchance(enemy) + "%"), ::Reforged.NestedTooltips.getNestedSkillName(a, extraData));
+					break;
+				}
+			}
+
+			foreach (enemyAttack in enemy.getSkills().getAllSkillsOfType(::Const.SkillType.Active).filter(@(_, _a) _a.isAttack()))
+			{
+				if (enemyAttack.isUsable() && enemyAttack.isInRange(destTile) && (!enemyAttack.isVisibleTileNeeded() || enemy.getTile().hasLineOfSightTo(destTile, enemy.getCurrentProperties().getVision())))
+				{
+					// We update the skills of the enemy so that it sets the correct properties
+					// with the previewing entity being considered at the destTile. During cleanup
+					// we will have to do another update on these enemies to set them back to the
+					// correct properties.
+					enemy.getSkills().update();
+					_tag.ActorsToUpdate.push(enemy);
+
+					local hitChance = enemyAttack.getHitchance(entity);
+					if (text == "" && hitChance <= collapseThreshold)
+					{
+						attacksBelowThreshold += ::Reforged.NestedTooltips.getNestedEntityImage(enemy);
+					}
+					else
+					{
+						score += hitChance;
+						text += text == "" ? "" : ", ";
+						text += format("%s with %s", ::MSU.Text.colorNegative(hitChance + "%"), ::Reforged.NestedTooltips.getNestedSkillName(enemyAttack, "entityId: " + enemy.getID()));
+					}
+					break;
+				}
+			}
+
+			if (text == "")
+				continue;
+
+			attacks.push([score, {
+				id = 100, type = "text", icon = ::Reforged.Mod.Tooltips.parseString(::Reforged.NestedTooltips.getNestedEntityImage(enemy)),
+				text = ::Reforged.Mod.Tooltips.parseString(text)
+			}]);
+		}
+
+		if (attacks.len() != 0)
+		{
+			ret.push({
+				id = 100, type = "text", icon = "ui/icons/icon_contract_swords.png",
+				text = format("Chances %s and %s:", ::MSU.Text.colorPositive("to hit"), ::MSU.Text.colorNegative("to be hit"))
+			})
+			attacks.sort(@(_a, _b) -1 * (_a[0] <=> _b[0]));
+			ret.extend(attacks.map(@(_a) _a[1]));
+		}
+
+		if (attacksBelowThreshold != "")
+		{
+			ret.push({
+				id = 100, type = "text", icon = "ui/icons/icon_contract_swords.png",
+				text = "Opponents with hitchance below " + ::MSU.Text.colorNegative(collapseThreshold + "%")
+				children = [{ id = 100, type = "text", text = ::Reforged.Mod.Tooltips.parseString(attacksBelowThreshold) }]
+			});
+		}
+
+		_cleanupFunc(_tag);
 		return ret;
-	}}.RF_getZOCAttackTooltip;
+	}}.RF_getHitchancesAtDestination;
 
 	q.getBaseAttributesTooltip <- { function getBaseAttributesTooltip( _entityId, _elementId, _elementOwner )
 	{

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -26,7 +26,11 @@
 	tacticalTooltipPage.addBooleanSetting("ShowStatusPerkAndEffect", true, "Show Status Perk And Effect", "Some Perks are also Status Effects. Usually their Effect is hidden until some condition is fulfilled. When this setting is enabled, these perks show up in the Perks category even when they show up under Effects (e.g. when their effect is active). When disabled, when they appear under Effects, they will be hidden from the Perks category. This can help save space on the tooltip.");
 	tacticalTooltipPage.addBooleanSetting("HeaderForEmptyCategories", false, "Show Header for empty categories");
 
-	tacticalTooltipPage.addRangeSetting("TacticalTooltip_ThreatHitchanceThreshold", 5, 0, 100, 1, "Threat Hitchance Threshold", "During movement preview, opponents with predicted hitchance equal to this or less are collapsed into a single tooltip entry.");
+	tacticalTooltipPage.addDivider("TacticalTooltip_Divider1");
+	tacticalTooltipPage.addTitle("TacticalTooltip_Title_MovementPreview", "Movement Preview");
+
+	tacticalTooltipPage.addEnumSetting("TacticalTooltip_MovementPreviewHitchances", "All", ["All", "AI Only", "Player Only", "None"], "Show Predicted Hitchances", "During movement preview, show predicted chance to hit and to be hit based on the hovered tile.");
+	tacticalTooltipPage.addRangeSetting("TacticalTooltip_CollapseHitchanceThreshold", 5, 0, 100, 1, "Collapse Hitchance Threshold", "During movement preview, opponents with predicted hitchance equal to this or less are collapsed into a single tooltip entry.");
 }
 
 {	// Misc

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -25,6 +25,8 @@
 	tacticalTooltipPage.addBooleanSetting("TacticalTooltip_CollapseAsText", false, "Collapse as Text", "If enabled, then skills collapse using their names as text, otherwise they collapse using their icons.");
 	tacticalTooltipPage.addBooleanSetting("ShowStatusPerkAndEffect", true, "Show Status Perk And Effect", "Some Perks are also Status Effects. Usually their Effect is hidden until some condition is fulfilled. When this setting is enabled, these perks show up in the Perks category even when they show up under Effects (e.g. when their effect is active). When disabled, when they appear under Effects, they will be hidden from the Perks category. This can help save space on the tooltip.");
 	tacticalTooltipPage.addBooleanSetting("HeaderForEmptyCategories", false, "Show Header for empty categories");
+
+	tacticalTooltipPage.addRangeSetting("TacticalTooltip_ThreatHitchanceThreshold", 5, 0, 100, 1, "Threat Hitchance Threshold", "During movement preview, opponents with predicted hitchance equal to this or less are collapsed into a single tooltip entry.");
 }
 
 {	// Misc

--- a/scripts/skills/perks/perk_rf_steady_brace.nut
+++ b/scripts/skills/perks/perk_rf_steady_brace.nut
@@ -54,6 +54,11 @@ this.perk_rf_steady_brace <- ::inherit("scripts/skills/skill", {
 
 	function onAnySkillUsed( _skill, _targetEntity, _properties )
 	{
+		// Don't apply the bonuses during previewed movement so we don't include the
+		// bonuses in the hit-chance preview during movement preview.
+		if (this.getContainer().getActor().getPreviewMovement() != null)
+			return;
+
 		if (!this.m.IsInEffect || !this.isSkillValid(_skill))
 			return;
 

--- a/scripts/skills/special/rf_formidable_approach_manager.nut
+++ b/scripts/skills/special/rf_formidable_approach_manager.nut
@@ -29,7 +29,9 @@ this.rf_formidable_approach_manager <- ::inherit("scripts/skills/skill", {
 		if (actor.isPreviewing() && actor.getPreviewMovement() != null)
 		{
 			local destTile = ::Tactical.State.getLastTileHovered();
-			if (destTile.IsEmpty)
+			// destTile can be null when swapping items using extra keyinds mod while previewing a movement.
+			// Maybe this needs to be fixed over at that mod.
+			if (destTile != null && destTile.IsEmpty)
 			{
 				// Iterate over the enemies next to the previewed destination tile
 				foreach (enemy in ::Tactical.Entities.getAdjacentActors(destTile).filter(@(_, _a) !_a.isAlliedWith(actor)))

--- a/scripts/skills/special/rf_formidable_approach_manager.nut
+++ b/scripts/skills/special/rf_formidable_approach_manager.nut
@@ -1,6 +1,10 @@
 this.rf_formidable_approach_manager <- ::inherit("scripts/skills/skill", {
 	m = {
-		Enemies = []
+		Enemies = [],
+		// Temporarily store enemy IDs here for which we "enable" formidable approach
+		// with enemies around destination tile while previewing a movement. We store
+		// the IDs so we can clean up when ending preview.
+		__EnemiesDuringPreview = []
 	},
 	function create()
 	{
@@ -10,6 +14,63 @@ this.rf_formidable_approach_manager <- ::inherit("scripts/skills/skill", {
 		this.m.Type = ::Const.SkillType.Special;
 		this.m.IsHidden = true;
 		this.m.IsSerialized = false;
+	}
+
+	// Enable formidable approach with enemies around destination tile while previewing a movement.
+	// This works under the assumption that a "preview" type update is always followed by one
+	// that isn't a preview one. During the preview update we "register" the enemies around
+	// the destination tile, and then during the next update we clean it up.
+	// This helps to account for formidable approach in the hit-chance preview during movement preview.
+	function onUpdate( _properties )
+	{
+		local actor = this.getContainer().getActor();
+		local myPerk = this.getContainer().getSkillByID("perk.rf_formidable_approach");
+
+		if (actor.isPreviewing() && actor.getPreviewMovement() != null)
+		{
+			local destTile = ::Tactical.State.getLastTileHovered();
+			if (destTile.IsEmpty)
+			{
+				// Iterate over the enemies next to the previewed destination tile
+				foreach (enemy in ::Tactical.Entities.getAdjacentActors(destTile).filter(@(_, _a) !_a.isAlliedWith(actor)))
+				{
+					this.m.__EnemiesDuringPreview.push(enemy.getID());
+
+					if (myPerk != null)
+					{
+						myPerk.m.Enemies.push(enemy.getID());
+					}
+
+					local enemyPerk = enemy.getSkills().getSkillByID("perk.rf_formidable_approach");
+					if (enemyPerk != null)
+					{
+						enemyPerk.m.Enemies.push(actor.getID());
+					}
+				}
+			}
+		}
+		else
+		{
+			foreach (id in this.m.__EnemiesDuringPreview)
+			{
+				if (myPerk != null)
+				{
+					::MSU.Array.removeByValue(myPerk.m.Enemies, id);
+				}
+
+				local entity = ::Tactical.getEntityByID(id);
+				if (entity == null)
+					continue;
+
+				local enemyPerk = entity.getSkills().getSkillByID("perk.rf_formidable_approach");
+				if (enemyPerk != null)
+				{
+					::MSU.Array.removeByValue(enemyPerk.m.Enemies, actor.getID());
+				}
+			}
+
+			this.m.__EnemiesDuringPreview.clear();
+		}
 	}
 
 	function onMovementStarted( _tile, _numTiles )


### PR DESCRIPTION
The main changes are in the first commit. The second commit is simply adapting some existing skills to use this system.

Now whenever a character is previewing movement, hovering over any empty tile will show the predicted chances to hit and to be hit from that tile against relevant enemies (i.e. attackable enemies and enemies that can attack you).

The system uses some switcheroos and hacky methods to achieve as accurate of a prediction as possible including the effects of terrain, zone of control, skills/perks and their effects etc.

Note: Any skill that has triggers for things affecting potential hitchances in `onMovementFinished` etc. will need to properly account for those to make the prediction work reliably. Most skills don't fall into this category, but those that do will need to implement support for this system otherwise they won't be accurately taken into account. See the second commit to see how I adjust some relevant Reforged skills accordingly e.g. Formidable Approach.

In addition to the screenshot below, there is also a [video demonstration](https://discord.com/channels/1006908336991645757/1496970977677152296/1498921679311863839) of the system on the discord.

<img src="https://cdn.discordapp.com/attachments/1496970977677152296/1498197758425956372/image.png?ex=69f394a4&is=69f24324&hm=43db564bfef5b89e8c3c83803a3193fc1b4e8b5aabd02039035c94b3139a23f9&">