### PR TITLE
fix: revert the usage of handleInvoluntaryMovement

### DIFF
--- a/scripts/skills/actives/rf_net_pull_skill.nut
+++ b/scripts/skills/actives/rf_net_pull_skill.nut
@@ -147,7 +147,27 @@ this.rf_net_pull_skill <- ::inherit("scripts/skills/skill", {
 			::Sound.play(this.m.SoundOnHit[::Math.rand(0, this.m.SoundOnHit.len() - 1)], ::Const.Sound.Volume.Skill, _user.getPos());
 		}
 
-		::Tactical.State.handleInvoluntaryMovement(target, _user, _targetTile, pullToTile, this, this.onPulledDown, this.onHookingComplete);
+		target.setCurrentMovementType(::Const.Tactical.MovementType.Involuntary);
+		local damage = ::Math.max(0, ::Math.abs(pullToTile.Level - _targetTile.Level) - 1) * ::Const.Combat.FallingDamage;
+		local tag = {
+			Attacker = _user,
+			Skill = this,
+			HitInfo = clone ::Const.Tactical.HitInfo,
+			TargetTile = pullToTile
+		};
+
+		if (damage == 0)
+		{
+			::Tactical.getNavigator().teleport(_targetTile.getEntity(), pullToTile, this.onHookingComplete, tag, true);
+		}
+		else
+		{
+			tag.HitInfo.DamageRegular = damage;
+			tag.HitInfo.DamageFatigue = ::Const.Combat.FatigueReceivedPerHit;
+			tag.HitInfo.DamageDirect = 1.0;
+			tag.HitInfo.BodyPart = ::Const.BodyPart.Body;
+			::Tactical.getNavigator().teleport(_targetTile.getEntity(), pullToTile, this.onPulledDown, tag, true);
+		}
 
 		return true;
 	}

--- a/scripts/skills/actives/rf_swordmaster_kick_skill.nut
+++ b/scripts/skills/actives/rf_swordmaster_kick_skill.nut
@@ -159,7 +159,31 @@ this.rf_swordmaster_kick_skill <- ::inherit("scripts/skills/actives/rf_swordmast
 				::Sound.play(this.m.SoundOnHit[::Math.rand(0, this.m.SoundOnHit.len() - 1)], ::Const.Sound.Volume.Skill, _user.getPos());
 			}
 
-			::Tactical.State.handleInvoluntaryMovement(target, _user, _targetTile, knockToTile, this, this.onKnockedDown, this.onKnockedBackComplete);
+			target.setCurrentMovementType(::Const.Tactical.MovementType.Involuntary);
+			local damage = ::Math.max(0, ::Math.abs(knockToTile.Level - _targetTile.Level) - 1) * ::Const.Combat.FallingDamage;
+
+			if (damage == 0)
+			{
+				::Tactical.getNavigator().teleport(target, knockToTile, null, null, true);
+			}
+			else
+			{
+				local p = this.getContainer().getActor().getCurrentProperties();
+				local tag = {
+					Attacker = _user,
+					Skill = this,
+					HitInfo = clone ::Const.Tactical.HitInfo,
+					HitInfoBash = null
+				};
+				tag.HitInfo.DamageRegular = damage;
+				tag.HitInfo.DamageFatigue = ::Const.Combat.FatigueReceivedPerHit;
+				tag.HitInfo.DamageDirect = 1.0;
+				tag.HitInfo.BodyPart = ::Const.BodyPart.Body;
+				tag.HitInfo.BodyDamageMult = 1.0;
+				tag.HitInfo.FatalityChanceMult = 1.0;
+
+				::Tactical.getNavigator().teleport(target, knockToTile, this.onKnockedDown, tag, true);
+			}
 		}
 
 		return success;
@@ -167,9 +191,14 @@ this.rf_swordmaster_kick_skill <- ::inherit("scripts/skills/actives/rf_swordmast
 
 	function onKnockedDown( _entity, _tag )
 	{
-	}
+		if (_tag.HitInfo.DamageRegular != 0)
+		{
+			_entity.onDamageReceived(_tag.Attacker, _tag.Skill, _tag.HitInfo);
+		}
 
-	function onKnockedBackComplete( _entity, _tag )
-	{
+		if (_tag.HitInfoBash != null)
+		{
+			_entity.onDamageReceived(_tag.Attacker, _tag.Skill, _tag.HitInfoBash);
+		}
 	}
 });


### PR DESCRIPTION
This reverts commits e2699128b1ccfcd45a9b98f6c5bdb6f07f11f5e2 and 24d2fc0014d31a9c0b1fd0cf227fc7b246f9ce4d.

The vanilla function requires the `_onMovementCompleted` callback to have a single parameter, so our callbacks were not working. The vanilla function is also limited in terms of the information passed in the tags and we need extra information.

See my detailed criticism of the vanilla function in this Discord thread: https://discord.com/channels/965324395851694140/1523321576739569716