### PR TITLE
feat(chg): add newlines before mention of softcap in defense concepts

### DIFF
--- a/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_reforged/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -71,7 +71,7 @@
 						{
 							if (entry.id == 2 && entry.type == "description")
 							{
-								entry.text += ::Reforged.Mod.Tooltips.parseString(" Each point of [current|Concept.CurrentAttribute] defense above " + ::Const.Tactical.Settings.AttributeDefenseSoftCap + " counts as half a point.");
+								entry.text += ::Reforged.Mod.Tooltips.parseString("\n\nEach point of [current|Concept.CurrentAttribute] defense above " + ::Const.Tactical.Settings.AttributeDefenseSoftCap + " counts as half a point.");
 								break;
 							}
 						}


### PR DESCRIPTION
## Before
<img width="255" height="185" alt="image" src="https://github.com/user-attachments/assets/3d6d8850-85fa-48f7-9612-fc904e98c1f6" />

## After
<img width="255" height="203" alt="image" src="https://github.com/user-attachments/assets/0686afe8-b2c0-4b12-a6b0-df606b9fd170" />
