### PR TITLE
fix: ctrl hotkey reminder showing up on enemy active skills

### DIFF
--- a/mod_reforged/hooks/skills/skill.nut
+++ b/mod_reforged/hooks/skills/skill.nut
@@ -192,7 +192,7 @@
 	{
 		local ret = __original();
 
-		if (::Tactical.isActive() && this.isActive() && !this.m.IsTargeted)
+		if (::Tactical.isActive() && this.isActive() && !this.m.IsTargeted && ::Tactical.TurnSequenceBar.isActiveEntity(this.getContainer().getActor()))
 		{
 			ret.push({
 				id = 100,


### PR DESCRIPTION
This solution is not perfect but it catches most problematic tooltips.
The only thing it can't catch is when you view the actor tooltip of the active entity and view active skills in here

## Before

<img width="368" height="356" alt="image" src="https://github.com/user-attachments/assets/f772e1df-c6bb-4111-a912-e3dad16698ec" />

## After

<img width="369" height="321" alt="image" src="https://github.com/user-attachments/assets/92530b93-ba24-4960-a0e4-eaf5d21de822" />
