### PR TITLE
feat(chg): Combo does not remove itself on free skill use.

### DIFF
--- a/scripts/skills/perks/perk_rf_combo.nut
+++ b/scripts/skills/perks/perk_rf_combo.nut
@@ -44,7 +44,10 @@ this.perk_rf_combo <- ::inherit("scripts/skills/skill", {
 		// We do this in onBeforeAnySkillExecuted because some skills remove themselves after executing them
 		// or some other effects may be triggered which may change the skill's ActionPointCost after execution
 		// and in both these cases getActionPointCost() will not give us the intended value in onAnySkillExecuted
-		this.m.IsUsingValidSkill = !_forFree && _skill.getActionPointCost() != 0;
+		if (!_forFree)
+		{
+			this.m.IsUsingValidSkill = _skill.getActionPointCost() != 0;
+		}
 	}
 
 	function onAnySkillExecutedFully( _skill, _targetTile, _targetEntity, _forFree )


### PR DESCRIPTION
All usecases of useForFree in rf:
en garde
net pull
swm charge
swm kick
swm push through
swm tackle
follow up
flail spinner
kingfisher
rebuke
whirling death

The only ones happen in the entity's turn are swm skills, trapper skills and flail skills. I think flail skills already work with combo. Not super sure about current status of trapper or swm skills but I dont see why they should interrupt combo.

In vanilla:
none


https://discord.com/channels/996482927531671692/996858365726691369/1542178187683831973