### PR TITLE
feat: ensure skills have a container during getTooltip

### DIFF
--- a/mod_reforged/hooks/skills/actives/release_falcon_skill.nut
+++ b/mod_reforged/hooks/skills/actives/release_falcon_skill.nut
@@ -8,10 +8,6 @@
 	q.getTooltip = @(__original) { function getTooltip()
 	{
 		local ret = __original();
-
-		local effect = ::new("scripts/skills/effects/rf_falcon_released_effect");
-		effect.m.Container = ::MSU.getDummyPlayer().getSkills();
-
 		ret.push({
 			id = 10,
 			type = "text",
@@ -19,9 +15,6 @@
 			text = ::Reforged.Mod.Tooltips.parseString(format("Allies who are not [$ $|Skill+stunned_effect], rooted, or [fleeing|Concept.Morale] gain the %s effect", ::Reforged.NestedTooltips.getNestedSkillName(effect))),
 			children = effect.getTooltip().slice(2) // slice 2 to remove name and description
 		});
-
-		effect.m.Container = null;
-
 		return ret;
 	}}.getTooltip;
 

--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -212,3 +212,20 @@
 		return this.m.IsTargeted ? __original(_userTile, _targetTile) : _userTile.isSameTileAs(_targetTile);
 	}}.onVerifyTarget;
 });
+
+::Reforged.QueueBucket.Late.push(function() {
+	::Reforged.HooksMod.hook("scripts/skills/skill", function(q) {
+		// Ensure that skill always has a valid container during getTooltip
+		// to prevent errors when getting tooltips of skills that aren't added to anyone.
+		q.getTooltip = @(__original) { function getTooltip()
+		{
+			if (!::MSU.isNull(this.getContainer()))
+				return __original();
+
+			this.m.Container = ::MSU.getDummyPlayer().getSkills();
+			local ret = __original();
+			this.m.Container = null;
+			return ret;
+		}}.getTooltip;
+	});
+});


### PR DESCRIPTION
If a skill doesn't have a container set, we set it to the dummy player's skill container. This is helpful when one wants to pull the tooltip of such skills e.g. to attach a basic tooltip of an effect as children in the tooltip of an active skill.

Discussion thread on dev discord: https://discord.com/channels/996482927531671692/1507787808931057778