### PR TITLE
Fix grieving malaise sfx

### DIFF
--- a/scripts/skills/effects/rf_grieving_malaise_effect.nut
+++ b/scripts/skills/effects/rf_grieving_malaise_effect.nut
@@ -71,7 +71,10 @@ this.rf_grieving_malaise_effect <- ::inherit("scripts/skills/skill", {
 		else
 		{
 			local actor = this.getContainer().getActor();
-			::Sound.play(::MSU.Array.rand(this.m.SoundOnUse), ::Const.Sound.Volume.Actor * actor.m.SoundVolume[::Const.Sound.ActorEvent.Idle] * (::Math.rand(75, 100) * 0.01), actor.getPos(), actor.m.SoundPitch);
+			if (!actor.isHiddenToPlayer() && actor.getMoraleState() != ::Const.MoraleState.Fleeing && !actor.getCurrentProperties().IsStunned && ::MSU.isKindOf(actor, "human"))
+			{
+				::Sound.play(::MSU.Array.rand(this.m.SoundOnUse), ::Const.Sound.Volume.Actor * actor.m.SoundVolume[::Const.Sound.ActorEvent.Idle] * (::Math.rand(75, 100) * 0.01), actor.getPos(), actor.m.SoundPitch);					
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently Grieving Malaise has the following issues:
- It produces an sfx, even if you can't see those characters, e.g. when NPCs fight offscreen
- It produces a cry-sfx (produced by a human mouth), even when that human is stunned
- It produces a human cry, even if the character is not a human

Futhermore I have the issue, that the sound at times causes too much "sound-pollution" to happen at the same time.
A character who flees already produces a unique sound effect on turn start. With Malaise there would be 2 sounds playing at the same time.

## Other ideas I considered

- We could restrict this sfx to only play for player controlled humans, in order to further reduce audical noise spam in third-party fights.