### PR TITLE
feat: add horizontal line in skill tooltips above warnings

### DIFF
--- a/mod_reforged/hooks/skills/skill_container.nut
+++ b/mod_reforged/hooks/skills/skill_container.nut
@@ -45,7 +45,18 @@
 				warnings.push(_tooltip.remove(i));
 			}
 		}
-		_tooltip.extend(warnings);
+
+		if (warnings.len() > 0)
+		{
+			_tooltip.push({
+				id = 111,
+				type = "text",
+				text = "rf_divider",
+			});
+
+			_tooltip.extend(warnings);
+		}
+
 		return ret;
 	}}.onQueryTooltip;
 


### PR DESCRIPTION
Here an image on how it looks like ingame

<img width="318" height="229" alt="image" src="https://github.com/user-attachments/assets/ced31ba1-603c-4603-9c97-b12e37caf9b8" />
