### PR TITLE
Wip/ci test workflow

### DIFF
--- a/.github/actions/setup-bbbuilder/action.yml
+++ b/.github/actions/setup-bbbuilder/action.yml
@@ -70,7 +70,7 @@ runs:
           ModPath  = "${{ inputs.mod_root }}"
           MoveZip  = $false
           UseSteam = $false
-          Verbose  = $true
+          Verbose  = $false
           SetPath  = $false
           LogTime  = $true
           FoldersArray = @()

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -1,0 +1,34 @@
+name: Verify Compilation
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  compile:
+    runs-on: windows-latest
+
+    env:
+      MOD_ROOT: ${{ github.workspace }}\
+      MOD_PATH: ${{ github.workspace }}\repo
+      GAME_PATH: ${{ github.workspace }}\_game_fake
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: repo
+          ref: ${{ github.event.pull_request.head.sha }} # Checks out the exact PR commit
+
+      - name: Setup BBBuilder
+        id: bbbuilder
+        uses: ./repo/.github/actions/setup-bbbuilder
+        with:
+          game_path: ${{ env.GAME_PATH }}
+          mod_root: ${{ env.MOD_ROOT }}
+
+      - name: Compile Core
+        shell: cmd
+        working-directory: ${{ steps.bbbuilder.outputs.path }}
+        env:
+          DOTNET_ROLL_FORWARD: Major
+        run: BBbuilder.exe build "%MOD_PATH%" -rebuild -ex "brushes,gfx,music,sounds,scripts/!mods_preload/mod_reforged_assets,scripts/!mods_preload/mod_reforged_patch" -zipname "${{ steps.info.outputs.core_zip }}"


### PR DESCRIPTION
This new workflow will compile Reforged Code every time someone creates or pushes onto a Pull Request.
When that compilation fails, then 
- you see a red warning under the PR
- you can view the BBBuilder debug output on the website

This currently doesnt yet prevent merging on a fail. But we can enable that seperately in the github settings for this repo.

I will squash the first commits, if the argument support is really not required

## Example

Look into this PR: https://github.com/Battle-Modders/mod-reforged/pull/1066

<img width="838" height="582" alt="image" src="https://github.com/user-attachments/assets/20e51c77-7536-48f7-bcd9-cbb151c720ef" />
