### PR TITLE
feat: add ability to auto-negotiate and skip screens in contracts

### DIFF
--- a/mod_reforged/hooks/contracts/contract.nut
+++ b/mod_reforged/hooks/contracts/contract.nut
@@ -1,5 +1,29 @@
 ::Reforged.HooksMod.hook("scripts/contracts/contract", function(q)
 {
+	// Will auto-negotiate this contract for _numAttempts times.
+	// Will stop if the employer gives his final offer or if negotiations fail.
+	q.RF_autoNegotiate <- { function RF_autoNegotiate( _numAttempts = 1 )
+	{
+		if (!this.isStarted())
+			this.start();
+
+		if (this.m.ActiveScreen.ID == "Negotiation.Fail" || this.m.Payment.IsFinal)
+			return;
+
+		if (this.m.ActiveScreen.ID != "Negotiation")
+			this.setScreen("Negotiation");
+
+		for (local i = 0; i < _numAttempts; i++)
+		{
+			this.setScreen(this.getScreen(this.m.ActiveScreen.Options[1].getResult()));
+			if (this.m.ActiveScreen.ID == "Negotiation.Fail")
+				return;
+
+			if (this.m.Payment.IsFinal)
+				break;
+		}
+	}}.RF_autoNegotiate;
+
 	// Is used to "start" a contract so that its home, origin, destination, payment etc.
 	// is fully set and generated.
 	q.RF_fakeStart <- { function RF_fakeStart()

--- a/mod_reforged/hooks/contracts/contract.nut
+++ b/mod_reforged/hooks/contracts/contract.nut
@@ -19,6 +19,8 @@
 			if (this.m.ActiveScreen.ID == "Negotiation.Fail")
 				return;
 
+			// This does not *really* mean Final Offer. All it really means is that
+			// the last negotiation attempt was "rejected" by the employer.
 			if (this.m.Payment.IsFinal)
 				break;
 		}

--- a/mod_reforged/hooks/ui/screens/world/world_town_screen.nut
+++ b/mod_reforged/hooks/ui/screens/world/world_town_screen.nut
@@ -14,4 +14,59 @@
 			}
 		}
 	}
+
+	// We add handling for auto-negotiation of contracts and for skipping
+	// contracts to a certain screen.
+	q.onContractClicked = @(__original) { function onContractClicked( _data )
+	{
+		// Same guard as vanilla
+		if (this.isAnimating())
+		{
+			__original();
+			return;
+		}
+
+		local n = ::Reforged.Mod.ModSettings.getSetting("AutoNegotiateAttempts").getValue();
+		local skipTo = ::Reforged.Mod.ModSettings.getSetting("SkipContractsToScreen").getValue();
+		if (n != 0 || skipTo != "Disabled")
+		{
+			foreach (c in ::World.Contracts.getOpenContracts())
+			{
+				if (c.getID() != _data)
+					continue;
+
+				// If a contract is already at Overview, it has been
+				// fully negotiated, so we mustn't do anything.
+				if (c.m.ActiveScreen.ID == "Overview")
+					break;
+
+				if (skipTo == "Negotiation")
+				{
+					c.setScreen("Negotiation");
+				}
+
+				if (n != 0)
+				{
+					c.RF_autoNegotiate(n);
+				}
+
+				if (skipTo == "Overview")
+				{
+					if (c.m.ActiveScreen.ID == "Negotiation")
+					{
+						c.setScreen(c.m.ActiveScreen.Options[0].getResult());
+					}
+					else if (c.m.ActiveScreen.ID != "Negotiation.Fail")
+					{
+						c.setScreen("Negotiation");
+						c.setScreen(c.m.ActiveScreen.Options[0].getResult());
+					}
+				}
+
+				break;
+			}
+		}
+
+		__original(_data);
+	}}.onContractClicked;
 });

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -9,7 +9,7 @@
 	generalPage.addDivider("MiscDivider1");
 	generalPage.addTitle("General_Title_Contracts", "Contracts");
 	generalPage.addEnumSetting("SkipContractsToScreen", "Overview", ["Disabled", "Negotiation", "Overview"], "Skip Contracts To", "Allows you to save some time by skipping to a certain screen when opening a contract in settlements.\n\nDisabled: Same behavior as vanilla, you have to click through all of the contract\'s screens.\n\nNegotiation: Skip the introduction screens and go straight to the negotiation.\n\nOverview: Skip to the final screen in the contract where you can accept or reject it. With this option, you will no longer be able to manually negotiate contracts.");
-	generalPage.addRangeSetting("AutoNegotiateAttempts", 1, 0, 10, 1, "Auto-Negotiate Attempts", "When clicking on contracts in settlements, auto-negotiate them this many times for more payment. This process will stop as soon as the employer gives his final offer or negotiations turn sour.");
+	generalPage.addRangeSetting("AutoNegotiateAttempts", 1, 0, 10, 1, "Auto-Negotiate Attempts", "When clicking on contracts in settlements, auto-negotiate them this many times for more payment. This process will stop as soon as the employer rejects a negotiation attempt (i.e. did not increase his offer), or the negotiations fail.");
 }
 { // Tooltips page
 	local tooltipsPage = ::Reforged.Mod.ModSettings.addPage("Tooltips", "Tooltips");

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -5,6 +5,11 @@
 
 	generalPage.addEnumSetting("CraftingBlueprintVisibility", "One Ingredient Available", ["Always", "One Ingredient Available", "All Ingredients Available", "Vanilla"], "Blueprints Visible When", "Crafting Recipes in the Taxidermist will be displayed when this condition is met.\nNote that individual Blueprints (like Snake Oil) may still have custom rules preventing them from being shown.\n\n\'Vanilla\' means that the visibility behavior is unchanged from how it works in the base game.");
 	generalPage.addBooleanSetting("ConfirmSkillUse", false, "Confirm Skill Use", "If enabled, skills that are normally used immediately (e.g. Shieldwall, Rally) will instead require you to target your character. This allows you to preview Action Point and Fatigue costs and the predicted affordability of other skills. Hold the \'Confirm Skill Use\' key (default Ctrl) to bypass this and use the skill immediately.\n\nIf disabled, these skills are used immediately as in vanilla, but the keybind can be used to preview them and require confirmation.");
+
+	generalPage.addDivider("MiscDivider1");
+	generalPage.addTitle("General_Title_Contracts", "Contracts");
+	generalPage.addEnumSetting("SkipContractsToScreen", "Overview", ["Disabled", "Negotiation", "Overview"], "Skip Contracts To", "Allows you to save some time by skipping to a certain screen when opening a contract in settlements.\n\nDisabled: Same behavior as vanilla, you have to click through all of the contract\'s screens.\n\nNegotiation: Skip the introduction screens and go straight to the negotiation.\n\nOverview: Skip to the final screen in the contract where you can accept or reject it. With this option, you will no longer be able to manually negotiate contracts.");
+	generalPage.addRangeSetting("AutoNegotiateAttempts", 1, 0, 10, 1, "Auto-Negotiate Attempts", "When clicking on contracts in settlements, auto-negotiate them this many times for more payment. This process will stop as soon as the employer gives his final offer or negotiations turn sour.");
 }
 { // Tooltips page
 	local tooltipsPage = ::Reforged.Mod.ModSettings.addPage("Tooltips", "Tooltips");

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -8,8 +8,8 @@
 
 	generalPage.addDivider("MiscDivider1");
 	generalPage.addTitle("General_Title_Contracts", "Contracts");
-	generalPage.addEnumSetting("SkipContractsToScreen", "Overview", ["Disabled", "Negotiation", "Overview"], "Skip Contracts To", "Allows you to save some time by skipping to a certain screen when opening a contract in settlements.\n\nDisabled: Same behavior as vanilla, you have to click through all of the contract\'s screens.\n\nNegotiation: Skip the introduction screens and go straight to the negotiation.\n\nOverview: Skip to the final screen in the contract where you can accept or reject it. With this option, you will no longer be able to manually negotiate contracts.");
-	generalPage.addRangeSetting("AutoNegotiateAttempts", 1, 0, 10, 1, "Auto-Negotiate Attempts", "When clicking on contracts in settlements, auto-negotiate them this many times for more payment. This process will stop as soon as the employer rejects a negotiation attempt (i.e. did not increase his offer), or the negotiations fail.");
+	generalPage.addEnumSetting("SkipContractsToScreen", "Disabled", ["Disabled", "Negotiation", "Overview"], "Skip Contracts To", "Allows you to save some time by skipping to a certain screen when opening a contract in settlements.\n\nDisabled: Same behavior as vanilla, you have to click through all of the contract\'s screens.\n\nNegotiation: Skip the introduction screens and go straight to the negotiation.\n\nOverview: Skip to the final screen in the contract where you can accept or reject it. With this option, you will no longer be able to manually negotiate contracts.");
+	generalPage.addRangeSetting("AutoNegotiateAttempts", 0, 0, 10, 1, "Auto-Negotiate Attempts", "When clicking on contracts in settlements, auto-negotiate them this many times for more payment. This process will stop as soon as the employer rejects a negotiation attempt (i.e. did not increase his offer), or the negotiations fail.");
 }
 { // Tooltips page
 	local tooltipsPage = ::Reforged.Mod.ModSettings.addPage("Tooltips", "Tooltips");


### PR DESCRIPTION
This is a quality of life feature as [discussed](https://discord.com/channels/1006908336991645757/1296562347066003560/1500868199804305599) with the players on the Reforged Discord.

- Add a mod setting to auto-skip screens in contracts to either Negotiation or Overview (final screen).
- Add a mod setting to auto-negotiate contracts a given number of times until the employer gives his final offer or the negotiations fail.

Default values for both are "Overview" and "1".

EDIT: Default values changed to "Disabled" and "0" after some discussion.

<img width="225" height="365" alt="image" src="https://github.com/user-attachments/assets/1e62f606-e725-4694-8e22-69ce91f557c3" />
<img width="290" height="215" alt="image" src="https://github.com/user-attachments/assets/b9832f84-565b-4c84-8188-f99169c72bf4" />
