### PR TITLE
feat: allow unused throwing weapons to drop from bag

### DIFF
--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -15,7 +15,7 @@
 	q.isDroppedAsLoot = @(__original) { function isDroppable()
 	{
 		local original_CurrentSlotType = this.m.CurrentSlotType;
-		this.m.CurrentSlotType = ::Const.ItemSlot.Mainhand;
+		this.m.CurrentSlotType = this.m.SlotType;
 		local ret = __original();
 		this.m.CurrentSlotType = original_CurrentSlotType;
 		return ret;

--- a/mod_reforged/hooks/items/weapons/weapon.nut
+++ b/mod_reforged/hooks/items/weapons/weapon.nut
@@ -8,6 +8,18 @@
 			this.m.Reach = ::Math.max(0, this.m.Reach);
 		}
 	}}.create;
+
+	// Vanilla does not allow weapons at their AmmoMax to drop from bag slot.
+	// We want such weapons to drop, so we switcheroo their CurrentSlotType
+	// before running the original function.
+	q.isDroppedAsLoot = @(__original) { function isDroppable()
+	{
+		local original_CurrentSlotType = this.m.CurrentSlotType;
+		this.m.CurrentSlotType = ::Const.ItemSlot.Mainhand;
+		local ret = __original();
+		this.m.CurrentSlotType = original_CurrentSlotType;
+		return ret;
+	}}.isDroppable;
 });
 
 ::Reforged.HooksMod.hook("scripts/items/weapons/weapon", function(q) {


### PR DESCRIPTION
Vanilla does not allow throwing weapons to drop from bag slot if they are at full ammo.

See [related discussion](https://discord.com/channels/1006908336991645757/1296562347066003560/1499459302857900102) on the Reforged Discord.