### PR TITLE
feat(chg): exclude dislocated jaw injury from undead

### DIFF
--- a/mod_reforged/config/msu_excluded_injuries.nut
+++ b/mod_reforged/config/msu_excluded_injuries.nut
@@ -7,6 +7,7 @@
 		"injury.broken_ribs",
 		"injury.bruised_leg",
 		"injury.crushed_windpipe",
+		"injury.rf_dislocated_jaw",
 		"injury.fractured_ribs",
 		"injury.severe_concussion",
 		// Burning


### PR DESCRIPTION
Because it affects Fatigue and Resolve which are both irrelevant for undead characters.

In version 0.6.1 we [excluded](c876fc88a6a7e92485b823e25f0896d170343070) Broken Ribs and Fractured Ribs from all undead because they affect Fatigue only and are therefore mostly useless to apply on undead. In view of that, it makes sense that we exclude Dislocated Jaw as well.