### PR TITLE
refactor: move free dagger swap into its own special skill file

### DIFF
--- a/mod_reforged/hooks/entity/tactical/actor.nut
+++ b/mod_reforged/hooks/entity/tactical/actor.nut
@@ -19,6 +19,7 @@
 		this.getSkills().add(::new("scripts/skills/special/rf_polearm_adjacency"));
 		this.getSkills().add(::new("scripts/skills/special/rf_follow_up_proccer"));
 		this.getSkills().add(::new("scripts/skills/special/rf_inspiring_presence_buff_effect"));
+		this.getSkills().add(::new("scripts/skills/special/rf_free_dagger_swap"));
 
 		local flags = this.getFlags();
 		if (flags.has("undead") && !flags.has("ghost") && !flags.has("ghoul") && !flags.has("vampire"))

--- a/mod_reforged/hooks/skills/special/double_grip.nut
+++ b/mod_reforged/hooks/skills/special/double_grip.nut
@@ -3,7 +3,6 @@
 	// because we go through weapon types alphabetically and choose the first applicable type
 	q.m.CurrWeaponType <- null;
 	q.m.MeleeDamageMult_Dagger <- 1.25;
-	q.m.IsFreeSwapSpent <- true;
 
 	q.create = @(__original) { function create()
 	{
@@ -13,35 +12,6 @@
 		// (primarily because of the fact that it applies Dazed in onTargetHit and other skills may check for the presence of dazed effect)
 		this.m.Order = ::Const.SkillOrder.First;
 	}}.create;
-
-	// Make swapping to bagged non-hybrid dagger a free action.
-	// This has nothing to do with double grip bonus but is implemented in double_grip just for convenience
-	// because double_grip is present on all relevant characters.
-	q.getItemActionCost = @() { function getItemActionCost( _items )
-	{
-		if (this.m.IsFreeSwapSpent)
-			return;
-
-		foreach (item in _items)
-		{
-			if (item != null && item.isItemType(::Const.Items.ItemType.Weapon) && item.isWeaponType(::Const.Items.WeaponType.Dagger, true, true))
-			{
-				return 0;
-			}
-		}
-	}}.getItemActionCost;
-
-	q.onPayForItemAction = @(__original) { function onPayForItemAction( _skill, _items )
-	{
-		__original(_skill, _items);
-		this.m.IsFreeSwapSpent = true;
-	}}.onPayForItemAction;
-
-	q.onTurnStart = @(__original) { function onTurnStart()
-	{
-		__original();
-		this.m.IsFreeSwapSpent = false;
-	}}.onTurnStart;
 
 	// Overwrite vanilla function to allow double-gripping with southern swords with the perk_rf_en_garde perk
 	q.canDoubleGrip = @() { function canDoubleGrip()

--- a/scripts/skills/special/rf_free_dagger_swap.nut
+++ b/scripts/skills/special/rf_free_dagger_swap.nut
@@ -1,0 +1,37 @@
+this.rf_free_dagger_swap <- ::inherit("scripts/skills/skill", {
+	m = {
+		IsSpent = true
+	},
+	function create()
+	{
+		this.m.ID = "special.rf_free_dagger_swap";
+		this.m.Type = ::Const.SkillType.Special;
+		this.m.IsSerialized = false;
+		this.m.IsHidden = true;
+	}
+
+	// Make swapping to/from non-hybrid dagger a free action.
+	function getItemActionCost( _items )
+	{
+		if (this.m.IsSpent)
+			return;
+
+		foreach (item in _items)
+		{
+			if (item != null && ::MSU.isKindOf(item, "weapon") && item.isWeaponType(::Const.Items.WeaponType.Dagger, true, true))
+			{
+				return 0;
+			}
+		}
+	}
+
+	function onPayForItemAction( _skill, _items )
+	{
+		this.m.IsSpent = true;
+	}
+
+	function onTurnStart()
+	{
+		this.m.IsSpent = false;
+	}
+});


### PR DESCRIPTION
Seems cleaner to do it this way.