### PR TITLE
feat: improve vanilla mult logic in properties for negative values

### DIFF
--- a/mod_reforged/hooks/config/character.nut
+++ b/mod_reforged/hooks/config/character.nut
@@ -10,7 +10,17 @@ local original_getClone = ::Const.CharacterProperties.getClone;
 	DefensiveReachIgnore = 0,
 	OffensiveReachIgnore = 0,
 	BonusPerReachAdvantage = 0,
-	RF_BleedingEffectMult = 1.0
+	RF_BleedingEffectMult = 1.0,
+
+	function getClone()
+	{
+		local ret = original_getClone();
+		ret.PositiveMoraleCheckBravery = clone this.PositiveMoraleCheckBravery;
+		ret.PositiveMoraleCheckBraveryMult = clone this.PositiveMoraleCheckBraveryMult;
+		ret.NegativeMoraleCheckBravery = clone this.NegativeMoraleCheckBravery;
+		ret.NegativeMoraleCheckBraveryMult = clone this.NegativeMoraleCheckBraveryMult;
+		return ret;
+	}
 
 	function getReach()
 	{
@@ -22,14 +32,47 @@ local original_getClone = ::Const.CharacterProperties.getClone;
 		return ::Math.floor(this.FatigueRecoveryRate * this.FatigueRecoveryRateMult);
 	}
 
-	function getClone()
+	// In vanilla negative values are always multiplied with (1.0 / mult)
+	// This causes mults between 0.0 and 1.0 i.e. those that would reduce a positive value
+	// to increase the negative value by double the amount. E.g. a 50% reduction on a positive
+	// value becomes a 2x increase on the negative value (in the negative direction).
+	// We implement a more intricate system whereby this behavior is only for mults > 1.0.
+	// For mults between 0.0 and 1.0 we instead multiply by 2.0 - mult. This results in
+	// a 50% reduction on a positive value to be a 50% increase on the negative value
+	// in the negative direction. So it behaves more intuitively.
+	function __getValueWithMult( _value, _mult )
 	{
-		local ret = original_getClone();
-		ret.PositiveMoraleCheckBravery = clone this.PositiveMoraleCheckBravery;
-		ret.PositiveMoraleCheckBraveryMult = clone this.PositiveMoraleCheckBraveryMult;
-		ret.NegativeMoraleCheckBravery = clone this.NegativeMoraleCheckBravery;
-		ret.NegativeMoraleCheckBraveryMult = clone this.NegativeMoraleCheckBraveryMult;
-		return ret;
+		return ::Math.floor(_value * (_value > 0 ? _mult : (_mult > 1.0 ? 1.0 / _mult : 2.0 - _mult)));
+	}
+
+	function getMeleeDefense()
+	{
+		return this.__getValueWithMult(this.MeleeDefense, this.MeleeDefenseMult);
+	}
+
+	function getRangedDefense()
+	{
+		return this.__getValueWithMult(this.RangedDefense, this.RangedDefenseMult);
+	}
+
+	function getMeleeSkill()
+	{
+		return this.__getValueWithMult(this.MeleeSkill, this.MeleeSkillMult);
+	}
+
+	function getRangedSkill()
+	{
+		return this.__getValueWithMult(this.RangedSkill, this.RangedSkillMult);
+	}
+
+	function getBravery()
+	{
+		return this.__getValueWithMult(this.Bravery, this.BraveryMult);
+	}
+
+	function getInitiative()
+	{
+		return this.__getValueWithMult(this.Initiative, this.InitiativeMult);
 	}
 });
 

--- a/mod_reforged/hooks/config/character.nut
+++ b/mod_reforged/hooks/config/character.nut
@@ -40,6 +40,7 @@ local original_getClone = ::Const.CharacterProperties.getClone;
 	// For mults between 0.0 and 1.0 we instead multiply by 2.0 - mult. This results in
 	// a 50% reduction on a positive value to be a 50% increase on the negative value
 	// in the negative direction. So it behaves more intuitively.
+	// Bonus: Also fixes the vanilla edge-case of division by zero when mult is 0.
 	function __getValueWithMult( _value, _mult )
 	{
 		return ::Math.floor(_value * (_value > 0 ? _mult : (_mult > 1.0 ? 1.0 / _mult : 2.0 - _mult)));


### PR DESCRIPTION
In vanilla negative values are always multiplied with (1.0 / mult) This causes mults between 0.0 and 1.0 i.e. those that would reduce a positive value to increase the negative value by double the amount. E.g. a 50% reduction on a positive value becomes a 2x increase on the negative value (in the negative direction). We implement a more intricate system whereby this behavior is only for mults > 1.0. For mults between 0.0 and 1.0 we instead multiply by 2.0 - mult. This results in a 50% reduction on a positive value to be a 50% increase on the negative value in the negative direction. So it behaves more intuitively.