### PR TITLE
feat(bal): reduce reach on 1-tile skills of swordstaff and poleaxe

### DIFF
--- a/scripts/items/weapons/rf_poleaxe.nut
+++ b/scripts/items/weapons/rf_poleaxe.nut
@@ -33,14 +33,7 @@ this.rf_poleaxe <- ::inherit("scripts/items/weapons/weapon", {
 	{
 		this.weapon.onEquip();
 
-		this.addSkill(::Reforged.new("scripts/skills/actives/chop", function(o) {
-			o.m.Name = "Hew";
-			o.m.ActionPointCost = 6;
-			o.m.FatigueCost = 15;
-			o.m.Icon = "skills/rf_poleaxe_hew_skill.png";
-			o.m.IconDisabled = "skills/rf_poleaxe_hew_skill_sw.png";
-			o.m.Overlay = "rf_poleaxe_hew_skill";
-		}));
+		this.addSkill(::Reforged.new("scripts/skills/actives/rf_hew_skill"));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/strike_skill", function(o) {
 			o.setApplyAxeMastery(true);

--- a/scripts/items/weapons/rf_swordstaff.nut
+++ b/scripts/items/weapons/rf_swordstaff.nut
@@ -35,9 +35,7 @@ this.rf_swordstaff <- ::inherit("scripts/items/weapons/weapon", {
 		local prong = ::new("scripts/skills/actives/prong_skill");
 		this.addSkill(prong);
 
-		this.addSkill(::Reforged.new("scripts/skills/actives/overhead_strike", function(o) {
-			o.m.IsIgnoredAsAOO = true;
-		}));
+		this.addSkill(::new("scripts/skills/actives/rf_overhead_strike_swordstaff_skill"));
 
 		this.addSkill(::Reforged.new("scripts/skills/actives/spearwall", function(o) {
 			o.m.ActionPointCost += 2;

--- a/scripts/skills/actives/rf_hew_skill.nut
+++ b/scripts/skills/actives/rf_hew_skill.nut
@@ -1,0 +1,43 @@
+this.rf_hew_skill <- ::inherit("scripts/skills/actives/chop", {
+	m = {
+		ReachAdd = -1
+	},
+	function create()
+	{
+		this.chop.create();
+		// We keep the ID the same as chop as this
+		// skill is basically the same thing.
+
+		this.m.Name = "Hew";
+		this.m.Icon = "skills/rf_poleaxe_hew_skill.png";
+		this.m.IconDisabled = "skills/rf_poleaxe_hew_skill_sw.png";
+		this.m.Overlay = "rf_poleaxe_hew_skill";
+		this.m.ActionPointCost = 6;
+		this.m.FatigueCost = 15;
+	}
+
+	function getTooltip()
+	{
+		local ret = this.chop.getTooltip();
+
+		if (this.m.ReachAdd != 0)
+		{
+			ret.push({
+				id = 10, type = "text", icon = "ui/icons/rf_reach.png",
+				text = ::Reforged.Mod.Tooltips.parseString(format("Has %s [Reach|Concept.Reach]", ::MSU.Text.colorizeValue(this.m.ReachAdd, {AddSign = true})))
+			});
+		}
+
+		return ret;
+	}
+
+	function onAnySkillUsed( _skill, _targetEntity, _properties )
+	{
+		this.chop.onAnySkillUsed(_skill, _targetEntity, _properties);
+
+		if (_skill == this)
+		{
+			_properties.Reach += this.m.ReachAdd;
+		}
+	}
+});

--- a/scripts/skills/actives/rf_overhead_strike_swordstaff_skill.nut
+++ b/scripts/skills/actives/rf_overhead_strike_swordstaff_skill.nut
@@ -1,0 +1,35 @@
+this.rf_overhead_strike_swordstaff_skill <- ::inherit("scripts/skills/actives/overhead_strike", {
+	m = {
+		ReachAdd = -1
+	},
+	function create()
+	{
+		this.overhead_strike.create();
+		this.m.IsIgnoredAsAOO = true;
+	}
+
+	function getTooltip()
+	{
+		local ret = this.overhead_strike.getTooltip();
+
+		if (this.m.ReachAdd != 0)
+		{
+			ret.push({
+				id = 10, type = "text", icon = "ui/icons/rf_reach.png",
+				text = ::Reforged.Mod.Tooltips.parseString(format("Has %s [Reach|Concept.Reach]", ::MSU.Text.colorizeValue(this.m.ReachAdd, {AddSign = true})))
+			});
+		}
+
+		return ret;
+	}
+
+	function onAnySkillUsed( _skill, _targetEntity, _properties )
+	{
+		this.overhead_strike.onAnySkillUsed(_skill, _targetEntity, _properties);
+
+		if (_skill == this)
+		{
+			_properties.Reach += this.m.ReachAdd;
+		}
+	}
+});


### PR DESCRIPTION
As [discussed](https://discord.com/channels/996482927531671692/1085023098551685140/1500740598108520459) on dev Discord server.

As these weapons have both 1-tile and 2-tile attacks while having the reach of a 2-tile weapon, having a dedicated 1-tile attack makes these weapons highly versatile. This small Reach penalty is not only more balanced, but also more immersive as you do not utilize the entire length of the weapon when attacking someone closer.