### PR TITLE
feat: adapt vanilla executioner background

### DIFF
--- a/mod_reforged/hooks/skills/backgrounds/executioner_background.nut
+++ b/mod_reforged/hooks/skills/backgrounds/executioner_background.nut
@@ -1,0 +1,71 @@
+::Reforged.HooksMod.hook("scripts/skills/backgrounds/executioner_background", function(q) {
+	q.createPerkTreeBlueprint = @() { function createPerkTreeBlueprint()
+	{
+		return ::new(::DynamicPerks.Class.PerkTree).init({
+			DynamicMap = {
+				"pgc.rf_exclusive_1": [],
+				"pgc.rf_shared_1": [],
+				"pgc.rf_weapon": [
+					"pg.rf_axe",
+					"pg.rf_sword"
+				],
+				"pgc.rf_armor": [],
+				"pgc.rf_fighting_style": [
+					"pg.rf_power"
+				]
+			}
+		});
+	}}.createPerkTreeBlueprint;
+
+	q.getPerkGroupCollectionMin = @() { function getPerkGroupCollectionMin( _collection )
+	{
+		switch (_collection.getID())
+		{
+			case "pgc.rf_weapon":
+				return _collection.getMin() + 1;
+		}
+	}}.getPerkGroupCollectionMin;
+
+	q.getPerkGroupMultiplier = @() { function getPerkGroupMultiplier( _groupID, _perkTree )
+	{
+		if (::Reforged.Skills.getPerkGroupMultiplier_MeleeOnly(_groupID, _perkTree) == 0)
+			return 0;
+
+		switch (_groupID)
+		{
+			case "pg.rf_vicious":
+			case "pg.rf_unstoppable":
+			case "pg.rf_cleaver":
+				return 2;
+		}
+	}}.getPerkGroupMultiplier;
+
+	q.getTooltip = @(__original) { function getTooltip()
+	{
+		local ret = __original();
+		ret.push({
+			id = 10,
+			type = "text",
+			icon = "ui/icons/special.png",
+			text = ::Reforged.Mod.Tooltips.parseString("Has the [$ $|Perk+perk_coup_de_grace] perk permanently for free")
+		});
+		return ret;
+	}}.getTooltip;
+
+	q.onAdded = @(__original) { function onAdded()
+	{
+		if (this.m.IsNew)
+		{
+			this.getContainer().add(::Reforged.new("scripts/skills/perks/perk_coup_de_grace", function(o) {
+				o.m.IsRefundable = false;
+			}));
+
+			local perkTree = this.getContainer().getActor().getPerkTree();
+			if (!perkTree.hasPerk("perk.coup_de_grace"))
+			{
+				perkTree.addPerk("perk.coup_de_grace", 2)
+			}
+		}
+		return __original();
+	}}.onAdded;
+});


### PR DESCRIPTION
The `executioner_southern_background` inherits from this background so it gets the same treatment automatically.

- This background spawns with axes and swords, so I gave him Axe and Sword guaranteed (it also seems thematic for this background). I gave the Power fighting style guaranteed too. Note: The southern variant can spawn with 2h scimitar etc. which is a cleaver, so I've given 2x multiplier for cleaver for this background.
- I gave him +1 weapon perk group so a total of 4. This makes up for the 2 guaranteed axe, sword groups to give some variety in the different recruits of this background.
- He is only a melee background, so will never roll ranged perk groups.
- To make him interesting, I've given him the Executioner perk for free (like we give Sword Mastery for free to Swordmasters) and that perk seems fitting for this background.
- The 2x multiplier for Vicious and Unstoppable also were given for thematic reasons because of the perks they contain (Berserk, Fearsome, Executioner etc.).