### PR TITLE
feat(bal): expire fresh and furious upon waiting and change to refund ap

### DIFF
--- a/mod_reforged/hooks/config/strings.nut
+++ b/mod_reforged/hooks/config/strings.nut
@@ -1285,7 +1285,7 @@ local vanillaDescriptions = [
 		Effects = [{
 			Type = ::UPD.EffectType.Passive,
 			Description = [
-				"The [Action Point|Concept.ActionPoints] cost of the first skill that costs [Action Points|Concept.ActionPoints] used every [turn|Concept.Turn] is " + ::MSU.Text.colorPositive("halved") + ".",
+				"Before [waiting|Concept.Wait] in a [round|Concept.Round], the first skill use that costs [Action Points|Concept.ActionPoints] refunds " + ::MSU.Text.colorPositive("half") + " of its [Action Point|Concept.ActionPoint] cost.",
 				"The effect becomes disabled if you start a [turn|Concept.Turn] with " + ::MSU.Text.colorNegative("30%") + " or more [Fatigue|Concept.Fatigue] built and remains disabled until you use [$ $|Skill+recover_skill]."
 			]
 		}]

--- a/scripts/skills/perks/perk_rf_fresh_and_furious.nut
+++ b/scripts/skills/perks/perk_rf_fresh_and_furious.nut
@@ -4,7 +4,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		ActionPointsRecoveredPct = 0.5,
 
 		// Private
-		UsedSkillBaseAPCost = 0,
+		UsedSkillAPCost = 0,
 		IsSpent = true,
 		RequiresRecover = false,
 		IconMiniBackup = ""
@@ -51,7 +51,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 				id = 11,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = ::Reforged.Mod.Tooltips.parseString("The next skill use will refund " + ::MSU.Text.colorizePct(this.m.ActionPointsRecoveredPct) + " of its base [Action Point|Concept.ActionPoints] cost")
+				text = ::Reforged.Mod.Tooltips.parseString("The next skill use will refund " + ::MSU.Text.colorizePct(this.m.ActionPointsRecoveredPct) + " of its [Action Point|Concept.ActionPoints] cost")
 			});
 		}
 
@@ -88,12 +88,12 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 	function onBeforeAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
 	{
 		// Sometimes you use a _forFree skill inside the use of a skill that costs AP
-		// In that case we don't want to change the value for UsedSkillBaseAPCost that
+		// In that case we don't want to change the value for UsedSkillAPCost that
 		// has already been set by the originally used skill.
 		if (_forFree)
 			return;
 
-		this.m.UsedSkillBaseAPCost = _skill.getBaseValue("ActionPointCost");
+		this.m.UsedSkillAPCost = _skill.getActionPointCost();
 	}
 
 	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
@@ -103,11 +103,11 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 			this.m.RequiresRecover = false;
 			this.m.IsSpent = true;
 		}
-		else if (this.m.UsedSkillBaseAPCost != 0)
+		else if (this.m.UsedSkillAPCost != 0)
 		{
 			this.m.IsSpent = true;
 			local actor = this.getContainer().getActor();
-			actor.setActionPoints(::Math.min(actor.getActionPointsMax(), actor.getActionPoints() + this.m.UsedSkillBaseAPCost * this.m.ActionPointsRecoveredPct));
+			actor.setActionPoints(::Math.min(actor.getActionPointsMax(), actor.getActionPoints() + this.m.UsedSkillAPCost * this.m.ActionPointsRecoveredPct));
 		}
 	}
 
@@ -117,7 +117,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		local actor = this.getContainer().getActor();
 		if (actor.isPreviewing() && actor.getPreviewSkill() != null && actor.getPreviewSkill().getActionPointCost() != 0)
 		{
-			_costsPreview.actionPointsPreview += ::Math.floor(actor.getPreviewSkill().getBaseValue("ActionPointCost") * this.m.ActionPointsRecoveredPct);
+			_costsPreview.actionPointsPreview += ::Math.floor(actor.getPreviewSkill().getActionPointCost() * this.m.ActionPointsRecoveredPct);
 		}
 	}
 

--- a/scripts/skills/perks/perk_rf_fresh_and_furious.nut
+++ b/scripts/skills/perks/perk_rf_fresh_and_furious.nut
@@ -1,9 +1,12 @@
 this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 	m = {
-		IsUsingFreeSkill = false,
+		FatigueThreshold = 0.3,
+		ActionPointsRecoveredPct = 0.5,
+
+		// Private
+		UsedSkillBaseAPCost = 0,
 		IsSpent = true,
 		RequiresRecover = false,
-		FatigueThreshold = 0.3
 		IconMiniBackup = ""
 	},
 	function create()
@@ -48,15 +51,22 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 				id = 11,
 				type = "text",
 				icon = "ui/icons/special.png",
-				text = ::Reforged.Mod.Tooltips.parseString("The next skill costing [Action Points|Concept.ActionPoints] has its [Action Point|Concept.ActionPoints] cost " + ::MSU.Text.colorPositive("halved"))
+				text = ::Reforged.Mod.Tooltips.parseString("The next skill use will refund " + ::MSU.Text.colorizePct(this.m.ActionPointsRecoveredPct) + " of its base [Action Point|Concept.ActionPoints] cost")
 			});
 		}
+
+		ret.push({
+			id = 20,
+			type = "text",
+			icon = "ui/icons/warning.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Does not expire when using skills that cost no [Action Points|Concept.ActionPoints] but will expire upon [waiting|Concept.Wait]")
+		});
 
 		// For non-dummy actor we also add the actual fatigue value calculated from the threshold
 		if (this.getContainer().getActor().getID() == ::MSU.getDummyPlayer().getID())
 		{
 			ret.push({
-				id = 12,
+				id = 21,
 				type = "text",
 				icon = "ui/icons/warning.png",
 				text = ::Reforged.Mod.Tooltips.parseString("Becomes disabled when starting a turn with " + ::MSU.Text.colorizePct(this.m.FatigueThreshold, {InvertColor = true}) + " or more [Fatigue|Concept.Fatigue] built")
@@ -65,7 +75,7 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		else
 		{
 			ret.push({
-				id = 12,
+				id = 21,
 				type = "text",
 				icon = "ui/icons/warning.png",
 				text = ::Reforged.Mod.Tooltips.parseString(format("Becomes disabled when starting a turn with %s (%s) or more [Fatigue|Concept.Fatigue] built", ::MSU.Text.colorizePct(this.m.FatigueThreshold, {InvertColor = true}), ::MSU.Text.colorNegative(::Math.round(this.m.FatigueThreshold * this.getContainer().getActor().getFatigueMax()))))
@@ -75,40 +85,40 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 		return ret;
 	}
 
-	function onAfterUpdate( _properties )
-	{
-		if (this.m.IsSpent || this.m.RequiresRecover)
-			return;
-
-		local actor = this.getContainer().getActor();
-		if (!actor.isPreviewing() || actor.getPreviewMovement() != null || actor.getPreviewSkill().getActionPointCost() == 0)
-		{
-			foreach (skill in this.getContainer().getAllSkillsOfType(::Const.SkillType.Active))
-			{
-				if (skill.m.ActionPointCost > 1)
-					skill.m.ActionPointCost /= 2;
-			}
-		}
-	}
-
 	function onBeforeAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
 	{
 		// Sometimes you use a _forFree skill inside the use of a skill that costs AP
-		// In that case we don't want to change the value for IsUsingFreeSkill that
+		// In that case we don't want to change the value for UsedSkillBaseAPCost that
 		// has already been set by the originally used skill.
 		if (_forFree)
 			return;
 
-		this.m.IsUsingFreeSkill = _skill.getActionPointCost() == 0;
+		this.m.UsedSkillBaseAPCost = _skill.getBaseValue("ActionPointCost");
 	}
 
 	function onAnySkillExecuted( _skill, _targetTile, _targetEntity, _forFree )
 	{
-		if (!this.m.IsUsingFreeSkill)
-			this.m.IsSpent = true;
-
 		if (_skill.getID() == "actives.recover")
+		{
 			this.m.RequiresRecover = false;
+			this.m.IsSpent = true;
+		}
+		else if (this.m.UsedSkillBaseAPCost != 0)
+		{
+			this.m.IsSpent = true;
+			local actor = this.getContainer().getActor();
+			actor.setActionPoints(::Math.min(actor.getActionPointsMax(), actor.getActionPoints() + this.m.UsedSkillBaseAPCost * this.m.ActionPointsRecoveredPct));
+		}
+	}
+
+	// Modular Vanilla function
+	function onCostsPreview( _costsPreview )
+	{
+		local actor = this.getContainer().getActor();
+		if (actor.isPreviewing() && actor.getPreviewSkill() != null && actor.getPreviewSkill().getActionPointCost() != 0)
+		{
+			_costsPreview.actionPointsPreview += ::Math.floor(actor.getPreviewSkill().getBaseValue("ActionPointCost") * this.m.ActionPointsRecoveredPct);
+		}
 	}
 
 	function onTurnStart()
@@ -126,6 +136,11 @@ this.perk_rf_fresh_and_furious <- ::inherit("scripts/skills/skill", {
 			this.m.Icon = ::Const.Perks.findById(this.getID()).IconDisabled;
 			this.m.IconMini = "";
 		}
+	}
+
+	function onWaitTurn()
+	{
+		this.m.IsSpent = true;
 	}
 
 	function onCombatFinished()


### PR DESCRIPTION
- Instead of halving the AP cost of the skill, we refund Action Points based on the Base Action Point Cost of the skill. This makes the perk less front-loaded and removes its ability to move large distances and still attack.
- Expiring upon waiting puts a neat restriction on the versatility of the skill.

Based on this [discussion thread](https://discord.com/channels/1006908336991645757/1374467342037155993) in Discord.