### PR TITLE
Feat ai pause in combat

### DIFF
--- a/mod_reforged/hooks/states/tactical_state.nut
+++ b/mod_reforged/hooks/states/tactical_state.nut
@@ -56,6 +56,33 @@
 		__original();
 	}}.onBattleEnded;
 
+	q.setPause = @(__original) { function setPause( _pause )
+	{
+		__original(_pause);
+
+		// Vanilla calls setPause during onInit, before the TacticalScreen is initialized
+		if (this.m.TacticalScreen != null)
+		{
+			// Feat: Display overlay with "Paused" and the keybind for unpausing, while the game is paused
+			if (_pause)
+			{
+				local data = {
+					Header = "Paused",
+					Subheader = null,
+				};
+				if (::Reforged.Mod.Keybinds.getKeybind("Tactical_PauseAI").getKeyCombinationsCapitalized() != "")
+				{
+					data.Subheader = "(Press " + ::Reforged.Mod.Keybinds.getKeybind("Tactical_PauseAI").getKeyCombinationsCapitalized() + " to unpause)";
+				}
+				this.m.TacticalScreen.m.JSHandle.asyncCall("RF_showMessage", data);
+			}
+			else
+			{
+				this.m.TacticalScreen.m.JSHandle.asyncCall("RF_hideMessage", null);
+			}
+		}
+	}}.setPause;
+	
 	q.showRetreatScreen = @(__original) function ( _tag = null )
 	{
 		this.m.TacticalScreen.getTopbarOptionsModule().changeFleeButtonToWin();

--- a/mod_reforged/msu_systems/mod_settings.nut
+++ b/mod_reforged/msu_systems/mod_settings.nut
@@ -65,6 +65,25 @@
 		}
 	}, "Wait Turn with all Characters");
 
+	::Reforged.Mod.Keybinds.addSQKeybind("Tactical_PauseAI", "ctrl+space", ::MSU.Key.State.Tactical, function()
+	{
+		if (!::Tactical.isActive() || this.m.MenuStack.hasBacksteps() || this.isInCharacterScreen())
+		{
+			return false;
+		}
+		else
+		{
+			local activeEntity = ::Tactical.TurnSequenceBar.getActiveEntity();
+			// We only allow pausing, while it is not the players turn, in order to prevent buffering inputs which can cause buggy behavior
+			if (::Tactical.State.isPaused() || activeEntity == null || !activeEntity.isPlayerControlled())
+			{
+				::Tactical.State.setPause(!::Tactical.State.isPaused());
+			}
+
+			return true;
+		}
+	}, "Pause Tactical Combat");
+
 	::Reforged.Mod.Keybinds.addSQKeybind("ConfirmSkillUseKeybind", "ctrl", ::MSU.Key.State.Tactical, @() true, "Confirm Skill Use", null, "Used to toggle the confirmation requirement for skills that are normally used immediately (e.g. Shieldwall, Rally). It allows you to either preview the Action Point and Fatigue costs or bypass confirmation, depending on your \'Confirm Skill Use\' setting.");
 
 	::Reforged.Mod.Keybinds.addSQKeybind("ToggleReforgedDevMode", "ctrl+tab", ::MSU.Key.State.All, function() { ::Reforged.__toggleDevMode(); return true; }, "Toggle Reforged Dev Mode", null, "Used to toggle Dev mode for Reforged. This enables/disables the various Dev mode settings all at once.");

--- a/ui/mods/mod_reforged/css_hooks/screens/tactical/tactical_screen.css
+++ b/ui/mods/mod_reforged/css_hooks/screens/tactical/tactical_screen.css
@@ -1,0 +1,36 @@
+.tactical-screen .rf-paused-wrapper
+{
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	z-index: 2;
+	text-align: center;
+	pointer-events: none;
+}
+
+.tactical-screen .rf-paused-label
+{
+	display: block;
+	font-size: 4rem;
+}
+
+.tactical-screen .rf-paused-spacebar-label
+{
+	display: block;
+	font-size: 2rem;
+	margin-top: 0.5rem;
+}
+
+.tactical-screen .rf-hidden
+{
+	display: none;
+	pointer-events: none;
+}

--- a/ui/mods/mod_reforged/js_hooks/screens/tactical/tactical_screen.js
+++ b/ui/mods/mod_reforged/js_hooks/screens/tactical/tactical_screen.js
@@ -1,0 +1,39 @@
+Reforged.Hooks.TacticalScreen_createDIV = TacticalScreen.prototype.createDIV;
+TacticalScreen.prototype.createDIV = function (_parentDiv)
+{
+	Reforged.Hooks.TacticalScreen_createDIV.call(this, _parentDiv);
+	// New elements, similar to how WorldScreenTopbarDayTimeModule does it
+
+	this.mRF_PausedWrapper = $('<div class="rf-paused-wrapper rf-hidden"/>');
+	this.mRF_PausedDiv = $('<div class="display-none title-font-very-big rf-paused-label font-color-title font-shadow-silhouette">PAUSED</div>');
+	this.mRF_PausedSpacebarDiv = $('<div class="display-none text-font-small rf-paused-spacebar-label font-color-title font-shadow-silhouette">(Press Spacebar)</div>');
+	this.mRF_PausedWrapper.append(this.mRF_PausedDiv);
+	this.mRF_PausedWrapper.append(this.mRF_PausedSpacebarDiv);
+
+	this.mContainer.append(this.mRF_PausedWrapper);
+}
+
+Reforged.Hooks.TacticalScreen_destroyDIV = TacticalScreen.prototype.destroyDIV;
+TacticalScreen.prototype.destroyDIV = function ()
+{
+	this.mRF_PausedWrapper.remove();
+	this.mRF_PausedWrapper = null;
+	this.mRF_PausedDiv = null;
+	this.mRF_PausedSpacebarDiv = null;
+	Reforged.Hooks.TacticalScreen_destroyDIV.call(this);
+}
+
+{	// New Functions
+	TacticalScreen.prototype.RF_showMessage = function(_data)
+	{
+		this.mRF_PausedDiv.html(_data.Header);
+		this.mRF_PausedSpacebarDiv.html(_data.Subheader);
+
+		this.mRF_PausedWrapper.removeClass('rf-hidden');
+	}
+
+	TacticalScreen.prototype.RF_hideMessage = function()
+	{
+		this.mRF_PausedWrapper.addClass('rf-hidden');
+	}
+}


### PR DESCRIPTION
feat: add keybind for pausing the game during tactical combat *works*
feat: display pause overlay with keybind while combat is paused does **not** work

A small disadvantages of the new pause overlay is that it briefly shows up when you open the main menu during combat.
I dont find that disruptive and consider is a minor annoyance.


## Overlay Text
<img width="929" height="496" alt="image" src="https://github.com/user-attachments/assets/47f17497-9d17-4bbd-b003-bfa07917d51c" />