### PR TITLE
feat: insert reforged entities in entitytype table for better display

### DIFF
--- a/mod_reforged/hooks/config/!entities.nut
+++ b/mod_reforged/hooks/config/!entities.nut
@@ -8,16 +8,44 @@ foreach (key, value in ::Const.EntityType)
 ::Reforged.Entities <- {
 	DefaultFaction = {},
 
-	function addEntity( _entityID, _name, _namePlural, _orientationIcon, _defaultFaction, _troopDef, _actorDef )
+	function addEntity( _entityTypeKey, _name, _namePlural, _orientationIcon, _defaultFaction, _troopDef, _actorDef, _atID = null )
 	{
-		::Const.EntityType[_entityID] <- ++highestID;
-		::Const.Strings.EntityName.push(_name);
-		::Const.Strings.EntityNamePlural.push(_namePlural);
-		::Const.EntityIcon.push(_orientationIcon);
-		this.DefaultFaction[highestID] <- _defaultFaction;
-		_troopDef.ID <- highestID;
-		this.addTroop(_entityID, _troopDef);
-		this.addActor(_entityID, _actorDef);
+		local id;
+		if (_atID != null)
+		{
+			id = _atID;
+
+			foreach (k, v in ::Const.EntityType)
+			{
+				if (typeof v == "integer" && v >= _atID)
+				{
+					::Const.EntityType[k] = v + 1;
+				}
+			}
+
+			foreach (v in ::Const.World.Spawn.Troops)
+			{
+				if (v.ID >= _atID)
+				{
+					v.ID += 1;
+				}
+			}
+
+			highestID++;
+		}
+		else
+		{
+			id = ++highestID;
+		}
+
+		::Const.EntityType[_entityTypeKey] <- id;
+		::Const.Strings.EntityName.insert(id, _name);
+		::Const.Strings.EntityNamePlural.insert(id, _namePlural);
+		::Const.EntityIcon.insert(id, _orientationIcon);
+		this.DefaultFaction[id] <- _defaultFaction;
+		_troopDef.ID <- id;
+		this.addTroop(_entityTypeKey, _troopDef);
+		this.addActor(_entityTypeKey, _actorDef);
 	}
 
 	function addTroop( _key, _troopDef )

--- a/mod_reforged/hooks/config/faction_bandits.nut
+++ b/mod_reforged/hooks/config/faction_bandits.nut
@@ -51,7 +51,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.BanditRaider
 );
 ::Reforged.Entities.editEntity("BanditRaider",
 	{
@@ -109,7 +110,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.BanditRaider + 1
 );
 ::Reforged.Entities.addTroopAndActor(
 	"RF_BanditThugTough",
@@ -236,7 +238,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.RF_BanditMarauder + 1
 );
 ::Reforged.Entities.addEntity(
 	"RF_BanditOutlaw",
@@ -264,6 +267,7 @@
 		],
 		FatigueRecoveryRate = 15
 	}
+	::Const.EntityType.RF_BanditVandal + 1
 );
 ::Reforged.Entities.addEntity(
 	"RF_BanditHighwayman",
@@ -290,7 +294,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.RF_BanditOutlaw + 1
 );
 ::Reforged.Entities.editEntity("BanditPoacher",
 	null, // Vanilla Cost/Strength: 12/12
@@ -374,7 +379,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.BanditMarksman + 1
 );
 ::Reforged.Entities.editEntity("BanditLeader",
 	{
@@ -434,7 +440,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.BanditLeader + 1
 );
 ::Reforged.Entities.editEntity("Wardog",
 	null, // Vanilla Cost/Strength: 8/9

--- a/mod_reforged/hooks/config/faction_military.nut
+++ b/mod_reforged/hooks/config/faction_military.nut
@@ -53,7 +53,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.Footman + 1
 );
 ::Reforged.Entities.editEntity("Billman",
 	{
@@ -110,7 +111,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.Billman + 1
 );
 ::Reforged.Entities.editEntity("Arbalester", // Crossbowman
 	{
@@ -172,7 +174,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.Arbalester + 1
 );
 ::Reforged.Entities.addEntity(
 	"RF_ManAtArms",
@@ -207,7 +210,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.Greatsword + 1
 );
 ::Reforged.Entities.editEntity("Greatsword", // Zweihander
 	{
@@ -270,7 +274,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.RF_ManAtArms + 1
 );
 ::Reforged.Entities.editEntity("Knight",
 	{
@@ -329,7 +334,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.Knight + 1
 );
 ::Reforged.Entities.addEntity(
 	"RF_Squire",
@@ -362,7 +368,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.RF_KnightAnointed + 1
 );
 ::Reforged.Entities.editEntity("Sergeant",
 	{
@@ -423,7 +430,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.Sergeant + 1
 );
 ::Reforged.Entities.editEntity("StandardBearer",
 	{
@@ -484,7 +492,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.StandardBearer + 1
 );
 ::Reforged.Entities.addEntity(
 	"RF_HeraldsBodyguard", // Royal Guard
@@ -517,7 +526,8 @@
 			0
 		],
 		FatigueRecoveryRate = 15
-	}
+	},
+	::Const.EntityType.RF_Herald + 1
 );
 ::Reforged.Entities.editEntity("Noble",
 	null,

--- a/mod_reforged/hooks/config/faction_undead.nut
+++ b/mod_reforged/hooks/config/faction_undead.nut
@@ -30,7 +30,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.SkeletonMedium + 1
 );
 ::Reforged.Entities.addTroop(
 	"RF_SkeletonMediumElitePolearm",
@@ -106,7 +107,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.SkeletonHeavy + 1
 );
 ::Reforged.Entities.addTroop(
 	"RF_SkeletonHeavyEliteBodyguard",
@@ -146,7 +148,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.RF_SkeletonHeavyElite + 1
 );
 ::Reforged.Entities.addEntity(
 	"RF_SkeletonCenturion",
@@ -178,7 +181,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.RF_SkeletonDecanus + 1
 );
 ::Reforged.Entities.addEntity(
 	"RF_SkeletonLegatus",
@@ -212,7 +216,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.RF_SkeletonCenturion + 1
 );
 ::Reforged.Entities.addEntity(
 	"RF_VampireLord",
@@ -246,7 +251,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.Vampire + 1
 );
 // Draugr
 ::Reforged.Entities.addEntity(
@@ -512,7 +518,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.ZombieKnight + 1
 );
 ::Reforged.Entities.addTroop(
 	"RF_ZombieHeroBodyguard",
@@ -551,7 +558,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.Ghost + 1
 );
 ::Reforged.Entities.addEntity(
 	"RF_Banshee",
@@ -585,7 +593,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.Ghost + 1
 );
 
 // Zombie Orc
@@ -619,52 +628,14 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.Ghost
 );
 ::Reforged.Entities.addTroop(
 	"RF_ZombieOrcYoungBodyguard",
 	::MSU.Table.merge(clone ::Const.World.Spawn.Troops.RF_ZombieOrcYoung, {
 		Row = 2,
 		Script = "scripts/entity/tactical/enemies/rf_zombie_orc_young_bodyguard"
-	})
-);
-::Reforged.Entities.addEntity(
-	"RF_ZombieOrcWarrior",
-	"Wiederganger Orc Warrior",
-	"Wiederganger Orc Warriors",
-	"rf_zombie_orc_warrior_orientation",
-	::Const.FactionType.Zombies,
-	{
-		Variant = 0,
-		Strength = 28,
-		Cost = 25,
-		Row = -1,
-		Script = "scripts/entity/tactical/enemies/rf_zombie_orc_warrior"
-	},
-	{
-		XP = 350,
-		ActionPoints = 7,
-		Hitpoints = 300,
-		Bravery = 90,
-		Stamina = 100,
-		MeleeSkill = 60,
-		RangedSkill = 0,
-		MeleeDefense = -15,
-		RangedDefense = -15,
-		Initiative = 60,
-		FatigueEffectMult = 0.0,
-		MoraleEffectMult = 0.0,
-		Armor = [
-			0,
-			0
-		]
-	}
-);
-::Reforged.Entities.addTroop(
-	"RF_ZombieOrcWarriorBodyguard",
-	::MSU.Table.merge(clone ::Const.World.Spawn.Troops.RF_ZombieOrcWarrior, {
-		Row = 2,
-		Script = "scripts/entity/tactical/enemies/rf_zombie_orc_warrior_bodyguard"
 	})
 );
 ::Reforged.Entities.addEntity(
@@ -697,7 +668,48 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.Ghost
+);
+::Reforged.Entities.addEntity(
+	"RF_ZombieOrcWarrior",
+	"Wiederganger Orc Warrior",
+	"Wiederganger Orc Warriors",
+	"rf_zombie_orc_warrior_orientation",
+	::Const.FactionType.Zombies,
+	{
+		Variant = 0,
+		Strength = 28,
+		Cost = 25,
+		Row = -1,
+		Script = "scripts/entity/tactical/enemies/rf_zombie_orc_warrior"
+	},
+	{
+		XP = 350,
+		ActionPoints = 7,
+		Hitpoints = 300,
+		Bravery = 90,
+		Stamina = 100,
+		MeleeSkill = 60,
+		RangedSkill = 0,
+		MeleeDefense = -15,
+		RangedDefense = -15,
+		Initiative = 60,
+		FatigueEffectMult = 0.0,
+		MoraleEffectMult = 0.0,
+		Armor = [
+			0,
+			0
+		]
+	},
+	::Const.EntityType.Ghost
+);
+::Reforged.Entities.addTroop(
+	"RF_ZombieOrcWarriorBodyguard",
+	::MSU.Table.merge(clone ::Const.World.Spawn.Troops.RF_ZombieOrcWarrior, {
+		Row = 2,
+		Script = "scripts/entity/tactical/enemies/rf_zombie_orc_warrior_bodyguard"
+	})
 );
 ::Reforged.Entities.addEntity(
 	"RF_ZombieOrcWarlord",
@@ -729,7 +741,8 @@
 			0,
 			0
 		]
-	}
+	},
+	::Const.EntityType.Ghost
 );
 
 // OTHER

--- a/mod_reforged/hooks/entity/world/world_entity.nut
+++ b/mod_reforged/hooks/entity/world/world_entity.nut
@@ -150,6 +150,28 @@
 			}
 		}
 	}}.RF_addDevSpawnInfo;
+
+	q.onDeserialize = @(__original) { function onDeserialize( _in )
+	{
+		__original(_in);
+
+		// Update troop EntityType. Necessary to preserve entity names in parties
+		// from older versions as we changed how entity types are added.
+		// TODO: Should be removed in the next save breaking release.
+		if (!::Reforged.Mod.Serialization.isSavedVersionAtLeast("0.8.18", _in.getMetaData()))
+		{
+			local troopScriptToEntityTypeMap = {};
+			foreach (t in ::Const.World.Spawn.Troops)
+			{
+				troopScriptToEntityTypeMap[t.Script] <- t.ID;
+			}
+
+			foreach (t in this.m.Troops)
+			{
+				t.ID = troopScriptToEntityTypeMap[t.Script];
+			}
+		}
+	}}.onDeserialize;
 });
 
 ::Reforged.HooksMod.hookTree("scripts/entity/world/world_entity", function(q) {


### PR DESCRIPTION
Vanilla getTroopComposition lists the entities in the order of their EntityType values. So, instead of appending all our entities at the very end of that, we should insert them at more appropriate places into that table.

So now we have:
**Bandits:**
- Pillager before Raider
- Marauder after Raider
- Fast bandits after Marauder in the order Vandal -> Outlaw -> Highwayman
- Baron after Leader

Note: Vanilla shows Thug -> Poacher -> Marksman -> Raider
we will have: Thug -> Poacher -> Marksman -> Sharpshooter -> Pillager -> Raider ... and so on.

**Noble**:
- Heavy Footman after Footman
- Halberdier after Billman
- Arbalester after Crossbowman
- Man at Arms after Zweihander
- Fencer after Man at Arms
- Anointed Knight after Knight
- Squire after Anointed Knight
- Marshal after Sergeant
- Herald after Standard Bearer
- Herald's Bodyguard after Herald

**Undead:**
- Triarius after Legionary
- Honor Guard after Praetorian
- Decanus after Honor Guard
- Centurion after Decanus
- Legatus after Centurion
- Fallen Hero after Fallen Knight
- Klagmutter after Geist
- Hollenhund after Klagmutter
- Zombie Orcs before Geist (Young -> Berserker -> Warrior -> Warlord)