### PR TITLE
feat(chg): exclude flying skulls from receiving injuries

### DIFF
--- a/mod_reforged/hooks/entity/tactical/enemies/flying_skull.nut
+++ b/mod_reforged/hooks/entity/tactical/enemies/flying_skull.nut
@@ -69,5 +69,6 @@
 		//Reforged
 		this.m.BaseProperties.IsAffectedByReach = false;
 		this.getSkills().update()
+		this.m.Skills.removeByID("special.rf_undead_injury_receiver");	// Make flying skulls immune to injuries again
 	}}.onInit;
 });


### PR DESCRIPTION
Currently Flying Skulls can receive injuries. As they are only a skull, almost all injuries look out of place.
Also because of their low hitpoints, injuries dont make much sense to have play a role on them

Because every undead gets the injury receiver effect, we need to manually remove it again, when we want a specific undead to be totally immune to injuries