### PR TITLE
feat: show current weight in nimble and poise tooltip

### DIFF
--- a/mod_reforged/hooks/skills/perks/perk_nimble.nut
+++ b/mod_reforged/hooks/skills/perks/perk_nimble.nut
@@ -65,7 +65,7 @@
 				id = 14,
 				type = "text",
 				icon = "ui/icons/fatigue.png",
-				text = format("The effectiveness drops above combined head and body armor weight of %s (current: %s)", this.getStaminaModifierThreshold(), -this.getContainer().getActor().getItems().getStaminaModifier([::Const.ItemSlot.Body, ::Const.ItemSlot.Head]))
+				text = format("The effectiveness drops above combined head and body armor weight of %s (current: %s)", this.getStaminaModifierThreshold(), -actor.getItems().getStaminaModifier([::Const.ItemSlot.Body, ::Const.ItemSlot.Head]))
 			});
 		}
 

--- a/mod_reforged/hooks/skills/perks/perk_nimble.nut
+++ b/mod_reforged/hooks/skills/perks/perk_nimble.nut
@@ -48,23 +48,26 @@
 			text = ::Reforged.Mod.Tooltips.parseString("Ignore 1 [Reach Disadvantage|Concept.ReachAdvantage] when attacking a target with lower [Initiative|Concept.Initiative] than yours")
 		});
 
-		local actor = this.getContainer().getActor();
-		local maxHPString = ::Math.floor(actor.getHitpointsMax() / (hpBonus * 0.01));
-		local currHPString = ::Math.floor(actor.getHitpoints() / (hpBonus * 0.01));
+		if (!::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			local actor = this.getContainer().getActor();
+			local maxHPString = ::Math.floor(actor.getHitpointsMax() / (hpBonus * 0.01));
+			local currHPString = ::Math.floor(actor.getHitpoints() / (hpBonus * 0.01));
 
-		ret.push({
-			id = 6,
-			type = "text",
-			icon = "ui/icons/special.png",
-			text = ::MSU.Text.colorPositive("Effective Hitpoints: ") + currHPString + " / " + maxHPString
-		});
+			ret.push({
+				id = 13,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::MSU.Text.colorPositive("Effective Hitpoints: ") + currHPString + " / " + maxHPString
+			});
 
-		ret.push({
-			id = 13,
-			type = "text",
-			icon = "ui/icons/fatigue.png",
-			text = "The effectiveness is reduced above combined head and body armor weight of " + this.getStaminaModifierThreshold()
-		});
+			ret.push({
+				id = 14,
+				type = "text",
+				icon = "ui/icons/fatigue.png",
+				text = format("The effectiveness drops above combined head and body armor weight of %s (current: %s)", this.getStaminaModifierThreshold(), -this.getContainer().getActor().getItems().getStaminaModifier([::Const.ItemSlot.Body, ::Const.ItemSlot.Head]))
+			});
+		}
 
 		return ret;
 	}}.getTooltip;

--- a/mod_reforged/hooks/skills/perks/perk_nimble.nut
+++ b/mod_reforged/hooks/skills/perks/perk_nimble.nut
@@ -48,9 +48,9 @@
 			text = ::Reforged.Mod.Tooltips.parseString("Ignore 1 [Reach Disadvantage|Concept.ReachAdvantage] when attacking a target with lower [Initiative|Concept.Initiative] than yours")
 		});
 
-		if (!::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		local actor = this.getContainer().getActor();
+		if (!::MSU.isEqual(actor, ::MSU.getDummyPlayer()))
 		{
-			local actor = this.getContainer().getActor();
 			local maxHPString = ::Math.floor(actor.getHitpointsMax() / (hpBonus * 0.01));
 			local currHPString = ::Math.floor(actor.getHitpoints() / (hpBonus * 0.01));
 

--- a/scripts/skills/perks/perk_rf_poise.nut
+++ b/scripts/skills/perks/perk_rf_poise.nut
@@ -59,9 +59,9 @@ this.perk_rf_poise <- ::inherit("scripts/skills/skill", {
 			text = ::Reforged.Mod.Tooltips.parseString("Ignore 1 [Reach Disadvantage|Concept.ReachAdvantage] when attacking a target with lower [Initiative|Concept.Initiative] than yours")
 		});
 
-		if (!::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		local actor = this.getContainer().getActor();
+		if (!::MSU.isEqual(actor, ::MSU.getDummyPlayer()))
 		{
-			local actor = this.getContainer().getActor();
 			local maxHPString = ::Math.floor(actor.getHitpointsMax() / (hpBonus * 0.01));
 			local currHPString = ::Math.floor(actor.getHitpoints() / (hpBonus * 0.01));
 

--- a/scripts/skills/perks/perk_rf_poise.nut
+++ b/scripts/skills/perks/perk_rf_poise.nut
@@ -76,7 +76,7 @@ this.perk_rf_poise <- ::inherit("scripts/skills/skill", {
 				id = 14,
 				type = "text",
 				icon = "ui/icons/fatigue.png",
-				text = format("The effectiveness drops above combined head and body armor weight of %s (current: %s)", this.getStaminaModifierThreshold(), -this.getContainer().getActor().getItems().getStaminaModifier([::Const.ItemSlot.Body, ::Const.ItemSlot.Head]))
+				text = format("The effectiveness drops above combined head and body armor weight of %s (current: %s)", this.getStaminaModifierThreshold(), -actor.getItems().getStaminaModifier([::Const.ItemSlot.Body, ::Const.ItemSlot.Head]))
 			});
 		}
 

--- a/scripts/skills/perks/perk_rf_poise.nut
+++ b/scripts/skills/perks/perk_rf_poise.nut
@@ -59,23 +59,26 @@ this.perk_rf_poise <- ::inherit("scripts/skills/skill", {
 			text = ::Reforged.Mod.Tooltips.parseString("Ignore 1 [Reach Disadvantage|Concept.ReachAdvantage] when attacking a target with lower [Initiative|Concept.Initiative] than yours")
 		});
 
-		local actor = this.getContainer().getActor();
-		local maxHPString = ::Math.floor(actor.getHitpointsMax() / (hpBonus * 0.01));
-		local currHPString = ::Math.floor(actor.getHitpoints() / (hpBonus * 0.01));
+		if (!::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			local actor = this.getContainer().getActor();
+			local maxHPString = ::Math.floor(actor.getHitpointsMax() / (hpBonus * 0.01));
+			local currHPString = ::Math.floor(actor.getHitpoints() / (hpBonus * 0.01));
 
-		ret.push({
-			id = 15,
-			type = "text",
-			icon = "ui/icons/special.png",
-			text = ::MSU.Text.colorPositive("Effective Hitpoints: ") + currHPString + " / " + maxHPString
-		});
+			ret.push({
+				id = 13,
+				type = "text",
+				icon = "ui/icons/special.png",
+				text = ::MSU.Text.colorPositive("Effective Hitpoints: ") + currHPString + " / " + maxHPString
+			});
 
-		ret.push({
-			id = 13,
-			type = "text",
-			icon = "ui/icons/fatigue.png",
-			text = "The effectiveness is reduced above combined head and body armor weight of " + this.getStaminaModifierThreshold()
-		});
+			ret.push({
+				id = 14,
+				type = "text",
+				icon = "ui/icons/fatigue.png",
+				text = format("The effectiveness drops above combined head and body armor weight of %s (current: %s)", this.getStaminaModifierThreshold(), -this.getContainer().getActor().getItems().getStaminaModifier([::Const.ItemSlot.Body, ::Const.ItemSlot.Head]))
+			});
+		}
 
 		return ret;
 	}


### PR DESCRIPTION
Additional minor changes in this commit:
- Adjust the ids of the tooltip entries to be consistent.
- Don't show the effective HP and armor weight tooltips for dummy player.

Please feel free to give suggestions for better wording of the tooltip.

Feature request on the discord server: https://discord.com/channels/1006908336991645757/1036777416309358643/1527830076102545539