### PR TITLE
fix: hyperlinks breaking in events due to double nesting

### DIFF
--- a/mod_reforged/msu_systems/nested_tooltips.nut
+++ b/mod_reforged/msu_systems/nested_tooltips.nut
@@ -25,61 +25,61 @@ local getThresholdForInjury = function( _script )
 	::Reforged.HooksMod.hookTree("scripts/entity/tactical/actor", function(q) {
 		q.getName = @(__original) { function getName()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|EventActor+%i]", __original(), this.getID())) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|EventActor+%i]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.getID())) : __original();
 		}}.getName;
 
 		q.getNameOnly = @(__original) { function getNameOnly()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|EventActor+%i]", __original(), this.getID())) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|EventActor+%i]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.getID())) : __original();
 		}}.getNameOnly;
 	});
 
 	::Reforged.HooksMod.hookTree("scripts/items/item", function(q) {
 		q.getName = @(__original) { function getName()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Obj+%s,contentType:ui-item]", __original(), ::Reforged.Mod.Tooltips.parseObject(this))) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Obj+%s,contentType:ui-item]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), ::Reforged.Mod.Tooltips.parseObject(this))) : __original();
 		}}.getName;
 
 		q.getIcon = @(__original) { function getIcon()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/ui/items/%s|Obj+%s,contentType:ui-item]", __original(), ::Reforged.Mod.Tooltips.parseObject(this))) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/ui/items/%s|Obj+%s,contentType:ui-item]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), ::Reforged.Mod.Tooltips.parseObject(this))) : __original();
 		}}.getIcon;
 	});
 
 	::Reforged.HooksMod.hookTree("scripts/skills/skill", function(q) {
 		q.getName = @(__original) { function getName()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Skill+%s%s]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
 		}}.getName;
 
 		if (q.contains("getNameOnly"))
 		{
 			q.getNameOnly = @(__original) { function getNameOnly()
 			{
-				return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+				return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Skill+%s%s]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
 			}}.getNameOnly;
 		}
 
 		q.getIcon = @(__original) { function getIcon()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|Skill+%s%s]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
 		}}.getIcon;
 
 		q.getIconColored = @(__original) { function getIconColored()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|Skill+%s%s]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
 		}}.getIconColored;
 
 		q.getIconDisabled = @(__original) { function getIconDisabled()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|Skill+%s%s]", __original(), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[Img/gfx/%s|Skill+%s%s]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.ClassName, ::MSU.isNull(this.getContainer()) ? "" : ",entityId:" + this.getContainer().getActor().getID())) : __original();
 		}}.getIconDisabled;
 	});
 
 	::Reforged.HooksMod.hookTree("scripts/factions/faction", function(q) {
 		q.getName = @(__original) { function getName()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Faction+%i]", __original(), this.getID())) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Faction+%i]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.getID())) : __original();
 		}}.getName;
 
 		// Some entities are spawned during event/contract `setScreen` while isApplyingNestingForEvents is true.
@@ -100,7 +100,7 @@ local getThresholdForInjury = function( _script )
 		{
 			q.getNameOnly = @(__original) { function getNameOnly()
 			{
-				return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Faction+%i]", __original(), this.getID())) : __original();
+				return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|Faction+%i]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.getID())) : __original();
 			}}.getNameOnly;
 		}
 	});
@@ -108,14 +108,14 @@ local getThresholdForInjury = function( _script )
 	::Reforged.HooksMod.hookTree("scripts/entity/world/world_entity", function(q) {
 		q.getName = @(__original) { function getName()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|WorldEntity+%i]", __original(), this.getID())) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|WorldEntity+%i]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.getID())) : __original();
 		}}.getName;
 	});
 
 	::Reforged.HooksMod.hookTree("scripts/entity/world/attached_location", function(q) {
 		q.getRealName = @(__original) { function getRealName()
 		{
-			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|WorldEntity+%i]", __original(), this.getID())) : __original();
+			return ::Reforged.NestedTooltips.isApplyingNestingForEvents() ? ::Reforged.Mod.Tooltips.parseString(format("[%s|WorldEntity+%i]", ::Reforged.Mod.Tooltips.removeAllFromString(__original()), this.getID())) : __original();
 		}}.getRealName;
 	});
 }


### PR DESCRIPTION
An example is in the vanilla `bowyer_crafts_masterwork_event` where the name of the bow is set via first calling `getNameOnly()` on the crafter bro, which hyperlinks his name. Then it calls `getName()` on the bow item when adding it to the list, which hyperlinks the bow's name. This results in the bow's name hyperlink containing a nested hyperlink of the bro's name, which leads to the bro's name being hyperlinked but the bow's name hyperlink to not be parsed correctly.

To fix this, we remove any hyperlinks from the original before nesting it.

Related bug report on Discord: https://discord.com/channels/1006908336991645757/1006909211919274096/1512956410197966891

<img width="664" height="183" alt="image" src="https://github.com/user-attachments/assets/ab507cd8-ebd9-4615-b763-bf3fb6dfa4b3" />
